### PR TITLE
feat: implement LinkedIn Company Page org selection and publishing

### DIFF
--- a/apps/publisher/engine.py
+++ b/apps/publisher/engine.py
@@ -354,6 +354,10 @@ class PublishEngine:
             if platform == "facebook" and "page_id" not in extra:
                 extra["page_id"] = account.account_platform_id
 
+            # Inject org author URN for LinkedIn Company Page.
+            if platform == "linkedin_company" and "author" not in extra:
+                extra["author"] = f"urn:li:organization:{account.account_platform_id}"
+
             # Pop link_url from extra and set on PublishContent directly
             link_url = extra.pop("link_url", None)
 

--- a/apps/publisher/tests.py
+++ b/apps/publisher/tests.py
@@ -3,11 +3,12 @@
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 from django.utils import timezone
 
 from apps.publisher.engine import MAX_RETRIES, RETRY_BACKOFF, PublishEngine
 from apps.publisher.models import PublishLog, RateLimitState
+from providers.types import AuthType, PostType, PublishResult
 
 
 class RateLimitStateModelTest(TestCase):
@@ -92,3 +93,89 @@ class PublishLogModelTest(TestCase):
         s = str(log)
         self.assertIn("2", s)
         self.assertIn("200", s)
+
+
+def _build_dispatch_mocks(platform: str, account_platform_id: str, platform_extra: dict | None = None):
+    """Build the minimal mocks needed to exercise _dispatch_to_provider's
+    extras-assembly without DB or filesystem side effects.
+
+    Returns (engine, platform_post, mock_provider).
+    """
+    engine = PublishEngine()
+
+    account = MagicMock()
+    account.platform = platform
+    account.account_platform_id = account_platform_id
+    account.token_expires_at = None  # skip the OAuth refresh branch
+    account.oauth_access_token = "tok"
+    account.account_name = "Test Account"
+
+    platform_post = MagicMock()
+    platform_post.social_account = account
+    platform_post.post.media_attachments.select_related.return_value.order_by.return_value = []
+    platform_post.post.tags = []
+    platform_post.effective_caption = "hello"
+    platform_post.effective_title = None
+    platform_post.effective_first_comment = None
+    platform_post.platform_extra = platform_extra or {}
+
+    mock_provider = MagicMock()
+    mock_provider.auth_type = AuthType.OAUTH2
+    mock_provider.supported_post_types = [PostType.TEXT]
+    mock_provider.publish_post.return_value = PublishResult(
+        platform_post_id="post-1",
+        url="https://example.com/p/1",
+        extra={},
+    )
+    return engine, platform_post, mock_provider
+
+
+class DispatchExtraInjectionTest(SimpleTestCase):
+    """Verify _dispatch_to_provider injects platform-specific extras."""
+
+    @patch("apps.publisher.engine.get_provider")
+    @patch("apps.publisher.engine._resolve_publish_credentials", return_value={})
+    def test_injects_organization_author_for_linkedin_company(self, _mock_creds, mock_get_provider):
+        engine, platform_post, mock_provider = _build_dispatch_mocks(
+            platform="linkedin_company",
+            account_platform_id="98765",
+        )
+        mock_get_provider.return_value = mock_provider
+
+        engine._dispatch_to_provider(platform_post)
+
+        mock_provider.publish_post.assert_called_once()
+        _access_token, content = mock_provider.publish_post.call_args.args
+        self.assertEqual(content.extra.get("author"), "urn:li:organization:98765")
+
+    @patch("apps.publisher.engine.get_provider")
+    @patch("apps.publisher.engine._resolve_publish_credentials", return_value={})
+    def test_does_not_overwrite_explicit_author(self, _mock_creds, mock_get_provider):
+        # When the caller has already set extra["author"], the engine must not
+        # overwrite it — important for callers that pass a different URN.
+        engine, platform_post, mock_provider = _build_dispatch_mocks(
+            platform="linkedin_company",
+            account_platform_id="98765",
+            platform_extra={"author": "urn:li:organization:override"},
+        )
+        mock_get_provider.return_value = mock_provider
+
+        engine._dispatch_to_provider(platform_post)
+
+        _access_token, content = mock_provider.publish_post.call_args.args
+        self.assertEqual(content.extra.get("author"), "urn:li:organization:override")
+
+    @patch("apps.publisher.engine.get_provider")
+    @patch("apps.publisher.engine._resolve_publish_credentials", return_value={})
+    def test_does_not_inject_author_for_other_platforms(self, _mock_creds, mock_get_provider):
+        # Sanity: the author-injection branch is scoped to linkedin_company only.
+        engine, platform_post, mock_provider = _build_dispatch_mocks(
+            platform="linkedin_personal",
+            account_platform_id="11111",
+        )
+        mock_get_provider.return_value = mock_provider
+
+        engine._dispatch_to_provider(platform_post)
+
+        _access_token, content = mock_provider.publish_post.call_args.args
+        self.assertNotIn("author", content.extra)

