### PR TITLE
Add admin UI for platform credentials (env-dominant resolution)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,8 @@ DEFAULT_FROM_EMAIL=noreply@yourdomain.com
 GOOGLE_AUTH_CLIENT_ID=
 GOOGLE_AUTH_CLIENT_SECRET=
 
-# PLATFORM CREDENTIALS (cloud version - self-hosted uses admin UI)
+# PLATFORM CREDENTIALS — set per deployment here (these take precedence), or
+# per organization via the Django admin at /admin/ -> Platform credentials.
 PLATFORM_FACEBOOK_APP_ID=
 PLATFORM_FACEBOOK_APP_SECRET=
 PLATFORM_INSTAGRAM_APP_ID=

--- a/README.md
+++ b/README.md
@@ -349,7 +349,14 @@ brightbean-studio/
 
 ## Platform Credentials
 
-To connect social media accounts, you need API credentials from each platform's developer portal. You can set these via environment variables in `.env` (see `.env.example`) or through the admin UI at **Settings → Platform Credentials**.
+To connect social media accounts, you need API credentials from each platform's developer portal. You can set these via environment variables in `.env` (see `.env.example`) or, per organization, through the Django admin at `{APP_URL}/admin/` → **Credentials → Platform credentials** (superuser only). If a platform is configured in both places, the `.env` value takes precedence.
+
+**Admin UI access (superuser only):** The Django admin at `{APP_URL}/admin/` (for example `https://brightbean.example.com/admin/`) is restricted to superuser accounts — only a superuser can view or edit platform credentials there. If you don't already have one, create a superuser, then sign in and open **Credentials → Platform credentials**:
+
+```bash
+python manage.py createsuperuser
+# Docker: docker compose exec app python manage.py createsuperuser
+```
 
 **Redirect URI:** When registering your app on any platform, set the OAuth redirect URI to:
 

--- a/apps/analytics/tasks.py
+++ b/apps/analytics/tasks.py
@@ -24,7 +24,6 @@ from datetime import date as dt_date
 from datetime import timedelta
 
 from background_task import background
-from django.conf import settings
 from django.db import transaction
 from django.utils import timezone
 
@@ -235,17 +234,11 @@ def _account_metrics_to_dict(metrics, platform: str) -> dict[str, float]:
 def _resolve_provider(account):
     """Mirror apps.social_accounts.tasks.check_social_account_health's credential
     resolution so platforms with org-level creds (Meta apps, etc.) work."""
-    from apps.credentials.models import PlatformCredential
+    from apps.credentials.models import resolve_platform_credentials
     from providers import get_provider
 
-    credentials: dict = {}
-    try:
-        org_id = account.workspace.organization_id
-        cred = PlatformCredential.objects.for_org(org_id).get(platform=account.platform, is_configured=True)
-        credentials = cred.credentials
-    except PlatformCredential.DoesNotExist:
-        env_creds = getattr(settings, "PLATFORM_CREDENTIALS_FROM_ENV", {})
-        credentials = env_creds.get(account.platform, {})
+    # .env is dominant; admin-entered org credentials are the fallback.
+    credentials = resolve_platform_credentials(account.platform, account.workspace.organization_id)
 
     if account.platform == "mastodon" and account.instance_url:
         from apps.social_accounts.models import MastodonAppRegistration

--- a/apps/composer/views.py
+++ b/apps/composer/views.py
@@ -1080,19 +1080,11 @@ def pinterest_boards(request, workspace_id, account_id):
     workspace = _get_workspace(request, workspace_id)
     account = get_object_or_404(SocialAccount, id=account_id, workspace=workspace, platform="pinterest")
 
-    from apps.credentials.models import PlatformCredential
+    from apps.credentials.models import resolve_platform_credentials
     from providers import get_provider
 
-    try:
-        cred = PlatformCredential.objects.for_org(workspace.organization_id).get(
-            platform="pinterest", is_configured=True
-        )
-        credentials = cred.credentials
-    except PlatformCredential.DoesNotExist:
-        from django.conf import settings as django_settings
-
-        env_creds = getattr(django_settings, "PLATFORM_CREDENTIALS_FROM_ENV", {})
-        credentials = env_creds.get("pinterest", {})
+    # .env is dominant; admin-entered org credentials are the fallback.
+    credentials = resolve_platform_credentials("pinterest", workspace.organization_id)
 
     provider = get_provider("pinterest", credentials)
 

--- a/apps/credentials/admin.py
+++ b/apps/credentials/admin.py
@@ -1,18 +1,33 @@
 from django.contrib import admin
 
+from .forms import PlatformCredentialAdminForm
 from .models import PlatformCredential
 
 
 @admin.register(PlatformCredential)
 class PlatformCredentialAdmin(admin.ModelAdmin):
+    form = PlatformCredentialAdminForm
     list_display = ("organization", "platform", "is_configured", "test_result", "tested_at")
     list_filter = ("platform", "is_configured", "test_result")
     search_fields = ("organization__name",)
-    readonly_fields = ("id", "created_at", "updated_at", "tested_at")
+    # is_configured is derived from the credentials on save (see model); the test
+    # fields have no flow yet — keep them read-only so they can't be hand-set.
+    readonly_fields = ("id", "is_configured", "test_result", "tested_at", "created_at", "updated_at")
 
-    def get_readonly_fields(self, request, obj=None):
-        fields = list(super().get_readonly_fields(request, obj))
-        # Never show raw encrypted credentials in admin
-        if "credentials" not in fields:
-            fields.append("credentials")
-        return fields
+    # Editing credentials necessarily reveals decrypted secrets on the change
+    # page, so restrict the whole model to superusers (admin already requires
+    # is_staff).
+    def has_module_permission(self, request):
+        return request.user.is_superuser
+
+    def has_view_permission(self, request, obj=None):
+        return request.user.is_superuser
+
+    def has_add_permission(self, request):
+        return request.user.is_superuser
+
+    def has_change_permission(self, request, obj=None):
+        return request.user.is_superuser
+
+    def has_delete_permission(self, request, obj=None):
+        return request.user.is_superuser

