### PR TITLE
Fix multiple bugs and improve UX across the platform

### DIFF
--- a/apps/accounts/views.py
+++ b/apps/accounts/views.py
@@ -52,6 +52,9 @@ def account_settings(request):
             _handle_password_update(request, user)
         elif action == "delete_account":
             return _handle_account_deletion(request, user)
+        elif action == "update_notifications":
+            _handle_notification_prefs(request, user)
+            return redirect("/accounts/settings/?tab=preferences")
 
         return redirect("accounts:settings")
 
@@ -60,14 +63,38 @@ def account_settings(request):
 
     org_membership = OrgMembership.objects.filter(user=user).select_related("organization").first()
 
-    return render(
-        request,
-        "accounts/settings.html",
-        {
-            "settings_active": settings_active,
-            "org_membership": org_membership,
-        },
-    )
+    context = {
+        "settings_active": settings_active,
+        "org_membership": org_membership,
+    }
+
+    # For the preferences tab, load notification preferences
+    if settings_active == "preferences":
+        from apps.notifications.models import Channel, EventType, NotificationPreference
+
+        # Build a lookup of existing preferences
+        prefs = NotificationPreference.objects.filter(user=user)
+        pref_lookup = {(p.event_type, p.channel): p.is_enabled for p in prefs}
+
+        # Build structured data for the template — each row has a flat list of channel entries
+        event_types = [(et.value, et.label) for et in EventType]
+        channels = [(ch.value, ch.label) for ch in Channel]
+        notification_prefs = []
+        for et_value, et_label in event_types:
+            channel_list = []
+            for ch_value, ch_label in channels:
+                channel_list.append({
+                    "value": ch_value,
+                    "label": ch_label,
+                    "field_name": f"notif_{et_value}_{ch_value}",
+                    "is_enabled": pref_lookup.get((et_value, ch_value), True),
+                })
+            notification_prefs.append({"event_type": et_value, "label": et_label, "channel_list": channel_list})
+
+        context["notification_prefs"] = notification_prefs
+        context["notification_channels"] = channels
+
+    return render(request, "accounts/settings.html", context)
 
 
 def _handle_photo_update(request, user):
@@ -217,6 +244,23 @@ def accept_terms(request):
         messages.error(request, "You must agree to the Terms of Service and Privacy Policy to continue.")
 
     return render(request, "account/accept_terms.html")
+
+
+def _handle_notification_prefs(request, user):
+    """Handle notification preference updates."""
+    from apps.notifications.models import Channel, EventType, NotificationPreference
+
+    for et in EventType:
+        for ch in Channel:
+            key = f"notif_{et.value}_{ch.value}"
+            is_enabled = key in request.POST
+            NotificationPreference.objects.update_or_create(
+                user=user,
+                event_type=et.value,
+                channel=ch.value,
+                defaults={"is_enabled": is_enabled},
+            )
+    messages.success(request, "Notification preferences updated.")
 
 
 def logout_view(request):

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -111,9 +111,11 @@ def _get_filtered_posts(workspace, request):
     if tags:
         from django.db.models import Q
 
+        from apps.utils import json_tag_contains
+
         tag_q = Q()
         for tag in tags:
-            tag_q |= Q(tags__contains=[tag])
+            tag_q |= json_tag_contains("tags", tag)
         qs = qs.filter(tag_q)
 
     # Date range
@@ -167,9 +169,11 @@ def _get_filtered_platform_posts(workspace, request):
     if tags:
         from django.db.models import Q
 
+        from apps.utils import json_tag_contains
+
         tag_q = Q()
         for tag in tags:
-            tag_q |= Q(post__tags__contains=[tag])
+            tag_q |= json_tag_contains("post__tags", tag)
         qs = qs.filter(tag_q)
 
     return qs
@@ -228,7 +232,9 @@ def _apply_publish_filters(qs, request):
 
     tag = request.GET.get("tag")
     if tag:
-        qs = qs.filter(tags__contains=[tag])
+        from apps.utils import json_tag_contains
+
+        qs = qs.filter(json_tag_contains("tags", tag))
 
     return qs
 
@@ -241,7 +247,9 @@ def _apply_pp_publish_filters(qs, request):
 
     tag = request.GET.get("tag")
     if tag:
-        qs = qs.filter(post__tags__contains=[tag])
+        from apps.utils import json_tag_contains
+
+        qs = qs.filter(json_tag_contains("post__tags", tag))
 
     return qs
 

--- a/apps/composer/views.py
+++ b/apps/composer/views.py
@@ -370,6 +370,27 @@ def compose(request, workspace_id, post_id=None):
     ws_role = membership.workspace_role if membership else None
     can_view_internal_notes = ws_role not in ("client", "viewer") if ws_role else True
 
+    # Template data pre-fill (if using a template)
+    template_id = request.GET.get("template")
+    template_data = None
+    if template_id and not post:
+        try:
+            tpl = PostTemplate.objects.get(id=template_id, workspace=workspace)
+            template_data = tpl.template_data
+        except (PostTemplate.DoesNotExist, ValidationError):
+            # Fall back to built-in template by integer ID
+            from apps.composer.builtin_templates import TEMPLATES as BUILTIN_TEMPLATES
+
+            builtin = next((t for t in BUILTIN_TEMPLATES if str(t["id"]) == template_id), None)
+            if builtin:
+                template_data = {"body": builtin.get("body", ""), "title": builtin.get("title", "")}
+
+    # Pre-fill caption from template data
+    if template_data and not post:
+        body = template_data.get("body", "")
+        if body:
+            form.initial["caption"] = body
+
     # Approval workflow context
     workflow_mode = workspace.approval_workflow_mode
     show_submit_button = workflow_mode != "none"
@@ -1440,7 +1461,9 @@ def _idea_columns(workspace, tag=None):
         .order_by("position", "-created_at")
     )
     if tag:
-        ideas_qs = ideas_qs.filter(tags__contains=[tag])
+        from apps.utils import json_tag_contains
+
+        ideas_qs = ideas_qs.filter(json_tag_contains("tags", tag))
 
     grouped_ideas = {str(grp.id): [] for grp in groups}
     for idea in ideas_qs:

--- a/apps/credentials/urls.py
+++ b/apps/credentials/urls.py
@@ -6,4 +6,6 @@ app_name = "credentials"
 
 urlpatterns = [
     path("", views.credentials_list, name="list"),
+    path("<str:platform>/save/", views.credentials_save, name="save"),
+    path("<str:platform>/remove/", views.credentials_remove, name="remove"),
 ]