--- a/apps/social_accounts/views.py
+++ b/apps/social_accounts/views.py
@@ -348,15 +348,25 @@ def oauth_callback(request, platform):
                 }
                 return redirect("social_accounts:select_account")
             else:
-                messages.warning(
-                    request,
-                    "No Facebook Pages were found for your account. "
-                    "Only Pages can be connected — personal profiles are not "
-                    "supported by the Facebook API. "
-                    "If you expected to see a Page, make sure you have admin "
-                    "access and try removing the app in Facebook Settings \u2192 "
-                    "Business Integrations, then reconnect.",
-                )
+                if platform == PlatformCredential.Platform.LINKEDIN_COMPANY:
+                    warning = (
+                        "No LinkedIn Company Pages were found for your account. "
+                        "Only Company Pages you administer can be connected — "
+                        "personal profiles connect via the LinkedIn (Personal) option. "
+                        "If you expected to see a Page, ask the page owner to grant "
+                        "you Admin access in LinkedIn \u2192 Admin tools \u2192 "
+                        "Manage admins, then reconnect."
+                    )
+                else:
+                    warning = (
+                        "No Facebook Pages were found for your account. "
+                        "Only Pages can be connected — personal profiles are not "
+                        "supported by the Facebook API. "
+                        "If you expected to see a Page, make sure you have admin "
+                        "access and try removing the app in Facebook Settings \u2192 "
+                        "Business Integrations, then reconnect."
+                    )
+                messages.warning(request, warning)
                 return redirect("social_accounts:list", workspace_id=workspace_id)
 
         # Standard single-account flow (non-Facebook/Instagram platforms)

--- a/apps/social_accounts/views.py
+++ b/apps/social_accounts/views.py
@@ -328,10 +328,11 @@ def oauth_callback(request, platform):
         tokens = provider.exchange_code(code, redirect_uri)
         profile = provider.get_profile(tokens.access_token)
 
-        # Facebook/Instagram: only connect Pages, not personal profiles
+        # Facebook/Instagram/LinkedIn Company: connect Pages, not personal profiles
         if platform in (
             PlatformCredential.Platform.FACEBOOK,
             PlatformCredential.Platform.INSTAGRAM,
+            PlatformCredential.Platform.LINKEDIN_COMPANY,
         ) and hasattr(provider, "get_user_pages"):
             pages = provider.get_user_pages(tokens.access_token)
             if pages:

--- a/providers/linkedin_company.py
+++ b/providers/linkedin_company.py
@@ -1,13 +1,17 @@
 """LinkedIn provider variant for Company Page posting.
 
-Uses the Community Management API app with organization scopes. Posts to
-Company Pages the authenticated member administers via
-``w_organization_social`` and ``rw_organization_admin``.
+Lists organizations the authenticated member administers, lets the user
+pick one, and publishes to that Company Page via the organization URN.
 """
 
 from __future__ import annotations
 