--- a/apps/credentials/forms.py
+++ b/apps/credentials/forms.py
@@ -1,0 +1,81 @@
+from django import forms
+from django.utils.safestring import mark_safe
+
+from .models import REQUIRED_CREDENTIAL_KEYS, PlatformCredential, derive_is_configured
+
+# Human-readable required-key hints, shown under the credentials field in the
+# admin. Mirrors what each provider reads (see providers/*.py).
+_KEY_HINTS = {
+    "facebook": "client_id, client_secret (app_id / app_secret also accepted)",
+    "instagram": "client_id, client_secret (app_id / app_secret also accepted)",
+    "instagram_login": "client_id, client_secret (app_id / app_secret also accepted)",
+    "threads": "client_id, client_secret (app_id / app_secret also accepted)",
+    "pinterest": "client_id, client_secret (app_id / app_secret also accepted)",
+    "tiktok": "client_key, client_secret  (note: client_key, NOT client_id)",
+    "youtube": "client_id, client_secret",
+    "google_business": "client_id, client_secret (optional: account_id, location_id)",
+    "linkedin_personal": "client_id, client_secret (optional: _oauth_mode = oidc | community_management)",
+    "linkedin_company": "client_id, client_secret",
+}
+
+CREDENTIALS_HELP = mark_safe(
+    'JSON object of app credentials, e.g. <code>{"client_id": "...", "client_secret": "..."}</code>. '
+    "Required keys per platform:<br>"
+    + "<br>".join(f"<b>{platform}</b>: {hint}" for platform, hint in _KEY_HINTS.items())
+)
+
+
+class PlatformCredentialAdminForm(forms.ModelForm):
+    # Override the EncryptedJSONField (a bare TextField) with a real JSON field so
+    # the admin renders/parses proper JSON instead of a Python repr — without this
+    # a no-edit save would store a corrupt JSON-encoded string.
+    credentials = forms.JSONField(
+        required=False,
+        widget=forms.Textarea(attrs={"rows": 8, "cols": 60}),
+        help_text=CREDENTIALS_HELP,
+    )
+
+    class Meta:
+        model = PlatformCredential
+        fields = ("organization", "platform", "credentials")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Only offer platforms that take app-level credentials (exclude session /
+        # per-instance auth platforms like bluesky and mastodon).
+        self.fields["platform"].choices = [
+            choice
+            for choice in self.fields["platform"].choices
+            if choice[0] == "" or choice[0] in REQUIRED_CREDENTIAL_KEYS
+        ]
+
+    def clean_credentials(self):
+        data = self.cleaned_data.get("credentials")
+        if data in (None, ""):
+            return {}
+        if not isinstance(data, dict):
+            raise forms.ValidationError(
+                'Credentials must be a JSON object, e.g. {"client_id": "...", "client_secret": "..."}.'
+            )
+        cleaned = {}
+        for key, value in data.items():
+            if value is None:
+                continue
+            text = value if isinstance(value, str) else str(value)
+            if text.strip():
+                cleaned[key] = text
+        return cleaned
+
+    def clean(self):
+        cleaned = super().clean()
+        platform = cleaned.get("platform")
+        credentials = cleaned.get("credentials") or {}
+        if platform and credentials and not derive_is_configured(platform, credentials):
+            required = REQUIRED_CREDENTIAL_KEYS.get(platform, ())
+            hint = ", ".join(" / ".join(group) for group in required)
+            self.add_error(
+                "credentials",
+                f"Missing required keys for {platform}. Expected: {hint or 'none'}. "
+                "Fill in every required key — the row stays inactive until they are all present.",
+            )
+        return cleaned

--- a/apps/credentials/models.py
+++ b/apps/credentials/models.py
@@ -5,6 +5,39 @@ from django.db import models
 from apps.common.encryption import EncryptedJSONField
 from apps.common.managers import OrgScopedManager
 
+# Per-platform required credential keys. Each inner tuple is an "any of these
+# aliases" group; a platform counts as configured only when EVERY group has a
+# non-empty value. Mirrors the keys each provider actually reads — TikTok uses
+# ``client_key`` (not ``client_id``); Meta and Pinterest accept ``app_id`` /
+# ``app_secret`` as aliases for ``client_id`` / ``client_secret``. Platforms
+# with no entry (bluesky, mastodon) use session / per-instance auth and need no
+# app-level credentials.
+REQUIRED_CREDENTIAL_KEYS = {
+    "facebook": (("client_id", "app_id"), ("client_secret", "app_secret")),
+    "instagram": (("client_id", "app_id"), ("client_secret", "app_secret")),
+    "instagram_login": (("client_id", "app_id"), ("client_secret", "app_secret")),
+    "threads": (("client_id", "app_id"), ("client_secret", "app_secret")),
+    "pinterest": (("client_id", "app_id"), ("client_secret", "app_secret")),
+    "tiktok": (("client_key",), ("client_secret",)),
+    "youtube": (("client_id",), ("client_secret",)),
+    "google_business": (("client_id",), ("client_secret",)),
+    "linkedin_personal": (("client_id",), ("client_secret",)),
+    "linkedin_company": (("client_id",), ("client_secret",)),
+}
+
+
+def derive_is_configured(platform, credentials):
+    """Return True when ``credentials`` holds every required key for ``platform``.
+
+    Used to populate ``PlatformCredential.is_configured`` (the runtime gate) from
+    the credential values, so a row activates only when it is actually usable.
+    """
+    groups = REQUIRED_CREDENTIAL_KEYS.get(platform)
+    if not groups:
+        return False
+    creds = credentials or {}
+    return all(any(str(creds.get(k) or "").strip() for k in group) for group in groups)
+
 
 class PlatformCredential(models.Model):
     class Platform(models.TextChoices):
@@ -56,6 +89,17 @@ class PlatformCredential(models.Model):
     def __str__(self):
         return f"{self.organization.name} - {self.get_platform_display()}"
 
+    def save(self, *args, **kwargs):
+        # ``is_configured`` is the runtime gate every consumer filters on; keep it
+        # a pure function of the credential values so a row is only ever active
+        # when it actually has the keys its provider needs.
+        self.is_configured = derive_is_configured(self.platform, self.credentials)
+        update_fields = kwargs.get("update_fields")
+        if update_fields is not None:
+            # Persist the derived flag even on a partial (update_fields) save.
+            kwargs["update_fields"] = {*update_fields, "is_configured"}
+        super().save(*args, **kwargs)
+
     @property
     def masked_credentials(self):
         """Return credentials with secrets masked (last 4 chars only)."""
@@ -66,3 +110,62 @@ class PlatformCredential(models.Model):
             else:
                 masked[key] = "****"
         return masked
+
+
+def _extract_secret(credentials):
+    """Return the app secret from a credentials dict, accepting either spelling."""
+    creds = credentials or {}
+    return creds.get("app_secret") or creds.get("client_secret") or ""
+
+
+def resolve_platform_credentials(platform, org_id):
+    """Return app credentials for ``platform``, with ``.env`` dominant.
+
+    If env has any non-empty value for the platform it wins; otherwise fall back
+    to the org's admin-entered ``PlatformCredential`` row. Returns a fresh dict.
+    """
+    from django.conf import settings
+
+    env_creds = getattr(settings, "PLATFORM_CREDENTIALS_FROM_ENV", {}).get(platform, {})
+    # .env wins only when it fully satisfies the platform's required keys, so a
+    # partial env config can't shadow a complete admin-entered row.
+    if derive_is_configured(platform, env_creds):
+        return dict(env_creds)
+    try:
+        cred = PlatformCredential.objects.for_org(org_id).get(platform=platform, is_configured=True)
+        return dict(cred.credentials)
+    except PlatformCredential.DoesNotExist:
+        return dict(env_creds)
+
+
+def resolve_app_secret(platform, org_id):
+    """Return the single app secret for one org's platform (.env dominant).
+
+    Used to bind inbound-webhook verification to the specific account/org being
+    written, so one org's secret can't authorize events for another org.
+    """
+    return _extract_secret(resolve_platform_credentials(platform, org_id))
+
+
+def resolve_app_secrets(*platforms):
+    """Return all candidate app secrets for verifying inbound webhooks.
+
+    Webhook verification authenticates an inbound event rather than selecting a
+    single app, so we collect every secret that could legitimately have signed
+    it: the env secret (if set) plus each configured org's admin-entered secret,
+    across all the given platform keys (e.g. facebook + instagram share one Meta
+    app). Deduped, env first.
+    """
+    from django.conf import settings
+
+    env_map = getattr(settings, "PLATFORM_CREDENTIALS_FROM_ENV", {})
+    secrets = []
+    for platform in platforms:
+        env_secret = _extract_secret(env_map.get(platform, {}))
+        if env_secret and env_secret not in secrets:
+            secrets.append(env_secret)
+    for cred in PlatformCredential.objects.filter(platform__in=platforms, is_configured=True):
+        secret = _extract_secret(cred.credentials)
+        if secret and secret not in secrets:
+            secrets.append(secret)
+    return secrets

--- a/apps/credentials/tests.py
+++ b/apps/credentials/tests.py
@@ -1,0 +1,377 @@
+"""Tests for platform credential resolution, derivation, the admin form, and the
+removal of the dormant /credentials/ placeholder."""
+
+import pytest
+from django.test import override_settings
+from django.urls import NoReverseMatch, Resolver404, resolve, reverse
+
+from apps.credentials.forms import PlatformCredentialAdminForm
+from apps.credentials.models import (
+    PlatformCredential,
+    derive_is_configured,
+    resolve_app_secret,
+    resolve_app_secrets,
+    resolve_platform_credentials,
+)
+
+# ---------------------------------------------------------------------------
+# derive_is_configured (pure function — no DB)
+# ---------------------------------------------------------------------------
+
+
+def test_derive_tiktok_requires_client_key():
+    assert derive_is_configured("tiktok", {"client_key": "k", "client_secret": "s"}) is True
+    # TikTok uses client_key, not client_id — client_id must NOT count.
+    assert derive_is_configured("tiktok", {"client_id": "k", "client_secret": "s"}) is False
+
+
+def test_derive_meta_accepts_app_id_aliases():
+    assert derive_is_configured("facebook", {"app_id": "a", "app_secret": "b"}) is True
+    assert derive_is_configured("facebook", {"client_id": "a", "client_secret": "b"}) is True
+
+
+def test_derive_false_for_partial_or_empty():
+    assert derive_is_configured("facebook", {"app_id": "a"}) is False
+    assert derive_is_configured("youtube", {}) is False
+    assert derive_is_configured("youtube", {"client_id": "", "client_secret": "  "}) is False
+    # None values must not read as truthy ("None" string bug guard).
+    assert derive_is_configured("youtube", {"client_id": None, "client_secret": None}) is False
+
+
+def test_derive_false_for_credential_less_platforms():
+    assert derive_is_configured("bluesky", {"anything": "x"}) is False
+    assert derive_is_configured("mastodon", {"client_id": "x", "client_secret": "y"}) is False
+
+
+# ---------------------------------------------------------------------------
+# PlatformCredential.save() derives is_configured
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_save_sets_is_configured_from_credentials(organization):
+    cred = PlatformCredential.objects.create(
+        organization=organization,
+        platform="youtube",
+        credentials={"client_id": "cid", "client_secret": "csec"},
+    )
+    cred.refresh_from_db()
+    assert cred.is_configured is True
+
+
+@pytest.mark.django_db
+def test_save_leaves_incomplete_row_inactive(organization):
+    cred = PlatformCredential.objects.create(
+        organization=organization,
+        platform="youtube",
+        credentials={"client_id": "cid"},  # no secret
+        is_configured=True,  # should be overridden by save()
+    )
+    cred.refresh_from_db()
+    assert cred.is_configured is False
+
+
+# ---------------------------------------------------------------------------
+# resolve_platform_credentials — .env dominant, DB fallback
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@override_settings(PLATFORM_CREDENTIALS_FROM_ENV={"facebook": {"app_id": "ENV_ID", "app_secret": "ENV_SECRET"}})
+def test_resolve_env_wins_over_db(organization):
+    PlatformCredential.objects.create(
+        organization=organization,
+        platform="facebook",
+        credentials={"client_id": "DB_ID", "client_secret": "DB_SECRET"},
+    )
+    result = resolve_platform_credentials("facebook", organization.id)
+    assert result == {"app_id": "ENV_ID", "app_secret": "ENV_SECRET"}
+
+
+@pytest.mark.django_db
+@override_settings(PLATFORM_CREDENTIALS_FROM_ENV={})
+def test_resolve_falls_back_to_db_when_env_empty(organization):
+    PlatformCredential.objects.create(
+        organization=organization,
+        platform="facebook",
+        credentials={"client_id": "DB_ID", "client_secret": "DB_SECRET"},
+    )
+    result = resolve_platform_credentials("facebook", organization.id)
+    assert result == {"client_id": "DB_ID", "client_secret": "DB_SECRET"}
+
+
+@pytest.mark.django_db
+@override_settings(PLATFORM_CREDENTIALS_FROM_ENV={})
+def test_resolve_returns_empty_when_nothing_configured(organization):
+    assert resolve_platform_credentials("facebook", organization.id) == {}
+
+
+@pytest.mark.django_db
+@override_settings(PLATFORM_CREDENTIALS_FROM_ENV={})
+def test_resolve_skips_incomplete_db_row(organization):
+    # Incomplete row -> is_configured False -> resolver must not pick it up.
+    PlatformCredential.objects.create(
+        organization=organization,
+        platform="facebook",
+        credentials={"client_id": "DB_ID"},
+    )
+    assert resolve_platform_credentials("facebook", organization.id) == {}
+
+
+# ---------------------------------------------------------------------------
+# resolve_app_secrets — union of env + admin secrets (for webhook verification)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@override_settings(PLATFORM_CREDENTIALS_FROM_ENV={"facebook": {"app_secret": "ENV_SEC"}})
+def test_resolve_app_secrets_unions_env_and_db(organization):
+    PlatformCredential.objects.create(
+        organization=organization,
+        platform="facebook",
+        credentials={"client_id": "x", "client_secret": "DB_SEC"},
+    )
+    secrets = resolve_app_secrets("facebook")
+    assert secrets == ["ENV_SEC", "DB_SEC"]  # env first, then DB
+
+
+@pytest.mark.django_db
+@override_settings(PLATFORM_CREDENTIALS_FROM_ENV={})
+def test_resolve_app_secrets_db_only(organization):
+    PlatformCredential.objects.create(
+        organization=organization,
+        platform="instagram_login",
+        credentials={"app_id": "x", "app_secret": "ONLY_DB"},
+    )
+    assert resolve_app_secrets("instagram_login") == ["ONLY_DB"]
+
+
+@pytest.mark.django_db
+@override_settings(PLATFORM_CREDENTIALS_FROM_ENV={})
+def test_resolve_app_secrets_dedupes_and_spans_platforms(organization):
+    PlatformCredential.objects.create(
+        organization=organization,
+        platform="facebook",
+        credentials={"client_id": "x", "client_secret": "SHARED"},
+    )
+    PlatformCredential.objects.create(
+        organization=organization,
+        platform="instagram",
+        credentials={"client_id": "y", "client_secret": "SHARED"},
+    )
+    # facebook + instagram share one Meta app; identical secret deduped to one.
+    assert resolve_app_secrets("facebook", "instagram") == ["SHARED"]
+
+
+# ---------------------------------------------------------------------------
+# PlatformCredentialAdminForm
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_admin_form_round_trip_persists_dict_and_activates(organization):
+    form = PlatformCredentialAdminForm(
+        data={
+            "organization": str(organization.pk),
+            "platform": "youtube",
+            "credentials": '{"client_id": "cid", "client_secret": "csec"}',
+        }
+    )
+    assert form.is_valid(), form.errors
+    obj = form.save()
+    obj.refresh_from_db()
+    # Stored as a real, decryptable dict (not a Python-repr string), and active.
+    assert obj.credentials == {"client_id": "cid", "client_secret": "csec"}
+    assert obj.is_configured is True
+
+
+@pytest.mark.django_db
+def test_admin_form_rejects_missing_required_keys(organization):
+    form = PlatformCredentialAdminForm(
+        data={
+            "organization": str(organization.pk),
+            "platform": "youtube",
+            "credentials": '{"client_id": "cid"}',  # missing client_secret
+        }
+    )
+    assert not form.is_valid()
+    assert "credentials" in form.errors
+
+
+@pytest.mark.django_db
+def test_admin_form_rejects_non_object_json(organization):
+    form = PlatformCredentialAdminForm(
+        data={
+            "organization": str(organization.pk),
+            "platform": "youtube",
+            "credentials": '"just a string"',
+        }
+    )
+    assert not form.is_valid()
+    assert "credentials" in form.errors
+
+
+def test_admin_form_excludes_credential_less_platforms():
+    choice_values = [value for value, _label in PlatformCredentialAdminForm().fields["platform"].choices]
+    assert "youtube" in choice_values
+    assert "bluesky" not in choice_values
+    assert "mastodon" not in choice_values
+
+
+# ---------------------------------------------------------------------------
+# Dormant /credentials/ placeholder removed
+# ---------------------------------------------------------------------------
+
+
+def test_credentials_placeholder_url_removed():
+    with pytest.raises(Resolver404):
+        resolve("/credentials/")
+
+
+def test_credentials_namespace_reverse_removed():
+    with pytest.raises(NoReverseMatch):
+        reverse("credentials:list")
+
+
+# ---------------------------------------------------------------------------
+# Django admin integration — editable credentials field, superuser-only gating
+# ---------------------------------------------------------------------------
+
+ADD_URL = "/admin/credentials/platformcredential/add/"
+
+
+@pytest.mark.django_db
+def test_admin_add_page_renders_editable_credentials_for_superuser(client):
+    from django.utils import timezone
+
+    from apps.accounts.models import User
+
+    admin_user = User.objects.create_superuser(
+        email="su@example.com", password="x", name="Super", tos_accepted_at=timezone.now()
+    )
+    client.force_login(admin_user)
+    resp = client.get(ADD_URL)
+    assert resp.status_code == 200
+    # An editable form field (not the old read-only display) is rendered.
+    assert b'name="credentials"' in resp.content
+
+
+@pytest.mark.django_db
+def test_admin_blocked_for_non_superuser_staff(client):
+    from django.utils import timezone
+
+    from apps.accounts.models import User
+
+    staff = User.objects.create_user(
+        email="staff@example.com", password="x", name="Staff", tos_accepted_at=timezone.now(), is_staff=True
+    )
+    client.force_login(staff)
+    resp = client.get(ADD_URL)
+    assert resp.status_code in (302, 403)
+
+
+# ---------------------------------------------------------------------------
+# Hardening: incomplete .env must not shadow a complete admin row
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@override_settings(PLATFORM_CREDENTIALS_FROM_ENV={"facebook": {"app_id": "ENV_ID"}})  # no secret -> incomplete
+def test_resolve_incomplete_env_does_not_shadow_db(organization):
+    PlatformCredential.objects.create(
+        organization=organization,
+        platform="facebook",
+        credentials={"client_id": "DB_ID", "client_secret": "DB_SECRET"},
+    )
+    # Partial env (missing secret) must fall back to the complete DB row.
+    result = resolve_platform_credentials("facebook", organization.id)
+    assert result == {"client_id": "DB_ID", "client_secret": "DB_SECRET"}
+
+
+# ---------------------------------------------------------------------------
+# resolve_app_secret — single per-org secret (.env dominant)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+@override_settings(PLATFORM_CREDENTIALS_FROM_ENV={})
+def test_resolve_app_secret_returns_org_secret(organization):
+    PlatformCredential.objects.create(
+        organization=organization,
+        platform="facebook",
+        credentials={"client_id": "x", "client_secret": "ORG_SEC"},
+    )
+    assert resolve_app_secret("facebook", organization.id) == "ORG_SEC"
+
+
+@pytest.mark.django_db
+@override_settings(PLATFORM_CREDENTIALS_FROM_ENV={"facebook": {"app_id": "i", "app_secret": "ENV_SEC"}})
+def test_resolve_app_secret_env_dominant(organization):
+    PlatformCredential.objects.create(
+        organization=organization,
+        platform="facebook",
+        credentials={"client_id": "x", "client_secret": "ORG_SEC"},
+    )
+    assert resolve_app_secret("facebook", organization.id) == "ENV_SEC"
+
+
+# ---------------------------------------------------------------------------
+# save(update_fields=...) still persists the derived is_configured flag
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+def test_save_update_fields_persists_derived_flag(organization):
+    cred = PlatformCredential.objects.create(
+        organization=organization,
+        platform="youtube",
+        credentials={"client_id": "cid"},  # incomplete -> inactive
+    )
+    cred.refresh_from_db()
+    assert cred.is_configured is False
+
+    cred.credentials = {"client_id": "cid", "client_secret": "csec"}
+    cred.save(update_fields=["credentials"])  # omits is_configured on purpose
+    cred.refresh_from_db()
+    assert cred.is_configured is True
+
+
+# ---------------------------------------------------------------------------
+# Backwards compatibility: existing .env-configured deployments keep working.
+# Mirrors the real key shapes built in config/settings/base.py
+# (PLATFORM_CREDENTIALS_FROM_ENV) so every platform's env config still resolves.
+# ---------------------------------------------------------------------------
+
+REALISTIC_ENV = {
+    "facebook": {"app_id": "fb-id", "app_secret": "fb-sec"},
+    "instagram": {"app_id": "fb-id", "app_secret": "fb-sec"},
+    "threads": {"app_id": "fb-id", "app_secret": "fb-sec"},
+    "instagram_login": {"app_id": "ig-id", "app_secret": "ig-sec"},
+    "linkedin_personal": {"client_id": "li-id", "client_secret": "li-sec", "_oauth_mode": "oidc"},
+    "linkedin_company": {"client_id": "lic-id", "client_secret": "lic-sec"},
+    "tiktok": {"client_key": "tt-key", "client_secret": "tt-sec"},
+    "youtube": {"client_id": "g-id", "client_secret": "g-sec"},
+    "google_business": {"client_id": "g-id", "client_secret": "g-sec"},
+    "pinterest": {"app_id": "pin-id", "app_secret": "pin-sec"},
+}
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("platform", list(REALISTIC_ENV))
+@override_settings(PLATFORM_CREDENTIALS_FROM_ENV=REALISTIC_ENV)
+def test_existing_env_only_deployment_resolves_every_platform(platform, organization):
+    # The existing-deployment reality: env set, no DB rows. Env creds resolve as-is.
+    assert resolve_platform_credentials(platform, organization.id) == REALISTIC_ENV[platform]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("platform", list(REALISTIC_ENV))
+@override_settings(PLATFORM_CREDENTIALS_FROM_ENV=REALISTIC_ENV)
+def test_env_dominates_db_for_every_platform(platform, organization):
+    # Even with a complete admin row present, a complete env config wins.
+    PlatformCredential.objects.create(
+        organization=organization,
+        platform=platform,
+        credentials={"client_id": "DB", "client_secret": "DB", "client_key": "DB"},
+    )
+    assert resolve_platform_credentials(platform, organization.id) == REALISTIC_ENV[platform]

--- a/apps/credentials/urls.py
+++ b/apps/credentials/urls.py
@@ -1,9 +1,0 @@
-from django.urls import path
-
-from . import views
-
-app_name = "credentials"
-
-urlpatterns = [
-    path("", views.credentials_list, name="list"),
-]

--- a/apps/credentials/views.py
+++ b/apps/credentials/views.py
@@ -1,7 +1,0 @@
-from django.contrib.auth.decorators import login_required
-from django.shortcuts import render
-
-
-@login_required
-def credentials_list(request):
-    return render(request, "credentials/list.html")

--- a/apps/inbox/tests/test_webhooks.py
+++ b/apps/inbox/tests/test_webhooks.py
@@ -229,3 +229,82 @@ class TestFacebookWebhookStillWorks:
         assert response.status_code == 200
         msg = InboxMessage.objects.get(platform_message_id="fb-msg-1")
         assert msg.social_account_id == fb_account.id
+
+
+@pytest.mark.django_db
+class TestMetaWebhookCrossTenantIsolation:
+    """A delivery signed with one org's app secret must not write into a different
+    org's accounts, even though that secret is a valid configured secret."""
+
+    def _setup_org(self, name, page_id, secret):
+        from apps.credentials.models import PlatformCredential
+        from apps.organizations.models import Organization
+        from apps.workspaces.models import Workspace
+
+        org = Organization.objects.create(name=name)
+        ws = Workspace.objects.create(name=f"{name} WS", organization=org)
+        PlatformCredential.objects.create(
+            organization=org,
+            platform="facebook",
+            credentials={"client_id": f"{name}-id", "client_secret": secret},
+        )
+        account = SocialAccount.objects.create(
+            workspace=ws,
+            platform="facebook",
+            account_platform_id=page_id,
+            account_name=f"{name} Page",
+        )
+        return account
+
+    @override_settings(PLATFORM_CREDENTIALS_FROM_ENV={})
+    def test_other_orgs_secret_cannot_forge_into_victim_account(self, client):
+        self._setup_org("OrgA", "page-A", "SECRET_A")  # victim
+        self._setup_org("OrgB", "page-B", "SECRET_B")  # attacker (knows SECRET_B)
+
+        # Attacker forges an event for the victim's page, signed with their own secret.
+        payload = {
+            "entry": [
+                {
+                    "id": "page-A",
+                    "messaging": [
+                        {"sender": {"id": "x", "name": "Mallory"}, "message": {"mid": "forged-1", "text": "forged"}}
+                    ],
+                }
+            ]
+        }
+        body = json.dumps(payload).encode()
+        url = reverse("inbox_webhooks:webhook_facebook")
+        response = client.post(
+            url,
+            data=body,
+            content_type="application/json",
+            HTTP_X_HUB_SIGNATURE_256=_sign_body(body, "SECRET_B"),
+        )
+        # SECRET_B is a valid configured secret, so the signature check passes (not 403),
+        # but the event must NOT be written into Org A's account.
+        assert response.status_code == 200
+        assert not InboxMessage.objects.filter(platform_message_id="forged-1").exists()
+
+    @override_settings(PLATFORM_CREDENTIALS_FROM_ENV={})
+    def test_owning_orgs_secret_processes_event(self, client):
+        account = self._setup_org("OrgC", "page-C", "SECRET_C")
+
+        payload = {
+            "entry": [
+                {
+                    "id": "page-C",
+                    "messaging": [{"sender": {"id": "u", "name": "Bob"}, "message": {"mid": "legit-1", "text": "hi"}}],
+                }
+            ]
+        }
+        body = json.dumps(payload).encode()
+        url = reverse("inbox_webhooks:webhook_facebook")
+        response = client.post(
+            url,
+            data=body,
+            content_type="application/json",
+            HTTP_X_HUB_SIGNATURE_256=_sign_body(body, "SECRET_C"),
+        )
+        assert response.status_code == 200
+        msg = InboxMessage.objects.get(platform_message_id="legit-1")
+        assert msg.social_account_id == account.id

--- a/apps/inbox/webhooks.py
+++ b/apps/inbox/webhooks.py
@@ -12,6 +12,7 @@ from django.views.decorators.http import require_http_methods
 from django_ratelimit.decorators import ratelimit
 
 from apps.common.validators import safe_xml_fromstring
+from apps.credentials.models import resolve_app_secret, resolve_app_secrets
 from apps.social_accounts.models import SocialAccount
 
 from .models import InboxMessage
@@ -60,11 +61,20 @@ def _verify_meta_signature(body: bytes, signature_header: str, app_secret: str) 
     return hmac.compare_digest(expected, signature_header)
 
 
-def _meta_receive(request, app_secret: str, platforms: list[str]):
-    """Validate signature and dispatch incoming Meta webhook events."""
+def _meta_receive(request, platforms: list[str]):
+    """Validate the HMAC signature and dispatch incoming Meta webhook events.
+
+    A delivery is signed by exactly one Meta app. We accept the request only if
+    the signature matches a configured app secret, then process events *only* for
+    accounts whose owning org's secret actually signed the body (see
+    ``_process_meta_events``) — so one org's secret can never authorize writes
+    into another org's accounts.
+    """
     signature = request.headers.get("X-Hub-Signature-256", "")
-    if not _verify_meta_signature(request.body, signature, app_secret):
-        logger.warning("Invalid Meta webhook signature.")
+    candidate_secrets = resolve_app_secrets(*platforms)
+    valid_secrets = {secret for secret in candidate_secrets if _verify_meta_signature(request.body, signature, secret)}
+    if not valid_secrets:
+        logger.warning("Meta webhook: signature did not match any configured app secret.")
         return HttpResponseForbidden("Invalid signature.")
 
     try:
@@ -73,14 +83,17 @@ def _meta_receive(request, app_secret: str, platforms: list[str]):
         logger.warning("Invalid JSON in Meta webhook payload.")
         return HttpResponse("Bad request", status=400)
 
-    _process_meta_events(payload, platforms)
+    _process_meta_events(payload, platforms, valid_secrets)
     return HttpResponse("OK", status=200)
 
 
-def _process_meta_events(payload: dict, platforms: list[str]):
+def _process_meta_events(payload: dict, platforms: list[str], valid_secrets: set[str]):
     """Process Meta (Facebook/Instagram) webhook events into InboxMessages.
 
-    Only events for SocialAccounts whose platform is in `platforms` are processed.
+    An event is processed only for SocialAccounts whose platform is in
+    `platforms` AND whose owning org's app secret signed this delivery (i.e. is in
+    `valid_secrets`). This binds each event to the org that owns the signing app,
+    preventing one org's secret from forging events into another org's accounts.
     """
     for entry in payload.get("entry", []):
         page_id = entry.get("id")
@@ -94,6 +107,14 @@ def _process_meta_events(payload: dict, platforms: list[str]):
         ).select_related("workspace__organization")
 
         for account in accounts:
+            account_secret = resolve_app_secret(account.platform, account.workspace.organization_id)
+            if not account_secret or account_secret not in valid_secrets:
+                logger.warning(
+                    "Meta webhook: signature not valid for account %s's org app; skipping event.",
+                    account.id,
+                )
+                continue
+
             for change in entry.get("changes", []):
                 _handle_facebook_change(account, change)
 
@@ -115,8 +136,8 @@ def facebook_webhook(request):
     """
     if request.method == "GET":
         return _meta_verify(request, settings.FACEBOOK_WEBHOOK_VERIFY_TOKEN)
-    app_secret = settings.PLATFORM_CREDENTIALS_FROM_ENV.get("facebook", {}).get("app_secret", "")
-    return _meta_receive(request, app_secret, platforms=["facebook", "instagram"])
+    # Facebook + Instagram (Facebook Login) share one Meta app.
+    return _meta_receive(request, platforms=["facebook", "instagram"])
 
 
 @csrf_exempt
@@ -131,8 +152,7 @@ def instagram_login_webhook(request):
     """
     if request.method == "GET":
         return _meta_verify(request, settings.INSTAGRAM_LOGIN_WEBHOOK_VERIFY_TOKEN)
-    app_secret = settings.PLATFORM_CREDENTIALS_FROM_ENV.get("instagram_login", {}).get("app_secret", "")
-    return _meta_receive(request, app_secret, platforms=["instagram_login"])
+    return _meta_receive(request, platforms=["instagram_login"])
 
 
 # --- Event handlers (shared between facebook + instagram_login) ---