--- a/apps/credentials/views.py
+++ b/apps/credentials/views.py
@@ -1,7 +1,236 @@
+from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import render
+from django.http import JsonResponse
+from django.shortcuts import redirect, render
+from django.views.decorators.http import require_POST
+
+from apps.members.models import OrgMembership
+
+from .models import PlatformCredential
+
+# Define what fields each platform needs, with help text and developer console URLs
+PLATFORM_FIELDS = {
+    "facebook": {
+        "label": "Facebook",
+        "fields": [
+            {"name": "app_id", "label": "App ID", "type": "text"},
+            {"name": "app_secret", "label": "App Secret", "type": "password"},
+        ],
+        "help": "Create an app at Meta for Developers. You'll need a Facebook App with Facebook Login enabled.",
+        "docs_url": "https://developers.facebook.com/apps/",
+        "docs_label": "Meta for Developers",
+        "shared_with": ["Instagram", "Threads"],
+    },
+    "instagram": {
+        "label": "Instagram (Business)",
+        "fields": [
+            {"name": "app_id", "label": "App ID", "type": "text"},
+            {"name": "app_secret", "label": "App Secret", "type": "password"},
+        ],
+        "help": "Uses the same Meta App as Facebook. Enable Instagram Graph API in your app settings.",
+        "docs_url": "https://developers.facebook.com/apps/",
+        "docs_label": "Meta for Developers",
+        "shared_with": ["Facebook", "Threads"],
+    },
+    "instagram_personal": {
+        "label": "Instagram (Personal)",
+        "fields": [
+            {"name": "app_id", "label": "App ID", "type": "text"},
+            {"name": "app_secret", "label": "App Secret", "type": "password"},
+        ],
+        "help": "Requires a separate Instagram App (not the Facebook App). Enable Instagram Basic Display API.",
+        "docs_url": "https://developers.facebook.com/apps/",
+        "docs_label": "Meta for Developers",
+    },
+    "threads": {
+        "label": "Threads",
+        "fields": [
+            {"name": "app_id", "label": "App ID", "type": "text"},
+            {"name": "app_secret", "label": "App Secret", "type": "password"},
+        ],
+        "help": "Uses the same Meta App as Facebook. Enable Threads API in your app settings.",
+        "docs_url": "https://developers.facebook.com/apps/",
+        "docs_label": "Meta for Developers",
+        "shared_with": ["Facebook", "Instagram"],
+    },
+    "linkedin_personal": {
+        "label": "LinkedIn (Personal)",
+        "fields": [
+            {"name": "client_id", "label": "Client ID", "type": "text"},
+            {"name": "client_secret", "label": "Client Secret", "type": "password"},
+        ],
+        "help": "Create an app in the LinkedIn Developer Portal. Request the Community Management API product.",
+        "docs_url": "https://www.linkedin.com/developers/apps",
+        "docs_label": "LinkedIn Developer Portal",
+        "shared_with": ["LinkedIn (Company)"],
+    },
+    "linkedin_company": {
+        "label": "LinkedIn (Company)",
+        "fields": [
+            {"name": "client_id", "label": "Client ID", "type": "text"},
+            {"name": "client_secret", "label": "Client Secret", "type": "password"},
+        ],
+        "help": "Uses the same LinkedIn app as Personal. Ensure Community Management API access is approved.",
+        "docs_url": "https://www.linkedin.com/developers/apps",
+        "docs_label": "LinkedIn Developer Portal",
+        "shared_with": ["LinkedIn (Personal)"],
+    },
+    "tiktok": {
+        "label": "TikTok",
+        "fields": [
+            {"name": "client_key", "label": "Client Key", "type": "text"},
+            {"name": "client_secret", "label": "Client Secret", "type": "password"},
+        ],
+        "help": "Register at the TikTok for Developers portal. Create a Login Kit app and request content posting scope.",
+        "docs_url": "https://developers.tiktok.com/",
+        "docs_label": "TikTok for Developers",
+    },
+    "youtube": {
+        "label": "YouTube",
+        "fields": [
+            {"name": "client_id", "label": "Client ID", "type": "text"},
+            {"name": "client_secret", "label": "Client Secret", "type": "password"},
+        ],
+        "help": "Create OAuth credentials in Google Cloud Console. Enable the YouTube Data API v3.",
+        "docs_url": "https://console.cloud.google.com/apis/credentials",
+        "docs_label": "Google Cloud Console",
+        "shared_with": ["Google Business Profile"],
+    },
+    "google_business": {
+        "label": "Google Business Profile",
+        "fields": [
+            {"name": "client_id", "label": "Client ID", "type": "text"},
+            {"name": "client_secret", "label": "Client Secret", "type": "password"},
+        ],
+        "help": "Uses the same Google OAuth client as YouTube. Enable the Google My Business API.",
+        "docs_url": "https://console.cloud.google.com/apis/credentials",
+        "docs_label": "Google Cloud Console",
+        "shared_with": ["YouTube"],
+    },
+    "pinterest": {
+        "label": "Pinterest",
+        "fields": [
+            {"name": "app_id", "label": "App ID", "type": "text"},
+            {"name": "app_secret", "label": "App Secret", "type": "password"},
+        ],
+        "help": "Create an app at Pinterest for Developers. Request access to the Content Publishing API.",
+        "docs_url": "https://developers.pinterest.com/apps/",
+        "docs_label": "Pinterest for Developers",
+    },
+    "bluesky": {
+        "label": "Bluesky",
+        "fields": [],
+        "help": "Bluesky uses app passwords instead of OAuth. No developer credentials needed — users connect directly with their handle and an app password.",
+        "no_setup_needed": True,
+    },
+    "mastodon": {
+        "label": "Mastodon",
+        "fields": [
+            {"name": "instance_url", "label": "Instance URL", "type": "text", "placeholder": "https://mastodon.social"},
+            {"name": "client_id", "label": "Client ID", "type": "text"},
+            {"name": "client_secret", "label": "Client Secret", "type": "password"},
+        ],
+        "help": "Register an application on your Mastodon instance under Preferences > Development > New Application.",
+        "docs_url": "https://docs.joinmastodon.org/client/token/",
+        "docs_label": "Mastodon Docs",
+    },
+}
 
 
 @login_required
 def credentials_list(request):
-    return render(request, "credentials/list.html")
+    """Show all platforms with their configuration status."""
+    org = request.org
+    if not org:
+        return redirect("/")
+
+    # Get existing credentials from DB
+    existing = {
+        c.platform: c for c in PlatformCredential.objects.filter(organization=org)
+    }
+
+    platforms = []
+    for platform_value, config in PLATFORM_FIELDS.items():
+        cred = existing.get(platform_value)
+        platforms.append({
+            "value": platform_value,
+            "label": config["label"],
+            "is_configured": cred.is_configured if cred else False,
+            "test_result": cred.test_result if cred else "untested",
+            "masked": cred.masked_credentials if cred else {},
+            "config": config,
+        })
+
+    return render(request, "credentials/list.html", {
+        "platforms": platforms,
+        "settings_active": "credentials",
+    })
+
+
+@login_required
+@require_POST
+def credentials_save(request, platform):
+    """Save platform credentials from the setup form."""
+    org = request.org
+    if not org:
+        return JsonResponse({"error": "No organization"}, status=400)
+
+    # Only owners/admins can manage credentials
+    if request.org_membership.org_role not in (
+        OrgMembership.OrgRole.OWNER,
+        OrgMembership.OrgRole.ADMIN,
+    ):
+        return JsonResponse({"error": "Permission denied"}, status=403)
+
+    config = PLATFORM_FIELDS.get(platform)
+    if not config:
+        return JsonResponse({"error": "Unknown platform"}, status=400)
+
+    # Build credentials dict from POST data
+    credentials = {}
+    for field in config.get("fields", []):
+        value = request.POST.get(field["name"], "").strip()
+        if value:
+            credentials[field["name"]] = value
+
+    # Check if all required fields are provided
+    has_all = all(
+        request.POST.get(f["name"], "").strip()
+        for f in config.get("fields", [])
+    )
+
+    cred, _created = PlatformCredential.objects.update_or_create(
+        organization=org,
+        platform=platform,
+        defaults={
+            "credentials": credentials,
+            "is_configured": has_all and bool(credentials),
+            "test_result": PlatformCredential.TestResult.UNTESTED,
+        },
+    )
+
+    if has_all and credentials:
+        messages.success(request, f"{config['label']} credentials saved successfully.")
+    else:
+        messages.warning(request, f"Some fields are missing for {config['label']}.")
+
+    return redirect("credentials:list")
+
+
+@login_required
+@require_POST
+def credentials_remove(request, platform):
+    """Remove platform credentials."""
+    org = request.org
+    if not org:
+        return JsonResponse({"error": "No organization"}, status=400)
+
+    if request.org_membership.org_role not in (
+        OrgMembership.OrgRole.OWNER,
+        OrgMembership.OrgRole.ADMIN,
+    ):
+        return JsonResponse({"error": "Permission denied"}, status=403)
+
+    PlatformCredential.objects.filter(organization=org, platform=platform).delete()
+    messages.success(request, "Credentials removed.")
+    return redirect("credentials:list")

--- a/apps/organizations/views.py
+++ b/apps/organizations/views.py
@@ -223,7 +223,9 @@ def cross_workspace_calendar(request):
     # Tag filter
     tag = request.GET.get("tag")
     if tag:
-        base_pps = base_pps.filter(post__tags__contains=[tag])
+        from apps.utils import json_tag_contains
+
+        base_pps = base_pps.filter(json_tag_contains("post__tags", tag))
 
     # Status filter — editorial status now lives on the PlatformPost itself.
     status = request.GET.get("status")

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -1,0 +1,22 @@
+"""Shared utilities across apps."""
+
+import json
+
+from django.conf import settings
+from django.db.models import Q
+
+
+def json_tag_contains(field, tag):
+    """Return a Q object that filters a JSONField array containing the given tag.
+
+    Works on both PostgreSQL (__contains) and SQLite (__icontains fallback).
+    """
+    db_engine = settings.DATABASES["default"]["ENGINE"]
+    if "sqlite" in db_engine:
+        # SQLite doesn't support __contains on JSON fields at all.
+        # Use __icontains on the raw text representation instead.
+        # A JSON array like ["test", "foo"] is stored as text, so we search
+        # for the JSON-encoded string value (e.g. '"test"') within it.
+        json_str = json.dumps(tag)  # e.g. '"test"'
+        return Q(**{f"{field}__icontains": json_str})
+    return Q(**{f"{field}__contains": [tag]})

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -179,6 +179,9 @@ if STORAGE_BACKEND.lower() == "s3":
         "CacheControl": "max-age=86400",
     }
 else:
+    STORAGES["default"] = {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    }
     MEDIA_ROOT = env("MEDIA_ROOT", default=str(BASE_DIR / "media"))
     MEDIA_URL = "/media/"
 

--- a/templates/accounts/settings.html
+++ b/templates/accounts/settings.html
@@ -1,7 +1,56 @@
 {% extends "layouts/settings.html" %}
-{% block title %}Profile - Settings - Brightbean{% endblock %}
+{% block title %}{% if settings_active == 'preferences' %}Preferences{% else %}Profile{% endif %} - Settings - Brightbean{% endblock %}
 {% block content %}
 <div class="max-w-2xl">
+
+{% if settings_active == 'preferences' %}
+    <!-- ==================== PREFERENCES TAB ==================== -->
+    <h2 class="text-xl font-semibold mb-2" style="color: var(--text-primary);">Preferences</h2>
+    <p class="text-sm mb-8" style="color: var(--text-secondary);">Manage how and when you receive notifications.</p>
+
+    <form method="POST">
+        {% csrf_token %}
+        <input type="hidden" name="action" value="update_notifications">
+
+        <div class="rounded-xl overflow-hidden" style="border: 1px solid var(--border);">
+            <!-- Table header -->
+            <div class="grid gap-0 px-5 py-3" style="background: var(--neutral-50); border-bottom: 1px solid var(--border); grid-template-columns: 1fr repeat({{ notification_channels|length }}, 80px);">
+                <span class="text-xs font-semibold uppercase tracking-wider" style="color: var(--text-tertiary);">Event</span>
+                {% for ch_value, ch_label in notification_channels %}
+                <span class="text-xs font-semibold uppercase tracking-wider text-center" style="color: var(--text-tertiary);">{{ ch_label }}</span>
+                {% endfor %}
+            </div>
+
+            <!-- Rows -->
+            {% for pref in notification_prefs %}
+            <div class="grid gap-0 px-5 py-3 items-center"
+                 style="{% if not forloop.last %}border-bottom: 1px solid var(--border);{% endif %} grid-template-columns: 1fr repeat({{ notification_channels|length }}, 80px);">
+                <span class="text-sm" style="color: var(--text-primary);">{{ pref.label }}</span>
+                {% for ch in pref.channel_list %}
+                <label class="flex items-center justify-center cursor-pointer">
+                    <input type="checkbox" name="{{ ch.field_name }}"
+                           {% if ch.is_enabled %}checked{% endif %}
+                           class="w-4 h-4 rounded cursor-pointer"
+                           style="accent-color: var(--primary);">
+                </label>
+                {% endfor %}
+            </div>
+            {% endfor %}
+        </div>
+
+        <div class="mt-6">
+            <button type="submit"
+                    class="px-5 py-2 text-sm font-medium rounded-full transition-colors cursor-pointer"
+                    style="background: var(--primary); color: white;"
+                    onmouseenter="this.style.opacity='0.9'"
+                    onmouseleave="this.style.opacity='1'">
+                Save Preferences
+            </button>
+        </div>
+    </form>
+
+{% else %}
+    <!-- ==================== PROFILE TAB ==================== -->
     <h2 class="text-xl font-semibold mb-8" style="color: var(--text-primary);">Profile</h2>
 
     <!-- Photo section -->
@@ -200,5 +249,6 @@
             </div>
         </template>
     </div>
+{% endif %}
 </div>
 {% endblock %}

--- a/templates/calendar/partials/publish_list_shell.html
+++ b/templates/calendar/partials/publish_list_shell.html
@@ -28,37 +28,119 @@ Tab switching is HTMX partial swaps only - no full page reload.
         </div>
 
         <!-- Right: filter dropdowns -->
-        <div class="flex items-center gap-2 pb-2 overflow-x-auto flex-shrink-0">
+        <div class="flex items-center gap-2 pb-2 flex-shrink-0">
             <!-- Channels filter -->
-            <div class="relative">
-                <svg class="publish-filter-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M16 8v5a3 3 0 006 0v-1a10 10 0 10-3.92 7.94"/></svg>
-                <select class="publish-filter-select has-icon" x-model="activeChannel" @change="reloadTab()">
-                    <option value="">All Channels</option>
-                    {% for channel in channels_with_posts %}
-                    <option value="{{ channel.id }}">{{ channel.account_name|default:channel.account_handle }} ({{ channel.get_platform_display }})</option>
-                    {% endfor %}
-                </select>
+            <div x-data="{
+                    open: false,
+                    pos: { top: 0, left: 0 },
+                    updatePos() {
+                        const r = this.$refs.btn.getBoundingClientRect();
+                        this.pos = { top: r.bottom + 4 + 'px', left: (r.right - 224) + 'px' };
+                    },
+                    toggle() { this.open = !this.open; if (this.open) this.updatePos(); }
+                 }" @click.away="open = false">
+                <button @click="toggle()" type="button" x-ref="btn"
+                        class="inline-flex items-center gap-1.5 px-3 py-1.5 text-[12px] font-semibold rounded-lg border transition-all cursor-pointer whitespace-nowrap"
+                        :class="activeChannel ? 'bg-orange-50 border-orange-200 text-orange-700' : 'bg-white border-stone-200 text-stone-600 hover:border-stone-300'">
+                    <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M16 8v5a3 3 0 006 0v-1a10 10 0 10-3.92 7.94"/></svg>
+                    <span x-text="activeChannel ? (document.querySelector('[data-channel-id=\'' + activeChannel + '\']')?.textContent || 'Channel') : 'All Channels'"></span>
+                    <svg class="w-3 h-3 ml-0.5 transition-transform" :class="open && 'rotate-180'" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <template x-teleport="body">
+                    <div x-show="open"
+                         x-transition:enter="transition ease-out duration-100" x-transition:enter-start="opacity-0 scale-95" x-transition:enter-end="opacity-100 scale-100"
+                         x-transition:leave="transition ease-in duration-75" x-transition:leave-start="opacity-100 scale-100" x-transition:leave-end="opacity-0 scale-95"
+                         :style="'position:fixed; top:' + pos.top + '; left:' + pos.left + '; z-index:9999;'"
+                         class="w-56 bg-white rounded-xl shadow-lg ring-1 ring-stone-200 overflow-hidden" x-cloak>
+                        <div class="p-2">
+                            <button @click="activeChannel = ''; open = false; reloadTab()" type="button"
+                                    class="w-full text-left px-3 py-2 text-[12px] font-medium rounded-lg transition-colors"
+                                    :class="!activeChannel ? 'bg-orange-50 text-orange-700' : 'text-stone-600 hover:bg-stone-50'">All Channels</button>
+                            {% for channel in channels_with_posts %}
+                            <button @click="activeChannel = '{{ channel.id }}'; open = false; reloadTab()" type="button"
+                                    class="w-full text-left px-3 py-2 text-[12px] font-medium rounded-lg transition-colors"
+                                    :class="activeChannel === '{{ channel.id }}' ? 'bg-orange-50 text-orange-700' : 'text-stone-600 hover:bg-stone-50'"
+                                    data-channel-id="{{ channel.id }}">{{ channel.account_name|default:channel.account_handle }} ({{ channel.get_platform_display }})</button>
+                            {% endfor %}
+                        </div>
+                    </div>
+                </template>
             </div>
 
             <!-- Tags filter -->
