### PR TITLE
Add unsafe-eval to CSP for Alpine.js

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -245,10 +245,10 @@ else:
 # Tailwind
 TAILWIND_APP_NAME = "theme"
 
-# CSP - Using Alpine.js CSP build (@alpinejs/csp) which does not require
-# unsafe-eval. Styles use unsafe-inline because Tailwind utility classes are inline.
+# CSP - Alpine.js standard build requires unsafe-eval for inline expression
+# evaluation. Styles use unsafe-inline because Tailwind utility classes are inline.
 CSP_DEFAULT_SRC = ("'self'",)
-CSP_SCRIPT_SRC = ("'self'", "https://cdn.jsdelivr.net")
+CSP_SCRIPT_SRC = ("'self'", "'unsafe-eval'", "https://cdn.jsdelivr.net")
 CSP_STYLE_SRC = ("'self'", "'unsafe-inline'", "https://cdn.jsdelivr.net")
 CSP_IMG_SRC = ("'self'", "data:", "https:")
 CSP_FONT_SRC = ("'self'",)


### PR DESCRIPTION
## Summary
- Added `'unsafe-eval'` to `CSP_SCRIPT_SRC` to fix Alpine.js EvalError violations
- Fixed misleading comment that incorrectly stated the CSP build (`@alpinejs/csp`) was in use — the project uses the standard Alpine.js build which requires `unsafe-eval` for inline expression evaluation

## Test plan
- [ ] Deploy and open browser console — confirm no more `EvalError` / CSP violation messages
- [ ] Verify Alpine.js interactive elements work (dropdowns, modals, toggles, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)