--- a/apps/publisher/engine.py
+++ b/apps/publisher/engine.py
@@ -28,7 +28,7 @@ from django.db.models.functions import Coalesce
 from django.utils import timezone
 
 from apps.composer.models import PlatformPost
-from apps.credentials.models import PlatformCredential
+from apps.credentials.models import resolve_platform_credentials
 from providers import get_provider
 from providers.types import AuthType, PostType, PublishContent
 
@@ -43,21 +43,15 @@ RETRY_BACKOFF = [60, 300, 1800]  # 1min, 5min, 30min
 def _resolve_publish_credentials(account):
     """Resolve the credentials dict for publishing on behalf of `account`.
 
-    Combines org-level `PlatformCredential` (falling back to env) with
+    Combines org-level `PlatformCredential` (with `.env` dominant) with
     per-account federation metadata (Mastodon `instance_url` +
     `MastodonAppRegistration`, Bluesky `pds_url`). Returns a plain dict
     suitable for `get_provider(platform, credentials)`.
     """
     platform = account.platform
 
-    try:
-        cred = PlatformCredential.objects.for_org(account.workspace.organization_id).get(
-            platform=platform, is_configured=True
-        )
-        credentials = dict(cred.credentials)
-    except PlatformCredential.DoesNotExist:
-        env_creds = getattr(settings, "PLATFORM_CREDENTIALS_FROM_ENV", {})
-        credentials = dict(env_creds.get(platform, {}))
+    # .env is dominant; admin-entered org credentials are the fallback.
+    credentials = resolve_platform_credentials(platform, account.workspace.organization_id)
 
     if platform == "mastodon" and account.instance_url:
         from apps.common.validators import is_safe_url

