### PR TITLE
fix: support separate Threads App ID from Meta

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,10 @@ PLATFORM_FACEBOOK_APP_ID=
 PLATFORM_FACEBOOK_APP_SECRET=
 PLATFORM_INSTAGRAM_APP_ID=
 PLATFORM_INSTAGRAM_APP_SECRET=
+# Threads - Meta assigns a separate App ID for the "Access the Threads API" use case.
+# Falls back to PLATFORM_FACEBOOK_APP_ID/SECRET if not set.
+PLATFORM_THREADS_APP_ID=
+PLATFORM_THREADS_APP_SECRET=
 # LinkedIn - see README "LinkedIn" section. Choose Path A or Path B (or both).
 # Path B (Community Management API) credentials are automatically reused for
 # personal connections, giving refresh tokens + inbox.

--- a/README.md
+++ b/README.md
@@ -379,6 +379,12 @@ Facebook, Instagram, and Threads all use the same Meta app credentials.
    PLATFORM_FACEBOOK_APP_ID=your-app-id
    PLATFORM_FACEBOOK_APP_SECRET=your-app-secret
    ```
+6. **Threads App ID (if different):** Meta assigns a separate App ID for the "Access the Threads API" use case. You can find it under **Use cases → Access the Threads API → Settings** in your app dashboard. If it differs from your main App ID, set:
+   ```
+   PLATFORM_THREADS_APP_ID=your-threads-app-id
+   PLATFORM_THREADS_APP_SECRET=your-threads-app-secret
+   ```
+   If not set, these fall back to `PLATFORM_FACEBOOK_APP_ID` / `PLATFORM_FACEBOOK_APP_SECRET`.
 
 ### Instagram (Direct, via Instagram Login)
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -311,6 +311,10 @@ _INSTAGRAM_LOGIN_CREDENTIALS = {
     "app_id": env("PLATFORM_INSTAGRAM_APP_ID", default=""),
     "app_secret": env("PLATFORM_INSTAGRAM_APP_SECRET", default=""),
 }
+_THREADS_CREDENTIALS = {
+    "app_id": env("PLATFORM_THREADS_APP_ID", default="") or _META_CREDENTIALS["app_id"],
+    "app_secret": env("PLATFORM_THREADS_APP_SECRET", default="") or _META_CREDENTIALS["app_secret"],
+}
 _LINKEDIN_LEGACY_CLIENT_ID = env("PLATFORM_LINKEDIN_CLIENT_ID", default="")
 _LINKEDIN_LEGACY_CLIENT_SECRET = env("PLATFORM_LINKEDIN_CLIENT_SECRET", default="")
 
@@ -348,10 +352,12 @@ else:
     _LINKEDIN_PERSONAL_CREDENTIALS = {"client_id": "", "client_secret": ""}
 
 PLATFORM_CREDENTIALS_FROM_ENV = {
-    # Meta platforms - Facebook, Instagram, and Threads share the same app
+    # Meta platforms - Facebook and Instagram share the same app.
+    # Threads may use a separate App ID assigned by Meta's "Access the Threads API"
+    # use case; falls back to the shared Meta credentials when not set.
     "facebook": _META_CREDENTIALS,
     "instagram": _META_CREDENTIALS,
-    "threads": _META_CREDENTIALS,
+    "threads": _THREADS_CREDENTIALS,
     # Instagram (Direct) - uses Instagram Login with separate Instagram App credentials.
     # Despite the platform key, this targets Professional (Business/Creator) IG accounts
     # without requiring a linked Facebook Page. See providers/instagram_login.py.


### PR DESCRIPTION
## Summary

- Meta assigns a distinct App ID for the "Access the Threads API" use case, which differs from the main Facebook App ID
- Using the Facebook App ID for Threads OAuth results in error `4476002` ("No app ID was sent with the request")
- Added `PLATFORM_THREADS_APP_ID` / `PLATFORM_THREADS_APP_SECRET` env vars with fallback to the shared Meta credentials when not set

## Changes

- `config/settings/base.py`: Added `_THREADS_CREDENTIALS` dict with fallback to `_META_CREDENTIALS`
- `.env.example`: Documented the new env vars
- `README.md`: Added step 6 explaining when/how to set separate Threads credentials

Fixes #45