-            <div class="relative">
-                <svg class="publish-filter-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"/></svg>
-                <select class="publish-filter-select has-icon" x-model="activeTag" @change="reloadTab()">
-                    <option value="">All Tags</option>
-                    {% for tag in all_tags %}
-                    <option value="{{ tag }}">#{{ tag }}</option>
-                    {% endfor %}
-                </select>
+            <div x-data="{
+                    open: false,
+                    pos: { top: 0, left: 0 },
+                    updatePos() {
+                        const r = this.$refs.btn.getBoundingClientRect();
+                        this.pos = { top: r.bottom + 4 + 'px', left: (r.right - 192) + 'px' };
+                    },
+                    toggle() { this.open = !this.open; if (this.open) this.updatePos(); }
+                 }" @click.away="open = false">
+                <button @click="toggle()" type="button" x-ref="btn"
+                        class="inline-flex items-center gap-1.5 px-3 py-1.5 text-[12px] font-semibold rounded-lg border transition-all cursor-pointer whitespace-nowrap"
+                        :class="activeTag ? 'bg-orange-50 border-orange-200 text-orange-700' : 'bg-white border-stone-200 text-stone-600 hover:border-stone-300'">
+                    <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"/></svg>
+                    <span x-text="activeTag ? '#' + activeTag : 'All Tags'"></span>
+                    <svg class="w-3 h-3 ml-0.5 transition-transform" :class="open && 'rotate-180'" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <template x-teleport="body">
+                    <div x-show="open"
+                         x-transition:enter="transition ease-out duration-100" x-transition:enter-start="opacity-0 scale-95" x-transition:enter-end="opacity-100 scale-100"
+                         x-transition:leave="transition ease-in duration-75" x-transition:leave-start="opacity-100 scale-100" x-transition:leave-end="opacity-0 scale-95"
+                         :style="'position:fixed; top:' + pos.top + '; left:' + pos.left + '; z-index:9999;'"
+                         class="w-48 bg-white rounded-xl shadow-lg ring-1 ring-stone-200 overflow-hidden" x-cloak>
+                        <div class="p-2 max-h-56 overflow-y-auto">
+                            <button @click="activeTag = ''; open = false; reloadTab()" type="button"
+                                    class="w-full text-left px-3 py-2 text-[12px] font-medium rounded-lg transition-colors"
+                                    :class="!activeTag ? 'bg-orange-50 text-orange-700' : 'text-stone-600 hover:bg-stone-50'">All Tags</button>
+                            {% for tag in all_tags %}
+                            <button @click="activeTag = '{{ tag }}'; open = false; reloadTab()" type="button"
+                                    class="w-full text-left px-3 py-2 text-[12px] font-medium rounded-lg transition-colors"
+                                    :class="activeTag === '{{ tag }}' ? 'bg-orange-50 text-orange-700' : 'text-stone-600 hover:bg-stone-50'">#{{ tag }}</button>
+                            {% endfor %}
+                        </div>
+                    </div>
+                </template>
             </div>
 
             <!-- Timezone dropdown -->
-            <div class="relative">
-                <svg class="publish-filter-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
-                <select class="publish-filter-select has-icon" x-model="displayTimezone" @change="reloadTab()">
-                    {% for tz in timezone_choices %}
-                    <option value="{{ tz }}" {% if tz == display_timezone %}selected{% endif %}>{{ tz|cut:"America/"|cut:"Europe/"|cut:"Asia/"|cut:"US/"|cut:"Pacific/"|cut:"Australia/" }}{% if tz == workspace_timezone %} (workspace){% endif %}</option>
-                    {% endfor %}
-                </select>
+            <div x-data="{
+                    open: false,
+                    search: '',
+                    pos: { top: 0, left: 0 },
+                    updatePos() {
+                        const r = this.$refs.btn.getBoundingClientRect();
+                        this.pos = { top: r.bottom + 4 + 'px', left: (r.right - 224) + 'px' };
+                    },
+                    toggle() { this.open = !this.open; if (this.open) { this.updatePos(); this.$nextTick(() => this.$refs.tzSearch?.focus()); } else { this.search = ''; } }
+                 }" @click.away="open = false; search = ''">
+                <button @click="toggle()" type="button" x-ref="btn"
+                        class="inline-flex items-center gap-1.5 px-3 py-1.5 text-[12px] font-semibold rounded-lg border bg-white border-stone-200 text-stone-600 hover:border-stone-300 transition-all cursor-pointer whitespace-nowrap">
+                    <svg class="w-3.5 h-3.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
+                    <span x-text="displayTimezone.replace(/^(America|Europe|Asia|US|Pacific|Australia)\//, '') + (displayTimezone === '{{ workspace_timezone }}' ? ' (workspace)' : '')"></span>
+                    <svg class="w-3 h-3 ml-0.5 transition-transform" :class="open && 'rotate-180'" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <template x-teleport="body">
+                    <div x-show="open"
+                         x-transition:enter="transition ease-out duration-100" x-transition:enter-start="opacity-0 scale-95" x-transition:enter-end="opacity-100 scale-100"
+                         x-transition:leave="transition ease-in duration-75" x-transition:leave-start="opacity-100 scale-100" x-transition:leave-end="opacity-0 scale-95"
+                         :style="'position:fixed; top:' + pos.top + '; left:' + pos.left + '; z-index:9999;'"
+                         class="w-56 bg-white rounded-xl shadow-lg ring-1 ring-stone-200 overflow-hidden" x-cloak>
+                        <div class="p-2 border-b border-stone-100">
+                            <input type="text" x-ref="tzSearch" x-model="search" placeholder="Search timezones..."
+                                   class="w-full px-2.5 py-1.5 text-[12px] bg-stone-50 border border-stone-200 rounded-lg focus:outline-none focus:border-orange-300 focus:ring-1 focus:ring-orange-100">
+                        </div>
+                        <div class="p-2 max-h-56 overflow-y-auto">
+                            {% for tz in timezone_choices %}
+                            <button @click="displayTimezone = '{{ tz }}'; open = false; search = ''; reloadTab()" type="button"
+                                    x-show="!search || '{{ tz }}'.toLowerCase().includes(search.toLowerCase())"
+                                    class="w-full text-left px-3 py-2 text-[12px] font-medium rounded-lg transition-colors"
+                                    :class="displayTimezone === '{{ tz }}' ? 'bg-orange-50 text-orange-700' : 'text-stone-600 hover:bg-stone-50'">{{ tz|cut:"America/"|cut:"Europe/"|cut:"Asia/"|cut:"US/"|cut:"Pacific/"|cut:"Australia/" }}{% if tz == workspace_timezone %} <span class="text-stone-400">(workspace)</span>{% endif %}</button>
+                            {% endfor %}
+                        </div>
+                    </div>
+                </template>
             </div>
         </div>
     </div>

--- a/templates/credentials/list.html
+++ b/templates/credentials/list.html
@@ -1,8 +1,167 @@
-{% extends "base.html" %}
+{% extends "layouts/settings.html" %}
 {% block page_title %}Platform Credentials{% endblock %}
+{% block title %}Platform Credentials - Settings - Brightbean{% endblock %}
 {% block content %}