--- a/apps/social_accounts/tasks.py
+++ b/apps/social_accounts/tasks.py
@@ -27,19 +27,10 @@ def check_social_account_health(account_id: str):
         logger.warning("Health check: account %s not found, skipping", account_id)
         return
 
-    # Load app credentials from the workspace's org or env fallback
-    from django.conf import settings
+    # Load app credentials (.env dominant, admin-entered org creds as fallback).
+    from apps.credentials.models import PlatformCredential, resolve_platform_credentials
 
-    from apps.credentials.models import PlatformCredential
-
-    credentials: dict = {}
-    try:
-        org_id = account.workspace.organization_id
-        cred = PlatformCredential.objects.for_org(org_id).get(platform=account.platform, is_configured=True)
-        credentials = cred.credentials
-    except PlatformCredential.DoesNotExist:
-        env_creds = getattr(settings, "PLATFORM_CREDENTIALS_FROM_ENV", {})
-        credentials = env_creds.get(account.platform, {})
+    credentials = resolve_platform_credentials(account.platform, account.workspace.organization_id)
 
     # For Mastodon, inject instance-specific client credentials
     if account.platform == PlatformCredential.Platform.MASTODON and account.instance_url:

--- a/apps/social_accounts/views.py
+++ b/apps/social_accounts/views.py
@@ -20,7 +20,7 @@ from django.views.decorators.http import require_GET, require_POST
 from django_ratelimit.decorators import ratelimit
 
 from apps.common.validators import is_safe_url as _is_safe_url
