### PR TITLE
fix(composer): show saved templates in Use Template picker (#46)

### DIFF
--- a/apps/composer/tests/test_template_picker.py
+++ b/apps/composer/tests/test_template_picker.py
@@ -37,9 +37,7 @@ class TemplatePickerTests(TestCase):
             workspace_role=WorkspaceMembership.WorkspaceRole.OWNER,
         )
         self.client.force_login(self.user)
-        self.picker_url = reverse(
-            "composer:template_picker", kwargs={"workspace_id": self.workspace.id}
-        )
+        self.picker_url = reverse("composer:template_picker", kwargs={"workspace_id": self.workspace.id})
 
     def test_picker_returns_templates_for_workspace(self):
         PostTemplate.objects.create(
@@ -66,9 +64,7 @@ class TemplatePickerTests(TestCase):
         self.assertNotIn("No templates yet.", body)
 
     def test_picker_excludes_other_workspace_templates(self):
-        other_workspace = Workspace.objects.create(
-            organization=self.org, name="Other Workspace"
-        )
+        other_workspace = Workspace.objects.create(organization=self.org, name="Other Workspace")
         PostTemplate.objects.create(
             workspace=other_workspace,
             name="Secret template",

--- a/apps/composer/tests/test_template_picker.py
+++ b/apps/composer/tests/test_template_picker.py
@@ -1,0 +1,97 @@
+"""HTTP-level tests for the composer template picker view.
+
+Guards the workspace scoping of saved post templates surfaced through the
+"Use Template" picker on the composer page (issue #46).
+"""
+
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from apps.accounts.models import User
+from apps.composer.models import PostTemplate
+from apps.members.models import OrgMembership, WorkspaceMembership
+from apps.organizations.models import Organization
+from apps.workspaces.models import Workspace
+
+
+class TemplatePickerTests(TestCase):
+    """GET /workspace/<id>/composer/templates/picker/"""
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="owner@example.com",
+            password="testpass123",
+            tos_accepted_at=timezone.now(),
+        )
+        self.org = Organization.objects.create(name="Test Org")
+        self.workspace = Workspace.objects.create(organization=self.org, name="Test Workspace")
+        OrgMembership.objects.create(
+            user=self.user,
+            organization=self.org,
+            org_role=OrgMembership.OrgRole.OWNER,
+        )
+        WorkspaceMembership.objects.create(
+            user=self.user,
+            workspace=self.workspace,
+            workspace_role=WorkspaceMembership.WorkspaceRole.OWNER,
+        )
+        self.client.force_login(self.user)
+        self.picker_url = reverse(
+            "composer:template_picker", kwargs={"workspace_id": self.workspace.id}
+        )
+
+    def test_picker_returns_templates_for_workspace(self):
+        PostTemplate.objects.create(
+            workspace=self.workspace,
+            name="Launch announcement",
+            description="Reusable launch copy",
+            template_data={"caption": "We just launched!"},
+            created_by=self.user,
+        )
+        PostTemplate.objects.create(
+            workspace=self.workspace,
+            name="Weekly digest",
+            description="",
+            template_data={"caption": "This week at Acme..."},
+            created_by=self.user,
+        )
+
+        response = self.client.get(self.picker_url)
+
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode("utf-8")
+        self.assertIn("Launch announcement", body)
+        self.assertIn("Weekly digest", body)
+        self.assertNotIn("No templates yet.", body)
+
+    def test_picker_excludes_other_workspace_templates(self):
+        other_workspace = Workspace.objects.create(
+            organization=self.org, name="Other Workspace"
+        )
+        PostTemplate.objects.create(
+            workspace=other_workspace,
+            name="Secret template",
+            template_data={"caption": "Hidden"},
+            created_by=self.user,
+        )
+        PostTemplate.objects.create(
+            workspace=self.workspace,
+            name="Mine",
+            template_data={"caption": "Visible"},
+            created_by=self.user,
+        )
+
+        response = self.client.get(self.picker_url)
+
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode("utf-8")
+        self.assertIn("Mine", body)
+        self.assertNotIn("Secret template", body)
+
+    def test_picker_empty_state(self):
+        response = self.client.get(self.picker_url)
+
+        self.assertEqual(response.status_code, 200)
+        body = response.content.decode("utf-8")
+        self.assertIn("No templates yet.", body)

--- a/providers/linkedin_company.py
+++ b/providers/linkedin_company.py
@@ -52,11 +52,13 @@ class LinkedInCompanyProvider(LinkedInProvider):
                 identifiers = elements[0].get("identifiers", [])
                 if identifiers:
                     logo_url = identifiers[0].get("identifier")
-            pages.append({
-                "id": str(org_id),
-                "name": org.get("localizedName", ""),
-                "handle": org.get("vanityName", ""),
-                "access_token": access_token,
-                "picture": logo_url,
-            })
+            pages.append(
+                {
+                    "id": str(org_id),
+                    "name": org.get("localizedName", ""),
+                    "handle": org.get("vanityName", ""),
+                    "access_token": access_token,
+                    "picture": logo_url,
+                }
+            )
         return pages

--- a/templates/composer/compose.html
+++ b/templates/composer/compose.html
@@ -388,18 +388,22 @@
                                 </div>
                             </div>
                             {% endif %}
-                            <button type="button" @click="showTemplatePicker = !showTemplatePicker"
+                            <button type="button"
+                                    @click="showTemplatePicker = !showTemplatePicker; if (showTemplatePicker) $nextTick(() => htmx.trigger($refs.templatePicker, 'load-picker'))"
                                     class="text-xs font-semibold py-1.5 px-3 rounded-full border border-stone-200 text-stone-500 hover:border-stone-300 hover:text-stone-700 transition-colors flex items-center gap-1">
                                 <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/></svg>
                                 Use Template
                             </button>
                             <!-- Template picker modal -->
-                            <div x-show="showTemplatePicker" x-cloak x-transition
+                            <!-- hx-swap="innerHTML" is explicit because composer-form ancestor sets hx-swap="none" -->
+                            <div x-ref="templatePicker"
+                                 x-show="showTemplatePicker" x-cloak x-transition
                                  @click.outside="showTemplatePicker = false"
                                  class="absolute z-50 top-full mt-1 right-0 bg-white rounded-xl shadow-lg ring-1 ring-stone-200 w-80 max-w-[calc(100vw-2rem)] max-h-80 overflow-y-auto"
                                  hx-get="{% url 'composer:template_picker' workspace_id=workspace.id %}"
-                                 hx-trigger="intersect once"
-                                 hx-target="this">
+                                 hx-trigger="load-picker, templateSaved from:body, templateChanged from:body"
+                                 hx-target="this"
+                                 hx-swap="innerHTML">
                                 <div class="p-4 text-center text-xs text-stone-400">Loading templates…</div>
                             </div>
                         </div>


### PR DESCRIPTION
## What does this PR do?

Fixes the composer's **Use Template** picker so it actually displays user-saved `PostTemplate` rows. Replaces the unreliable `hx-trigger="intersect once"` with an Alpine-driven `load-picker` event fired in `$nextTick` after the modal opens, and pins `hx-swap="innerHTML"` on the picker to override an inherited `hx-swap="none"`.

## Why?

Closes [#46](https://github.com/brightbeanxyz/brightbean-studio/issues/46) — *Templates that I saved are not shown*.

Two issues compounded:

1. The picker modal starts hidden (`display: none` via Alpine `x-show` + `x-cloak`). `hx-trigger="intersect once"` fires inconsistently on a `display:none → display:block` transition across browsers.
2. **Root cause.** The picker sits inside `<form id="composer-form" hx-swap="none">`, and HTMX inherits `hx-swap` down the tree. The fetch fired and returned 200, `htmx:afterSwap` reported success, but the modal's innerHTML was never actually replaced because the inherited swap style was `none`. The loading placeholder stayed put. From the user's perspective this looked identical to "no templates yet".

The new trigger pattern mirrors the existing working `htmx.trigger(..., 'load')` in `create_landing.html:529`. Adding `templateSaved from:body` and `templateChanged from:body` to the trigger list lets the picker live-refresh when a template is saved or deleted while it is open — those events are already broadcast via `HX-Trigger` in [`save_as_template`](apps/composer/views.py) and [`template_delete`](apps/composer/views.py).

### Out of scope

The issue text mentions enriching the picker with the built-in templates from `apps/composer/builtin_templates.py`. That's a separate enhancement and is intentionally not included here.

## How to test

1. Run dev server, open the composer in a workspace with **zero** templates → click **Use Template** → confirm the picker renders *"No templates yet."* (not stuck on *"Loading templates…"*).
2. Edit an existing post → **Save as Template** → reopen **Use Template** → confirm the new template appears with its name, description, and caption snippet.
3. Click the entry → confirm navigation to `compose/?template=<uuid>` with the caption pre-filled.
4. With the picker open, save another template via the save flow → confirm the picker list refreshes automatically (validates the `templateSaved from:body` trigger).
5. DevTools → Network → confirm exactly one `GET …/composer/templates/picker/` per modal-open.
6. DevTools → Console → confirm zero CSP violations.
7. Run `python manage.py test apps.composer.tests` — 17/17 pass (3 new `test_template_picker.py` + 14 existing).

## Checklist

- [x] Tests pass (`python manage.py test apps.composer.tests` — 17/17)
- [x] Lint passes (`ruff check .` and `ruff format --check .`)
- [x] Documentation updated (n/a — bug fix, no user-facing docs change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)