-<div class="max-w-4xl">
-    <h2 class="text-xl font-semibold mb-6">Platform Credentials</h2>
-    <p class="text-gray-500">Credential management coming soon.</p>
+<div class="max-w-3xl">
+    <div class="mb-8">
+        <h2 class="text-xl font-semibold" style="color: var(--text-primary);">Platform Credentials</h2>
+        <p class="text-sm mt-1" style="color: var(--text-secondary);">
+            Configure your API credentials for each social media platform. These are needed before you can connect accounts.
+        </p>
+    </div>
+
+    <div class="space-y-3" x-data="{ openPlatform: null }">
+        {% for p in platforms %}
+        <div
+             class="rounded-xl border transition-all"
+             style="border-color: var(--border); background: var(--surface-0);">
+
+            <!-- Platform row -->
+            <div class="flex items-center gap-4 px-5 py-4">
+                <!-- Icon -->
+                <div class="w-10 h-10 rounded-lg flex items-center justify-center flex-shrink-0
+                    {% if p.value == 'facebook' %}bg-blue-50 text-blue-600
+                    {% elif p.value == 'instagram' %}bg-gradient-to-br from-purple-50 to-pink-50 text-pink-600
+                    {% elif p.value == 'instagram_personal' %}bg-gradient-to-br from-purple-50 to-pink-50 text-pink-600
+                    {% elif p.value == 'linkedin_personal' or p.value == 'linkedin_company' %}bg-blue-50 text-blue-700
+                    {% elif p.value == 'tiktok' %}bg-stone-900 text-white
+                    {% elif p.value == 'youtube' %}bg-red-50 text-red-600
+                    {% elif p.value == 'pinterest' %}bg-red-50 text-red-500
+                    {% elif p.value == 'threads' %}bg-stone-100 text-stone-800
+                    {% elif p.value == 'bluesky' %}bg-sky-50 text-sky-500
+                    {% elif p.value == 'google_business' %}bg-blue-50 text-blue-500
+                    {% elif p.value == 'mastodon' %}bg-indigo-50 text-indigo-600
+                    {% endif %}">
+                    {% include "social_accounts/partials/_platform_icon.html" with platform=p.value size="5" %}
+                </div>
+
+                <!-- Label + status -->
+                <div class="flex-1 min-w-0">
+                    <h3 class="text-sm font-semibold" style="color: var(--text-primary);">{{ p.label }}</h3>
+                    {% if p.config.shared_with %}
+                    <p class="text-[11px] mt-0.5" style="color: var(--text-tertiary);">
+                        Shares credentials with {{ p.config.shared_with|join:", " }}
+                    </p>
+                    {% endif %}
+                </div>
+
+                <!-- Status badge + action -->
+                <div class="flex items-center gap-3 flex-shrink-0">
+                    {% if p.config.no_setup_needed %}
+                    <span class="inline-flex items-center gap-1 px-2.5 py-1 text-[11px] font-semibold rounded-full bg-sky-50 text-sky-600">
+                        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                        No Setup Needed
+                    </span>
+                    {% elif p.is_configured %}
+                    <span class="inline-flex items-center gap-1 px-2.5 py-1 text-[11px] font-semibold rounded-full bg-green-50 text-green-600">
+                        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                        Configured
+                    </span>
+                    <button @click="openPlatform = openPlatform === '{{ p.value }}' ? null : '{{ p.value }}'" type="button"
+                            class="text-[12px] font-medium cursor-pointer transition-colors"
+                            style="color: var(--text-tertiary);"
+                            onmouseenter="this.style.color='var(--text-primary)'"
+                            onmouseleave="this.style.color='var(--text-tertiary)'">
+                        Edit
+                    </button>
+                    {% else %}
+                    <button @click="openPlatform = openPlatform === '{{ p.value }}' ? null : '{{ p.value }}'" type="button"
+                            class="inline-flex items-center gap-1.5 px-3 py-1.5 text-[12px] font-semibold rounded-full cursor-pointer transition-all"
+                            style="background: var(--primary); color: white;"
+                            onmouseenter="this.style.opacity='0.9'"
+                            onmouseleave="this.style.opacity='1'">
+                        <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
+                        Set Up
+                    </button>
+                    {% endif %}
+                </div>
+            </div>
+
+            <!-- Setup panel (expandable) -->
+            {% if not p.config.no_setup_needed %}
+            <div x-show="openPlatform === '{{ p.value }}'" x-collapse x-cloak>
+                <div class="px-5 pb-5 pt-1" style="border-top: 1px solid var(--border);">
+                    <!-- Help text -->
+                    <div class="rounded-lg p-3 mb-4" style="background: var(--neutral-50);">
+                        <p class="text-[12px]" style="color: var(--text-secondary);">
+                            {{ p.config.help }}
+                        </p>
+                        {% if p.config.docs_url %}
+                        <a href="{{ p.config.docs_url }}" target="_blank" rel="noopener"
+                           class="inline-flex items-center gap-1 mt-2 text-[12px] font-semibold transition-colors"
+                           style="color: var(--primary);">
+                            {{ p.config.docs_label }}
+                            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"/></svg>
+                        </a>
+                        {% endif %}
+                    </div>
+
+                    <!-- Credential form -->
+                    <form method="POST" action="{% url 'credentials:save' platform=p.value %}">
+                        {% csrf_token %}
+                        <div class="space-y-3">
+                            {% for field in p.config.fields %}
+                            <div>
+                                <label class="block text-[12px] font-semibold mb-1" style="color: var(--text-primary);">{{ field.label }}</label>
+                                <input type="{{ field.type }}"
+                                       name="{{ field.name }}"
+                                       value="{% if p.is_configured %}{% endif %}"
+                                       placeholder="{% if p.is_configured %}{{ field.label }} (saved — enter new value to update){% elif field.placeholder %}{{ field.placeholder }}{% else %}Enter {{ field.label }}{% endif %}"
+                                       class="w-full px-3 py-2 text-sm rounded-lg outline-none transition-colors"
+                                       style="border: 1px solid var(--border); color: var(--text-primary); background: var(--surface-0);"
+                                       onfocus="this.style.borderColor='var(--primary)'; this.style.boxShadow='0 0 0 3px var(--primary-ring)'"
+                                       onblur="this.style.borderColor='var(--border)'; this.style.boxShadow='none'"
+                                       {% if not p.is_configured %}required{% endif %}>
+                            </div>
+                            {% endfor %}
+                        </div>
+
+                        <div class="flex items-center gap-3 mt-4">
+                            <button type="submit"
+                                    class="inline-flex items-center gap-1.5 px-4 py-2 text-[12px] font-semibold rounded-full cursor-pointer transition-all"
+                                    style="background: var(--primary); color: white;"
+                                    onmouseenter="this.style.opacity='0.9'"
+                                    onmouseleave="this.style.opacity='1'">
+                                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                                Save Credentials
+                            </button>
+                            <button @click="openPlatform = null" type="button"
+                                    class="px-4 py-2 text-[12px] font-medium rounded-full cursor-pointer transition-colors"
+                                    style="color: var(--text-secondary);"
+                                    onmouseenter="this.style.color='var(--text-primary)'"
+                                    onmouseleave="this.style.color='var(--text-secondary)'">
+                                Cancel
+                            </button>
+                            {% if p.is_configured %}
+                            <form method="POST" action="{% url 'credentials:remove' platform=p.value %}" class="ml-auto" onsubmit="return confirm('Remove credentials for {{ p.label }}?')">
+                                {% csrf_token %}
+                                <button type="submit"
+                                        class="text-[12px] font-medium cursor-pointer transition-colors"
+                                        style="color: var(--error-500, #EF4444);">
+                                    Remove
+                                </button>
+                            </form>
+                            {% endif %}
+                        </div>
+                    </form>
+
+                    {% if p.is_configured and p.masked %}
+                    <div class="mt-3 pt-3" style="border-top: 1px solid var(--border);">
+                        <p class="text-[11px] font-medium mb-1" style="color: var(--text-tertiary);">Current credentials (masked):</p>
+                        <div class="flex flex-wrap gap-2">
+                            {% for key, val in p.masked.items %}
+                            <span class="inline-flex items-center px-2 py-0.5 text-[11px] font-mono rounded" style="background: var(--neutral-100); color: var(--text-tertiary);">
+                                {{ key }}: {{ val }}
+                            </span>
+                            {% endfor %}
+                        </div>
+                    </div>
+                    {% endif %}
+                </div>
+            </div>
+            {% endif %}
+        </div>
+        {% endfor %}
+    </div>
 </div>
 {% endblock %}

--- a/templates/inbox/feed.html
+++ b/templates/inbox/feed.html
@@ -129,21 +129,25 @@
     <div class="flex flex-wrap items-center justify-between gap-2 px-3 sm:px-5 py-3 border-b border-stone-200 flex-shrink-0">
         <div class="flex items-center gap-3 sm:gap-4">
             <h1 class="text-base font-semibold text-stone-900" style="letter-spacing: -0.01em;">Inbox</h1>
-            <div class="flex items-center gap-1 bg-stone-50 rounded-full p-0.5">
+            <div class="flex items-center gap-1 bg-stone-50 rounded-full p-0.5"
+                 x-data="{ active: '{{ current_view|default:'all' }}' }">
                 <a href="{% url 'inbox:feed' workspace_id=workspace.id %}"
-                   class="inbox-tab {% if current_view == 'all' %}active{% endif %}"
+                   class="inbox-tab" :class="active === 'all' && 'active'"
+                   @click="active = 'all'"
                    hx-get="{% url 'inbox:feed' workspace_id=workspace.id %}?view=all"
                    hx-target="#inbox-message-list"
                    hx-swap="innerHTML"
                    hx-push-url="true">All</a>
                 <a href="{% url 'inbox:feed' workspace_id=workspace.id %}?view=mine"
-                   class="inbox-tab {% if current_view == 'mine' %}active{% endif %}"
+                   class="inbox-tab" :class="active === 'mine' && 'active'"
+                   @click="active = 'mine'"
                    hx-get="{% url 'inbox:feed' workspace_id=workspace.id %}?view=mine"
                    hx-target="#inbox-message-list"
                    hx-swap="innerHTML"
                    hx-push-url="true">My Queue</a>
                 <a href="{% url 'inbox:feed' workspace_id=workspace.id %}?view=unassigned"
-                   class="inbox-tab {% if current_view == 'unassigned' %}active{% endif %}"
+                   class="inbox-tab" :class="active === 'unassigned' && 'active'"
+                   @click="active = 'unassigned'"
                    hx-get="{% url 'inbox:feed' workspace_id=workspace.id %}?view=unassigned"
                    hx-target="#inbox-message-list"
                    hx-swap="innerHTML"

--- a/templates/inbox/partials/_filter_bar.html
+++ b/templates/inbox/partials/_filter_bar.html
@@ -8,7 +8,7 @@
                name="q"
                value="{{ active_filters.q|default:'' }}"
                placeholder="Search messages..."
-               class="w-full pl-8 pr-3 py-1.5 text-[12px] bg-white border border-stone-200 rounded-md focus:outline-none focus:border-orange-400 focus:ring-2 focus:ring-orange-100 transition-all"
+               class="w-full pl-8 pr-3 py-1.5 text-[12px] bg-white border border-stone-200 rounded-lg focus:outline-none focus:border-orange-400 focus:ring-2 focus:ring-orange-100 transition-all"
                hx-get="{% url 'inbox:feed' workspace_id=workspace.id %}"
                hx-target="#inbox-message-list"
                hx-swap="innerHTML"