-from apps.credentials.models import PlatformCredential
+from apps.credentials.models import PlatformCredential, resolve_platform_credentials
 from apps.members.decorators import require_permission
 
 from .models import MastodonAppRegistration, PlatformVisibility, SocialAccount
@@ -36,13 +36,8 @@ def _get_provider_for_platform(platform: str, org_id, **extra_credentials):
     """Resolve app credentials and instantiate the provider."""
     from providers import get_provider
 
-    # Try org-specific credentials first, then env fallback
-    try:
-        cred = PlatformCredential.objects.for_org(org_id).get(platform=platform, is_configured=True)
-        credentials = cred.credentials
-    except PlatformCredential.DoesNotExist:
-        env_creds = getattr(settings, "PLATFORM_CREDENTIALS_FROM_ENV", {})
-        credentials = env_creds.get(platform, {})
+    # .env is dominant; admin-entered org credentials are the fallback.
+    credentials = resolve_platform_credentials(platform, org_id)
 
     if extra_credentials:
         credentials = {**credentials, **extra_credentials}

--- a/config/urls.py
+++ b/config/urls.py
@@ -20,7 +20,6 @@ urlpatterns = [
     path("workspaces/", include("apps.workspaces.urls")),
     path("members/", include("apps.members.urls")),
     path("settings/", include("apps.settings_manager.urls")),
-    path("credentials/", include("apps.credentials.urls")),
     path("social-accounts/", include("apps.social_accounts.urls")),
     # Content Pipeline (Stream A)
     path("workspace/<uuid:workspace_id>/", include("apps.composer.urls")),

--- a/templates/credentials/list.html
+++ b/templates/credentials/list.html
@@ -1,8 +1,0 @@
-{% extends "base.html" %}
-{% block page_title %}Platform Credentials{% endblock %}
-{% block content %}
-<div class="max-w-4xl">
-    <h2 class="text-xl font-semibold mb-6">Platform Credentials</h2>
-    <p class="text-gray-500">Credential management coming soon.</p>
-</div>
-{% endblock %}


### PR DESCRIPTION
## What does this PR do?

Makes the Django admin usable for entering per-organization platform API credentials and wires them into the runtime, while keeping `.env` authoritative.

- **`is_configured` is derived on save** from a per-platform required-keys map (TikTok `client_key`, Meta/Pinterest `app_id`/`app_secret` aliases, …), so a row only activates when it's actually usable.
- **New `PlatformCredentialAdminForm`** — a real `forms.JSONField` (avoids a Python-repr corruption trap on the encrypted field), validates required keys, and limits platform choices to credential-bearing platforms. The admin is restricted to **superusers** (editing reveals decrypted secrets).
- **One env-dominant resolver** `resolve_platform_credentials(platform, org_id)` — `.env` wins when complete, otherwise the org's admin-entered row. All five credential-resolution call sites (`social_accounts/views.py`, `social_accounts/tasks.py`, `publisher/engine.py`, `composer/views.py`, `analytics/tasks.py`) route through it (they were DB-first before).
- **Webhook hardening** — the Meta webhook HMAC is verified against the *owning org's* secret per account (`resolve_app_secret`), so one org's secret can't forge events into another org's accounts.
- **Removed the dormant `/credentials/` placeholder** (view, url, template, and the `config/urls.py` include); the `apps.credentials` app itself stays.
- **Docs** — README + `.env.example` describe the real admin path (`{APP_URL}/admin/` → Credentials → Platform credentials, superuser only), the env-dominant precedence rule, and how to create a superuser.

## Why?

The README advertised a "Settings → Platform Credentials" admin UI that never worked: the page was a "coming soon" placeholder, the admin forced the credentials field read-only, and nothing ever set the `is_configured` flag the runtime gates on — so the DB path was dead and credentials could only be supplied via `.env`. This closes that gap (self-hosters can configure credentials per org from the admin) without changing behavior for existing `.env` deployments.

## How to test

1. `pytest apps/credentials apps/inbox/tests/test_webhooks.py` — covers derivation, env-dominant resolution + per-platform `.env` backwards-compat, the admin form round-trip, superuser-only gating, and cross-tenant webhook isolation.
2. Manual: with `SECRET_KEY` + `ENCRYPTION_KEY_SALT` set, run `python manage.py createsuperuser`, sign in at `{APP_URL}/admin/` → **Credentials → Platform credentials**, add e.g. a `youtube` row `{"client_id": "...", "client_secret": "..."}` → it saves and shows `is_configured = True`. With no YouTube `.env` vars the connect flow uses the DB creds; set the `.env` vars and `.env` takes precedence.
3. Existing `.env`-only deployments are unchanged — every platform's real env key shape still resolves (parametrized backwards-compat tests).

## Checklist

- [x] Tests pass (`pytest`) — full suite green
- [x] Lint passes (`ruff check` and `ruff format --check`) on changed files
- [x] Documentation updated (README + `.env.example`)

> Note: no schema change — `is_configured` already exists, so no new migration.