-from .linkedin import LinkedInProvider
+import logging
+
+from .linkedin import API_BASE, LINKEDIN_HEADERS, LinkedInProvider
+from .types import AccountProfile
+
+logger = logging.getLogger(__name__)
 
 
 class LinkedInCompanyProvider(LinkedInProvider):
@@ -26,3 +30,34 @@ class LinkedInCompanyProvider(LinkedInProvider):
             "r_organization_social",
             "rw_organization_admin",
         ]
+
+    def get_user_pages(self, access_token: str) -> list[dict]:
+        resp = self._request(
+            "GET",
+            f"{API_BASE}/v2/organizationalEntityAcls"
+            "?q=roleAssignee&role=ADMINISTRATOR"
+            "&projection=(elements*(organizationalTarget~(id,localizedName,vanityName,logoV2(original~:playableStreams))))",
+            access_token=access_token,
+            headers=LINKEDIN_HEADERS,
+        )
+        data = resp.json()
+        pages: list[dict] = []
+        for element in data.get("elements", []):
+            org = element.get("organizationalTarget~", {})
+            org_urn = element.get("organizationalTarget", "")
+            org_id = org_urn.split(":")[-1] if org_urn else org.get("id", "")
+            logo_url = None
+            logo = org.get("logoV2", {}).get("original~", {})
+            elements = logo.get("elements", [])
+            if elements:
+                identifiers = elements[0].get("identifiers", [])
+                if identifiers:
+                    logo_url = identifiers[0].get("identifier")
+            pages.append({
+                "id": str(org_id),
+                "name": org.get("localizedName", ""),
+                "handle": org.get("vanityName", ""),
+                "access_token": access_token,
+                "picture": logo_url,
+            })
+        return pages

--- a/providers/linkedin_company.py
+++ b/providers/linkedin_company.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import logging
 
 from .linkedin import API_BASE, LINKEDIN_HEADERS, LinkedInProvider
-from .types import AccountProfile
 
 logger = logging.getLogger(__name__)
 