@@ -17,52 +17,118 @@
     </div>
 
     <!-- Platform filter -->
-    <select name="platform" class="filter-select"
-            hx-get="{% url 'inbox:feed' workspace_id=workspace.id %}"
-            hx-target="#inbox-message-list"
-            hx-swap="innerHTML"
-            hx-include="[name='q'],[name='type'],[name='status'],[name='sentiment']">
-        <option value="">All platforms</option>
-        {% for account in social_accounts %}
-        <option value="{{ account.platform }}" {% if account.platform in active_filters.platform %}selected{% endif %}>{{ account.get_platform_display|default:account.platform|title }}</option>
-        {% endfor %}
-    </select>
+    <div x-data="{
+            open: false,
+            value: '{{ active_filters.platform|default:'' }}',
+            pos: { top: 0, left: 0 },
+            updatePos() { const r = this.$refs.btn.getBoundingClientRect(); this.pos = { top: r.bottom + 4 + 'px', left: r.left + 'px' }; },
+            select(v) { this.value = v; this.open = false; htmx.trigger(document.querySelector('[name=q]'), 'change'); }
+         }" @click.away="open = false">
+        <input type="hidden" name="platform" :value="value">
+        <button @click="open = !open; if (open) updatePos()" x-ref="btn" type="button"
+                class="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-[12px] font-medium rounded-lg border transition-all cursor-pointer whitespace-nowrap"
+                :class="value ? 'bg-orange-50 border-orange-200 text-orange-700' : 'bg-white border-stone-200 text-stone-500 hover:border-stone-300'">
+            <span x-text="value ? (document.querySelector('[data-plat=\'' + value + '\']')?.textContent || value) : 'All platforms'"></span>
+            <svg class="w-3 h-3 transition-transform" :class="open && 'rotate-180'" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
+        </button>
+        <template x-teleport="body">
+            <div x-show="open" x-transition:enter="transition ease-out duration-100" x-transition:enter-start="opacity-0 scale-95" x-transition:enter-end="opacity-100 scale-100" x-transition:leave="transition ease-in duration-75"
+                 :style="'position:fixed; top:' + pos.top + '; left:' + pos.left + '; z-index:9999;'"
+                 class="w-48 bg-white rounded-xl shadow-lg ring-1 ring-stone-200 overflow-hidden" x-cloak>
+                <div class="p-1.5 max-h-48 overflow-y-auto">
+                    <button @click="select('')" type="button" class="w-full text-left px-3 py-1.5 text-[12px] font-medium rounded-lg transition-colors" :class="!value ? 'bg-orange-50 text-orange-700' : 'text-stone-600 hover:bg-stone-50'">All platforms</button>
+                    {% for account in social_accounts %}
+                    <button @click="select('{{ account.platform }}')" type="button" class="w-full text-left px-3 py-1.5 text-[12px] font-medium rounded-lg transition-colors" :class="value === '{{ account.platform }}' ? 'bg-orange-50 text-orange-700' : 'text-stone-600 hover:bg-stone-50'" data-plat="{{ account.platform }}">{{ account.get_platform_display|default:account.platform|title }}</button>
+                    {% endfor %}
+                </div>
+            </div>
+        </template>
+    </div>
 
     <!-- Type filter -->
-    <select name="type" class="filter-select"
-            hx-get="{% url 'inbox:feed' workspace_id=workspace.id %}"
-            hx-target="#inbox-message-list"
-            hx-swap="innerHTML"
-            hx-include="[name='q'],[name='platform'],[name='status'],[name='sentiment']">
-        <option value="">All types</option>
-        <option value="comment" {% if 'comment' in active_filters.type %}selected{% endif %}>Comments</option>
-        <option value="mention" {% if 'mention' in active_filters.type %}selected{% endif %}>Mentions</option>
-        <option value="dm" {% if 'dm' in active_filters.type %}selected{% endif %}>DMs</option>
-        <option value="review" {% if 'review' in active_filters.type %}selected{% endif %}>Reviews</option>
-    </select>
+    <div x-data="{
+            open: false,
+            value: '{{ active_filters.type|default:'' }}',
+            pos: { top: 0, left: 0 },
+            labels: { comment: 'Comments', mention: 'Mentions', dm: 'DMs', review: 'Reviews' },
+            updatePos() { const r = this.$refs.btn.getBoundingClientRect(); this.pos = { top: r.bottom + 4 + 'px', left: r.left + 'px' }; },
+            select(v) { this.value = v; this.open = false; htmx.trigger(document.querySelector('[name=q]'), 'change'); }
+         }" @click.away="open = false">
+        <input type="hidden" name="type" :value="value">
+        <button @click="open = !open; if (open) updatePos()" x-ref="btn" type="button"
+                class="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-[12px] font-medium rounded-lg border transition-all cursor-pointer whitespace-nowrap"
+                :class="value ? 'bg-orange-50 border-orange-200 text-orange-700' : 'bg-white border-stone-200 text-stone-500 hover:border-stone-300'">
+            <span x-text="value ? labels[value] : 'All types'"></span>
+            <svg class="w-3 h-3 transition-transform" :class="open && 'rotate-180'" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
+        </button>
+        <template x-teleport="body">
+            <div x-show="open" x-transition:enter="transition ease-out duration-100" x-transition:enter-start="opacity-0 scale-95" x-transition:enter-end="opacity-100 scale-100" x-transition:leave="transition ease-in duration-75"
+                 :style="'position:fixed; top:' + pos.top + '; left:' + pos.left + '; z-index:9999;'"
+                 class="w-40 bg-white rounded-xl shadow-lg ring-1 ring-stone-200 overflow-hidden" x-cloak>
+                <div class="p-1.5">
+                    <template x-for="opt in [{v:'',l:'All types'},{v:'comment',l:'Comments'},{v:'mention',l:'Mentions'},{v:'dm',l:'DMs'},{v:'review',l:'Reviews'}]">
+                        <button @click="select(opt.v)" type="button" class="w-full text-left px-3 py-1.5 text-[12px] font-medium rounded-lg transition-colors" :class="value === opt.v ? 'bg-orange-50 text-orange-700' : 'text-stone-600 hover:bg-stone-50'" x-text="opt.l"></button>
+                    </template>
+                </div>
+            </div>
+        </template>
+    </div>
 
     <!-- Status filter -->
-    <select name="status" class="filter-select"
-            hx-get="{% url 'inbox:feed' workspace_id=workspace.id %}"
-            hx-target="#inbox-message-list"
-            hx-swap="innerHTML"
-            hx-include="[name='q'],[name='platform'],[name='type'],[name='sentiment']">
-        <option value="">All statuses</option>
-        <option value="unread" {% if 'unread' in active_filters.status %}selected{% endif %}>Unread</option>
-        <option value="open" {% if 'open' in active_filters.status %}selected{% endif %}>Open</option>
-        <option value="resolved" {% if 'resolved' in active_filters.status %}selected{% endif %}>Resolved</option>
-        <option value="archived" {% if 'archived' in active_filters.status %}selected{% endif %}>Archived</option>
-    </select>
+    <div x-data="{
+            open: false,
+            value: '{{ active_filters.status|default:'' }}',
+            pos: { top: 0, left: 0 },
+            labels: { unread: 'Unread', open: 'Open', resolved: 'Resolved', archived: 'Archived' },
+            updatePos() { const r = this.$refs.btn.getBoundingClientRect(); this.pos = { top: r.bottom + 4 + 'px', left: r.left + 'px' }; },
+            select(v) { this.value = v; this.open = false; htmx.trigger(document.querySelector('[name=q]'), 'change'); }
+         }" @click.away="open = false">
+        <input type="hidden" name="status" :value="value">
+        <button @click="open = !open; if (open) updatePos()" x-ref="btn" type="button"
+                class="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-[12px] font-medium rounded-lg border transition-all cursor-pointer whitespace-nowrap"
+                :class="value ? 'bg-orange-50 border-orange-200 text-orange-700' : 'bg-white border-stone-200 text-stone-500 hover:border-stone-300'">
+            <span x-text="value ? labels[value] : 'All statuses'"></span>
+            <svg class="w-3 h-3 transition-transform" :class="open && 'rotate-180'" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
+        </button>
+        <template x-teleport="body">
+            <div x-show="open" x-transition:enter="transition ease-out duration-100" x-transition:enter-start="opacity-0 scale-95" x-transition:enter-end="opacity-100 scale-100" x-transition:leave="transition ease-in duration-75"
+                 :style="'position:fixed; top:' + pos.top + '; left:' + pos.left + '; z-index:9999;'"
+                 class="w-40 bg-white rounded-xl shadow-lg ring-1 ring-stone-200 overflow-hidden" x-cloak>
+                <div class="p-1.5">
+                    <template x-for="opt in [{v:'',l:'All statuses'},{v:'unread',l:'Unread'},{v:'open',l:'Open'},{v:'resolved',l:'Resolved'},{v:'archived',l:'Archived'}]">
+                        <button @click="select(opt.v)" type="button" class="w-full text-left px-3 py-1.5 text-[12px] font-medium rounded-lg transition-colors" :class="value === opt.v ? 'bg-orange-50 text-orange-700' : 'text-stone-600 hover:bg-stone-50'" x-text="opt.l"></button>
+                    </template>
+                </div>
+            </div>
+        </template>
+    </div>
 
     <!-- Sentiment filter -->
