### PR TITLE
Fix OAuth consent CSP so Claude Desktop can connect to the MCP server

### DIFF
--- a/apps/oauth_server/urls.py
+++ b/apps/oauth_server/urls.py
@@ -5,6 +5,7 @@ django-oauth-toolkit resolves against these routes. Only the routes the MCP
 flow needs are exposed — DOT's application-management UI is left unmounted.
 """
 
+from csp.decorators import csp_update
 from django.urls import path
 from oauth2_provider import views as oauth2_views
 
@@ -12,8 +13,17 @@ from . import views
 
 app_name = "oauth2_provider"
 
+# The consent form POSTs to /oauth/authorize/ ('self'), then 302-redirects to the
+# client's redirect_uri (Claude: https://claude.ai|claude.com/api/mcp/auth_callback).
+# Chromium enforces form-action across the whole redirect chain, so the redirect
+# target must be allowlisted on the consent page or the flow dies silently there.
+# csp_update appends to the global CSP_FORM_ACTION, scoping the relaxation here only.
+authorize_view = csp_update(FORM_ACTION="https://claude.ai https://claude.com")(
+    oauth2_views.AuthorizationView.as_view()
+)
+
 urlpatterns = [
-    path("authorize/", oauth2_views.AuthorizationView.as_view(), name="authorize"),
+    path("authorize/", authorize_view, name="authorize"),
     path("token/", oauth2_views.TokenView.as_view(), name="token"),
     path("revoke_token/", oauth2_views.RevokeTokenView.as_view(), name="revoke-token"),
     path("register", views.RegisterView.as_view(), name="register"),

--- a/templates/oauth2_provider/authorize.html
+++ b/templates/oauth2_provider/authorize.html
@@ -1,0 +1,50 @@
+{% extends "oauth2_provider/base.html" %}
+{% load i18n static %}
+
+{% block title %}Authorize {{ application.name|default:"an app" }} · BrightBean Studio{% endblock title %}
+
+{% block content %}
+    <div class="bb-head">
+        <img src="{% static 'img/brightbean-studio-logo.webp' %}" alt="BrightBean Studio" class="bb-logo">
+        <span class="bb-eyebrow">BrightBean · Studio</span>
+    </div>
+
+    <div class="bb-card">
+        {% if not error %}
+            <h1>{% blocktrans with name=application.name|default:"This application" %}Authorize {{ name }}?{% endblocktrans %}</h1>
+            <p>{% blocktrans with name=application.name|default:"This application" %}{{ name }} wants to connect to your BrightBean Studio workspace with the following permissions:{% endblocktrans %}</p>
+
+            <form id="authorizationForm" method="post">
+                {% csrf_token %}
+
+                {# Hidden fields carry redirect_uri, state, scope, response_type,
+                   code_challenge, etc. — must be rendered or the OAuth flow breaks. #}
+                {% for field in form %}
+                    {% if field.is_hidden %}{{ field }}{% endif %}
+                {% endfor %}
+
+                <ul class="bb-scopes">
+                    {% for scope in scopes_descriptions %}
+                        <li>{{ scope }}</li>
+                    {% endfor %}
+                </ul>
+
+                {% if form.errors %}<div class="bb-error">{{ form.errors }}</div>{% endif %}
+                {% if form.non_field_errors %}<div class="bb-error">{{ form.non_field_errors }}</div>{% endif %}
+
+                <div class="bb-actions">
+                    {# Cancel must NOT carry name="allow" — its absence signals denial to DOT. #}
+                    <input type="submit" class="bb-btn bb-btn-ghost" value="{% trans 'Cancel' %}"/>
+                    {# Authorize MUST keep name="allow" — DOT checks for it to detect approval. #}
+                    <input type="submit" class="bb-btn bb-btn-primary" name="allow" value="{% trans 'Authorize' %}"/>
+                </div>
+            </form>
+
+            <p class="bb-foot">{% trans "You can revoke this access at any time from BrightBean Studio." %}</p>
+        {% else %}
+            <h1>{% trans "Something went wrong" %}</h1>
+            <p>{{ error.error }}</p>
+            <p>{{ error.description }}</p>
+        {% endif %}
+    </div>
+{% endblock content %}

--- a/templates/oauth2_provider/base.html
+++ b/templates/oauth2_provider/base.html
@@ -1,0 +1,107 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}Authorize · BrightBean Studio{% endblock title %}</title>
+    <link rel="icon" href="{% static 'favicon/favicon.ico' %}" sizes="any">
+    <link rel="icon" type="image/svg+xml" href="{% static 'favicon/favicon.svg' %}">
+
+    {# Self-contained styling only — no external CDN. Inline <style> is permitted by
+       the site CSP (style-src 'unsafe-inline'); the logo/favicon are served from 'self'. #}
+    <style>
+        :root {
+            /* Brand olive is hardcoded on purpose: this page is self-contained and
+               can't extend the app shell (which needs workspace context the OAuth
+               view doesn't supply), so it can't read the app's brand token. Mirrors
+               login.html's inline override — keep in sync if the brand palette changes. */
+            --bb-primary: #93a240;
+            --bb-primary-hover: #849139;
+            --bb-text: #1f2421;
+            --bb-text-muted: #6b7280;
+            --bb-border: #e5e7eb;
+            --bb-bg: #f7f7f4;
+        }
+        * { box-sizing: border-box; }
+        body {
+            margin: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 40px 16px;
+            background-color: var(--bb-bg);
+            color: var(--bb-text);
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+            line-height: 1.5;
+            -webkit-font-smoothing: antialiased;
+        }
+        .bb-wrap { width: 100%; max-width: 420px; }
+        .bb-head { text-align: center; margin-bottom: 28px; }
+        .bb-logo { width: 48px; height: 48px; object-fit: contain; }
+        .bb-eyebrow {
+            display: block;
+            margin-top: 12px;
+            font-size: 11px;
+            font-weight: 600;
+            letter-spacing: 0.14em;
+            text-transform: uppercase;
+            color: var(--bb-primary);
+        }
+        .bb-card {
+            background: #fff;
+            border: 1px solid var(--bb-border);
+            border-radius: 14px;
+            padding: 28px 28px 24px;
+            box-shadow: 0 1px 3px rgba(0,0,0,.04), 0 8px 24px rgba(0,0,0,.05);
+        }
+        .bb-card h1 { font-size: 19px; font-weight: 700; margin: 0 0 6px; }
+        .bb-card p { margin: 0 0 14px; color: var(--bb-text-muted); font-size: 14px; }
+        .bb-scopes {
+            list-style: none;
+            margin: 0 0 22px;
+            padding: 14px 16px;
+            background: #fafaf7;
+            border: 1px solid var(--bb-border);
+            border-radius: 10px;
+            font-size: 14px;
+        }
+        .bb-scopes li { display: flex; gap: 10px; align-items: flex-start; }
+        .bb-scopes li + li { margin-top: 8px; }
+        .bb-scopes li::before { content: "✓"; color: var(--bb-primary); font-weight: 700; }
+        .bb-actions { display: flex; gap: 12px; margin-top: 4px; }
+        .bb-btn {
+            flex: 1;
+            appearance: none;
+            border: 1px solid transparent;
+            border-radius: 10px;
+            padding: 11px 16px;
+            font-size: 14px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: background-color .15s ease, box-shadow .15s ease;
+        }
+        .bb-btn-primary {
+            background-color: var(--bb-primary);
+            color: #fff;
+            box-shadow: 0 4px 14px rgba(147,162,64,.28);
+        }
+        .bb-btn-primary:hover { background-color: var(--bb-primary-hover); box-shadow: 0 6px 20px rgba(147,162,64,.35); }
+        .bb-btn-primary:focus-visible { outline: none; box-shadow: 0 0 0 3px rgba(147,162,64,.4); }
+        .bb-btn-ghost {
+            background: #fff;
+            color: var(--bb-text);
+            border-color: var(--bb-border);
+        }
+        .bb-btn-ghost:hover { background: #f3f4f1; }
+        .bb-error { color: #b91c1c; font-size: 13px; margin: 10px 0 0; }
+        .bb-foot { text-align: center; margin-top: 18px; font-size: 12px; color: var(--bb-text-muted); }
+    </style>
+</head>
+<body>
+    <div class="bb-wrap">
+        {% block content %}{% endblock content %}
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## What does this PR do?

Fixes the MCP OAuth consent screen so Claude Desktop / claude.ai can complete the OAuth handshake against `https://studio.brightbean.xyz/api/v1/mcp`. Two changes:

1. Adds the Claude callback hosts (`claude.ai`, `claude.com`) to the `form-action` CSP directive — **scoped to the `/oauth/authorize/` view only** via `csp_update`, not site-wide.
2. Replaces django-oauth-toolkit's stock consent template with a self-contained, BrightBean-branded one that drops a dead external CDN.

## Why?

Connecting Claude died on the consent screen with two CSP console errors:

- **`form-action` (the blocker):** approving consent issues a 302 redirect to `https://claude.ai/api/mcp/auth_callback`. Chromium enforces `form-action` across the *entire redirect chain* of a form submission, and `claude.ai` wasn't in our allowlist — so the authorization code never reached Claude and the connection silently failed. (Chrome reports the violation against the form's own action URL for privacy, which is why the console error confusingly named `studio.brightbean.xyz` even though `'self'` is allowed — the real blocked hop was the redirect out to claude.ai.)
- **`style-src` (cosmetic):** DOT's stock `base.html` loads Bootstrap 2.3.2 from the long-dead `netdna.bootstrapcdn.com`, which our `style-src` blocks → unstyled page + a second console error.

Scoping the `form-action` relaxation to the authorize view (rather than broadening the global policy) keeps every other form locked down. The redirect target is still validated by DOT against the registered client's `redirect_uri` + `ALLOWED_REDIRECT_URI_SCHEMES=["https"]`, so this does **not** introduce an open redirect. All DOT form mechanics (csrf token, hidden fields, `name="allow"`) are preserved in the template override.

## How to test

1. **Unit:** `pytest apps/oauth_server apps/mcp/tests/test_oauth_auth.py` — OAuth flow, PKCE S256, DCR, WWW-Authenticate challenge.
2. **CSP header** (dev CSP is report-only, so assert the header directly): as an authenticated user with a registered public client, `GET /oauth/authorize/?response_type=code&…&code_challenge_method=S256&scope=mcp` and confirm the response's `form-action` now contains `https://claude.ai https://claude.com`, while a non-OAuth page does **not** (confirms the relaxation is scoped).
3. **Branded page:** load the authorize URL in Chrome with DevTools open — both the `netdna` `style-src` error and the `form-action` error are gone, and the page renders on-brand. Click **Authorize** → redirects cleanly to `https://claude.ai/api/mcp/auth_callback?code=…`.
4. **Real client:** add the MCP server in Claude Desktop against `https://studio.brightbean.xyz/api/v1/mcp` and confirm it connects and lists tools.

## Checklist

- [x] Tests pass (`pytest`) — 712 passed
- [x] Lint passes (`ruff check .` and `ruff format --check .`) — both clean repo-wide
- [x] Documentation updated (if applicable) — N/A (no user-facing docs affected)