--- a/tests/providers/test_linkedin_company.py
+++ b/tests/providers/test_linkedin_company.py
@@ -1,0 +1,149 @@
+"""Tests for LinkedInCompanyProvider.get_user_pages."""
+
+from unittest.mock import MagicMock, patch
+
+from providers.linkedin_company import LinkedInCompanyProvider
+
+
+def _make_response(payload: dict) -> MagicMock:
+    resp = MagicMock()
+    resp.json = MagicMock(return_value=payload)
+    return resp
+
+
+class TestGetUserPages:
+    @patch.object(LinkedInCompanyProvider, "_request")
+    def test_resolves_logo_url_from_projection(self, mock_request):
+        # `organizationalEntityAcls` with the projection used in the provider
+        # returns the org URN under `organizationalTarget`, the expanded org
+        # under `organizationalTarget~`, and logo media URLs under
+        # `logoV2.original~.elements[0].identifiers[0].identifier`.
+        mock_request.return_value = _make_response(
+            {
+                "elements": [
+                    {
+                        "organizationalTarget": "urn:li:organization:98765",
+                        "organizationalTarget~": {
+                            "id": 98765,
+                            "localizedName": "Acme Robotics",
+                            "vanityName": "acme-robotics",
+                            "logoV2": {
+                                "original~": {
+                                    "elements": [
+                                        {
+                                            "identifiers": [
+                                                {
+                                                    "identifier": "https://media.licdn.com/dms/image/C4E03AQFM2Cu_RPHz4A/company-logo_200_200/0/example.png",
+                                                }
+                                            ],
+                                        }
+                                    ],
+                                }
+                            },
+                        },
+                    }
+                ]
+            }
+        )
+
+        provider = LinkedInCompanyProvider()
+        pages = provider.get_user_pages("token-xyz")
+
+        assert pages == [
+            {
+                "id": "98765",
+                "name": "Acme Robotics",
+                "handle": "acme-robotics",
+                "access_token": "token-xyz",
+                "picture": "https://media.licdn.com/dms/image/C4E03AQFM2Cu_RPHz4A/company-logo_200_200/0/example.png",
+            }
+        ]
+        # Verify the projection-bearing URL is what we requested.
+        args, kwargs = mock_request.call_args
+        assert args[0] == "GET"
+        assert "/v2/organizationalEntityAcls" in args[1]
+        assert "role=ADMINISTRATOR" in args[1]
+        assert "logoV2(original~:playableStreams)" in args[1]
+
+    @patch.object(LinkedInCompanyProvider, "_request")
+    def test_picture_is_none_when_logo_missing(self, mock_request):
+        # Org with no logoV2 set at all (newly created page without a logo).
+        mock_request.return_value = _make_response(
+            {
+                "elements": [
+                    {
+                        "organizationalTarget": "urn:li:organization:11111",
+                        "organizationalTarget~": {
+                            "id": 11111,
+                            "localizedName": "No Logo Co",
+                            "vanityName": "no-logo",
+                        },
+                    }
+                ]
+            }
+        )
+
+        provider = LinkedInCompanyProvider()
+        pages = provider.get_user_pages("token")
+
+        assert len(pages) == 1
+        assert pages[0]["picture"] is None
+        assert pages[0]["id"] == "11111"
+        assert pages[0]["name"] == "No Logo Co"
+
+    @patch.object(LinkedInCompanyProvider, "_request")
+    def test_picture_is_none_when_logo_elements_empty(self, mock_request):
+        # logoV2 present but elements list is empty.
+        mock_request.return_value = _make_response(
+            {
+                "elements": [
+                    {
+                        "organizationalTarget": "urn:li:organization:22222",
+                        "organizationalTarget~": {
+                            "id": 22222,
+                            "localizedName": "Empty Elements Co",
+                            "vanityName": "empty-elements",
+                            "logoV2": {"original~": {"elements": []}},
+                        },
+                    }
+                ]
+            }
+        )
+
+        provider = LinkedInCompanyProvider()
+        pages = provider.get_user_pages("token")
+
+        assert pages[0]["picture"] is None
+
+    @patch.object(LinkedInCompanyProvider, "_request")
+    def test_returns_empty_list_when_no_orgs(self, mock_request):
+        # User administers no organizations.
+        mock_request.return_value = _make_response({"elements": []})
+
+        provider = LinkedInCompanyProvider()
+        pages = provider.get_user_pages("token")
+
+        assert pages == []
+
+    @patch.object(LinkedInCompanyProvider, "_request")
+    def test_id_falls_back_to_expanded_when_urn_missing(self, mock_request):
+        # Defensive: if `organizationalTarget` URN is missing but the expanded
+        # block carries an `id`, fall back to that.
+        mock_request.return_value = _make_response(
+            {
+                "elements": [
+                    {
+                        "organizationalTarget~": {
+                            "id": 33333,
+                            "localizedName": "Fallback Co",
+                            "vanityName": "fallback",
+                        },
+                    }
+                ]
+            }
+        )
+
+        provider = LinkedInCompanyProvider()
+        pages = provider.get_user_pages("token")
+
+        assert pages[0]["id"] == "33333"


### PR DESCRIPTION
## Summary

- LinkedIn Company Page connections previously stored the authenticated user's personal profile, not the organization — posts published to the wrong account
- Added `get_user_pages()` to `LinkedInCompanyProvider` that lists orgs the user admins via `/v2/organizationalEntityAcls` with projection for name, vanity name, and logo
- Added `linkedin_company` to the page selection flow so users pick which company page to connect (reuses the existing Facebook multi-page selector UI)
- Publisher engine now injects `urn:li:organization:{id}` as the post author for `linkedin_company` posts

## Test plan

- [ ] Connect a LinkedIn Company Page — should show org selection screen
- [ ] Verify org name and logo display correctly after connection
- [ ] Publish a post to the company page — should appear on the company page, not personal profile

Fixes #48