-    <select name="sentiment" class="filter-select"
-            hx-get="{% url 'inbox:feed' workspace_id=workspace.id %}"
-            hx-target="#inbox-message-list"
-            hx-swap="innerHTML"
-            hx-include="[name='q'],[name='platform'],[name='type'],[name='status']">
-        <option value="">All sentiment</option>
-        <option value="positive" {% if 'positive' in active_filters.sentiment %}selected{% endif %}>Positive</option>
-        <option value="neutral" {% if 'neutral' in active_filters.sentiment %}selected{% endif %}>Neutral</option>
-        <option value="negative" {% if 'negative' in active_filters.sentiment %}selected{% endif %}>Negative</option>
-    </select>
+    <div x-data="{
+            open: false,
+            value: '{{ active_filters.sentiment|default:'' }}',
+            pos: { top: 0, left: 0 },
+            labels: { positive: 'Positive', neutral: 'Neutral', negative: 'Negative' },
+            updatePos() { const r = this.$refs.btn.getBoundingClientRect(); this.pos = { top: r.bottom + 4 + 'px', left: r.left + 'px' }; },
+            select(v) { this.value = v; this.open = false; htmx.trigger(document.querySelector('[name=q]'), 'change'); }
+         }" @click.away="open = false">
+        <input type="hidden" name="sentiment" :value="value">
+        <button @click="open = !open; if (open) updatePos()" x-ref="btn" type="button"
+                class="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-[12px] font-medium rounded-lg border transition-all cursor-pointer whitespace-nowrap"
+                :class="value ? 'bg-orange-50 border-orange-200 text-orange-700' : 'bg-white border-stone-200 text-stone-500 hover:border-stone-300'">
+            <span x-text="value ? labels[value] : 'All sentiment'"></span>
+            <svg class="w-3 h-3 transition-transform" :class="open && 'rotate-180'" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
+        </button>
+        <template x-teleport="body">
+            <div x-show="open" x-transition:enter="transition ease-out duration-100" x-transition:enter-start="opacity-0 scale-95" x-transition:enter-end="opacity-100 scale-100" x-transition:leave="transition ease-in duration-75"
+                 :style="'position:fixed; top:' + pos.top + '; left:' + pos.left + '; z-index:9999;'"
+                 class="w-40 bg-white rounded-xl shadow-lg ring-1 ring-stone-200 overflow-hidden" x-cloak>
+                <div class="p-1.5">
+                    <template x-for="opt in [{v:'',l:'All sentiment'},{v:'positive',l:'Positive'},{v:'neutral',l:'Neutral'},{v:'negative',l:'Negative'}]">
+                        <button @click="select(opt.v)" type="button" class="w-full text-left px-3 py-1.5 text-[12px] font-medium rounded-lg transition-colors" :class="value === opt.v ? 'bg-orange-50 text-orange-700' : 'text-stone-600 hover:bg-stone-50'" x-text="opt.l"></button>
+                    </template>
+                </div>
+            </div>
+        </template>
+    </div>
 </div>

--- a/templates/layouts/settings.html
+++ b/templates/layouts/settings.html
@@ -40,6 +40,10 @@
     <svg class="flex-shrink-0" width="18" height="18" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
     <span class="sidebar-nav-label">Media Library</span>
 </a>
+<a href="{% url 'credentials:list' %}" class="sidebar-nav-item mb-1 {% if settings_active == 'credentials' %}active{% endif %}">
+    <svg class="flex-shrink-0" width="18" height="18" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M15 7h3a5 5 0 010 10h-3m-6 0H6A5 5 0 016 7h3"/><line x1="8" y1="12" x2="16" y2="12"/></svg>
+    <span class="sidebar-nav-label">Platform Credentials</span>
+</a>
 {% endblock %}
 
 {% block content %}

--- a/templates/organizations/settings.html
+++ b/templates/organizations/settings.html
@@ -28,29 +28,68 @@
     </form>
 
     <!-- Default Timezone section -->
-    <form method="POST" class="mb-10">
+    <form method="POST" class="mb-10"
+          x-data="{
+              open: false,
+              search: '',
+              selected: '{{ organization.default_timezone }}',
+              pos: { top: 0, left: 0, width: 0 },
+              updatePos() {
+                  const r = this.$refs.tzBtn.getBoundingClientRect();
+                  this.pos = { top: r.bottom + 4 + 'px', left: r.left + 'px', width: r.width + 'px' };
+              },
+              toggle() {
+                  this.open = !this.open;
+                  if (this.open) { this.updatePos(); this.$nextTick(() => this.$refs.tzInput.focus()); }
+                  else { this.search = ''; }
+              },
+              pick(tz) { this.selected = tz; this.open = false; this.search = ''; }
+          }">
         {% csrf_token %}
         <input type="hidden" name="action" value="update_timezone">
+        <input type="hidden" name="timezone" :value="selected">
         <div class="flex items-end gap-4">
-            <div class="flex-1">
-                <label for="timezone" class="block text-sm font-semibold mb-1" style="color: var(--text-primary);">Default Timezone</label>
+            <div class="flex-1" @click.away="open = false; search = ''">
+                <label class="block text-sm font-semibold mb-1" style="color: var(--text-primary);">Default Timezone</label>
                 <p class="text-xs mb-2" style="color: var(--text-tertiary);">Used as the fallback for workspaces that don't set their own.</p>
-                <select id="timezone" name="timezone"
-                        class="w-full px-3 py-2 text-sm rounded-lg outline-none transition-colors"
-                        style="border: 1px solid var(--border); color: var(--text-primary); background: var(--surface-0);"
-                        onfocus="this.style.borderColor='var(--primary)'; this.style.boxShadow='0 0 0 3px var(--primary-ring)'"
-                        onblur="this.style.borderColor='var(--border)'; this.style.boxShadow='none'">
-                    <optgroup label="Common">
-                        {% for tz in common_timezones %}
-                        <option value="{{ tz }}" {% if tz == organization.default_timezone %}selected{% endif %}>{{ tz }}</option>
-                        {% endfor %}
-                    </optgroup>
-                    <optgroup label="All Timezones">
-                        {% for tz in all_timezones %}
-                        <option value="{{ tz }}" {% if tz == organization.default_timezone %}selected{% endif %}>{{ tz }}</option>
-                        {% endfor %}
-                    </optgroup>
-                </select>
+                <button @click="toggle()" type="button" x-ref="tzBtn"
+                        class="w-full flex items-center justify-between px-3 py-2 text-sm rounded-lg outline-none transition-colors text-left border border-stone-200 bg-white"
+                        :class="open ? 'border-orange-400 ring-2 ring-orange-100' : 'hover:border-stone-300'">
+                    <span x-text="selected || 'Select timezone'"></span>
+                    <svg class="w-4 h-4 transition-transform flex-shrink-0" :class="open && 'rotate-180'" style="color: var(--text-tertiary);" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
+                </button>
+                <template x-teleport="body">
+                    <div x-show="open"
+                         x-transition:enter="transition ease-out duration-100" x-transition:enter-start="opacity-0 scale-95" x-transition:enter-end="opacity-100 scale-100"
+                         x-transition:leave="transition ease-in duration-75"
+                         :style="'position:fixed; top:' + pos.top + '; left:' + pos.left + '; width:' + pos.width + '; z-index:9999;'"
+                         class="bg-white rounded-xl shadow-lg ring-1 ring-stone-200 overflow-hidden" x-cloak>
+                        <div class="p-2 border-b border-stone-100">
+                            <input type="text" x-ref="tzInput" x-model="search" placeholder="Search timezones..."
+                                   class="w-full px-2.5 py-1.5 text-sm bg-stone-50 border border-stone-200 rounded-lg focus:outline-none focus:border-orange-300 focus:ring-1 focus:ring-orange-100">
+                        </div>
+                        <div class="max-h-64 overflow-y-auto">
+                            <div class="px-2 pt-2 pb-1">
+                                <p class="px-2 py-1 text-[10px] font-semibold uppercase tracking-wider" style="color: var(--text-tertiary);">Common</p>
+                                {% for tz in common_timezones %}
+                                <button @click="pick('{{ tz }}')" type="button"
+                                        x-show="!search || '{{ tz }}'.toLowerCase().includes(search.toLowerCase())"
+                                        class="w-full text-left px-3 py-1.5 text-sm font-medium rounded-lg transition-colors"
+                                        :class="selected === '{{ tz }}' ? 'bg-orange-50 text-orange-700' : 'text-stone-600 hover:bg-stone-50'">{{ tz }}</button>
+                                {% endfor %}
+                            </div>
+                            <div class="px-2 pb-2">
+                                <p class="px-2 py-1 text-[10px] font-semibold uppercase tracking-wider" style="color: var(--text-tertiary);">All Timezones</p>
+                                {% for tz in all_timezones %}
+                                <button @click="pick('{{ tz }}')" type="button"
+                                        x-show="!search || '{{ tz }}'.toLowerCase().includes(search.toLowerCase())"
+                                        class="w-full text-left px-3 py-1.5 text-sm font-medium rounded-lg transition-colors"
+                                        :class="selected === '{{ tz }}' ? 'bg-orange-50 text-orange-700' : 'text-stone-600 hover:bg-stone-50'">{{ tz }}</button>
+                                {% endfor %}
+                            </div>
+                        </div>
+                    </div>
+                </template>
             </div>
             <button type="submit"
                     class="px-5 py-2 text-sm font-medium rounded-full transition-colors cursor-pointer whitespace-nowrap"

