### PR TITLE
Fix Instagram OAuth token endpoints to use GET instead of POST

### DIFF
--- a/providers/instagram_login.py
+++ b/providers/instagram_login.py
@@ -147,10 +147,11 @@ class InstagramLoginProvider(SocialProvider):
         return self._exchange_for_long_lived_token(short_lived_token)
 
     def _exchange_for_long_lived_token(self, short_lived_token: str) -> OAuthTokens:
+        # Meta's long-lived token endpoint requires GET with query params
         resp = self._request(
-            "POST",
+            "GET",
             f"{GRAPH_HOST}/access_token",
-            data={
+            params={
                 "grant_type": "ig_exchange_token",
                 "client_secret": self.credentials["client_secret"],
                 "access_token": short_lived_token,
@@ -180,9 +181,9 @@ class InstagramLoginProvider(SocialProvider):
         no separate refresh token.
         """
         resp = self._request(
-            "POST",
+            "GET",
             f"{GRAPH_HOST}/refresh_access_token",
-            data={
+            params={
                 "grant_type": "ig_refresh_token",
                 "access_token": refresh_token,
             },


### PR DESCRIPTION
## What does this PR do?

Changes the Instagram OAuth token exchange and refresh endpoints from POST requests with `data` parameters to GET requests with `query` parameters. This aligns with Meta's actual API requirements for the long-lived token and refresh token endpoints.

## Why?

Meta's Instagram Graph API documentation specifies that both the `access_token` and `refresh_access_token` endpoints require GET requests with query parameters, not POST requests with request bodies. The previous implementation was using the incorrect HTTP method and parameter format, which would cause token exchange and refresh operations to fail.

## How to test

- Run existing unit tests to verify token exchange and refresh flows work correctly: `pytest`
- Verify lint passes: `ruff check .` and `ruff format --check .`
- Manual testing of Instagram login flow to confirm token exchange and refresh operations succeed

## Checklist

- [ ] Tests pass (`pytest`)
- [ ] Lint passes (`ruff check .` and `ruff format --check .`)
- [ ] Documentation updated (if applicable)

https://claude.ai/code/session_01PJFeLMgpD9aj6okRLtck77