--- a/templates/social_accounts/connect.html
+++ b/templates/social_accounts/connect.html
@@ -65,14 +65,12 @@
             </form>
             {% else %}
             <div class="mt-4">
-                <span class="w-full inline-flex items-center justify-center px-4 py-2 text-xs font-semibold text-stone-400 bg-stone-100 rounded-full cursor-not-allowed">
-                    Not Configured
-                </span>
+                <a href="{% url 'credentials:list' %}"
+                   class="w-full inline-flex items-center justify-center gap-2 px-4 py-1.5 text-xs font-semibold text-stone-600 bg-stone-50 border border-stone-200 rounded-full hover:bg-stone-100 hover:border-stone-300 transition-all duration-200">
+                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/><circle cx="12" cy="12" r="3"/></svg>
+                    Set Up Credentials
+                </a>
             </div>
-            {% endif %}
-
-            {% if value not in configured_platforms %}
-            <div class="absolute inset-0 rounded-xl bg-white/40 cursor-not-allowed" title="Platform credentials not configured. Contact your administrator."></div>
             {% endif %}
         </div>
         {% endfor %}


### PR DESCRIPTION
## Summary

This PR addresses several bugs and UX issues discovered during local development testing, along with a new feature for managing platform credentials through the UI.

### Bug Fixes

- **Fix "Use Template" ValidationError** — Built-in templates use integer IDs, but the compose view only queried the UUID-based `PostTemplate` model. Added fallback to `builtin_templates.py` and pre-fill the caption textarea from the template body.
- **Fix Inbox tab active state** — HTMX partial swaps only replace the message list, not the tab bar. The `{% if current_view %}` active class never re-rendered. Added Alpine.js client-side state toggling so clicking All/My Queue/Unassigned highlights immediately.
- **Fix tag filtering crash on SQLite** — `tags__contains=[tag]` uses PostgreSQL's JSON `@>` operator, which is not supported on SQLite. Created a shared `json_tag_contains()` utility in `apps/utils.py` that uses `__icontains` on SQLite. Updated all 6 call sites across `composer`, `calendar`, and `organizations` apps.
- **Fix file upload crash on local dev** — `STORAGES["default"]` was never set when `STORAGE_BACKEND=local`, causing `InvalidStorageError` on every media upload. Added `FileSystemStorage` as the default backend in the non-S3 branch.

### UX Improvements

- **Separate Profile and Preferences pages** — Both tabs previously rendered identical content. Profile now shows photo/name/email/password/role. Preferences shows a notification settings matrix (event types × delivery channels: In-App, Email, Webhook) with per-toggle save.
- **Upgrade all dropdown menus** — Replaced native `<select>` elements across Calendar (channels, tags, timezone), Inbox (platform, type, status, sentiment), and Organization Settings (timezone) with Alpine.js custom dropdowns. Uses `x-teleport="body"` with fixed positioning to escape `overflow: hidden` containers. Includes search, smooth transitions, and orange active-item highlighting.

### New Feature

- **Platform Credentials UI** — Full CRUD interface at **Settings → Platform Credentials** for org owners/admins to configure API keys directly from the dashboard instead of hardcoding in `.env`. Each platform card includes:
  - Guided setup with help text explaining what's needed
  - Direct links to each platform's developer console
  - Platform-specific input fields (App ID, Secret, Client Key, etc.)
  - Encrypted storage via the existing `PlatformCredential` model (AES-256-GCM)
  - Masked credential display for configured platforms
  - "Shares credentials with" info for linked platforms (e.g., Facebook/Instagram/Threads)
  - Accordion UI — only one platform setup panel open at a time
- **Connect page updated** — "Not Configured" disabled badge replaced with a "Set Up Credentials" button linking to the new settings page

## Merge Conflict Resolution

This branch was rebased onto the latest `main` to resolve two conflicts:

**`apps/composer/views.py`** — Upstream removed the old template pre-fill block entirely (the `PostTemplate.objects.get()` call that was causing the ValidationError). Our branch keeps the fixed version that catches the error, falls back to built-in templates by integer ID, and pre-fills the caption from the template body. Without this, the "Use Template" feature would have no effect at all.

**`templates/calendar/partials/publish_list_shell.html`** — Upstream updated the channel display text to use `account_name|default:account_handle` (a fallback for channels without a display name). Our branch replaces the native `<select>` with a custom Alpine.js dropdown. Resolution: kept our custom dropdown and incorporated upstream's `account_name|default:account_handle` improvement into it.

## Files Changed (16 files, +853 / -118)

| File | Change |
|------|--------|
| `apps/utils.py` | **New** — Shared `json_tag_contains()` for SQLite-compatible JSON tag filtering |
| `apps/accounts/views.py` | Preferences tab logic, notification prefs handler |
| `apps/calendar/views.py` | SQLite tag filter fix (4 call sites) |
| `apps/composer/views.py` | Template fallback fix, SQLite tag filter fix, caption pre-fill |
| `apps/credentials/urls.py` | Added save/remove endpoints |
| `apps/credentials/views.py` | Full credentials CRUD views with platform field definitions |
| `apps/organizations/views.py` | SQLite tag filter fix |
| `config/settings/base.py` | Added `STORAGES["default"]` for local FileSystemStorage |
| `templates/accounts/settings.html` | Conditional Profile/Preferences rendering |
| `templates/calendar/partials/publish_list_shell.html` | Alpine.js teleported dropdowns |
| `templates/credentials/list.html` | Full credentials management UI |
| `templates/inbox/feed.html` | Alpine.js tab active state |
| `templates/inbox/partials/_filter_bar.html` | Alpine.js teleported filter dropdowns |
| `templates/layouts/settings.html` | Added Platform Credentials nav link |
| `templates/organizations/settings.html` | Custom timezone dropdown with search |
| `templates/social_accounts/connect.html` | "Set Up Credentials" button |

## Test Plan

- [ ] Click a built-in template from the template gallery → compose view opens with caption pre-filled
- [ ] Click Inbox tabs (All / My Queue / Unassigned) → clicked tab highlights immediately
- [ ] Create a tag, assign to an idea, filter by tag on Kanban board → no error on SQLite
- [ ] Upload media in compose view with `STORAGE_BACKEND=local` → file saves to `media/` directory
- [ ] Visit Settings → Profile vs Preferences → each tab shows different content
- [ ] Save notification preferences → persist across page reload
- [ ] Open calendar dropdowns (Channels, Tags, Timezone) → panels appear above content, not clipped
- [ ] Visit Settings → Platform Credentials → configure a platform → status shows "Configured"
- [ ] Visit Connect Account page → unconfigured platforms show "Set Up Credentials" link
- [ ] Open one platform setup card, then click another → first one closes automatically