### PR TITLE
Serve POST /api/v1/mcp without trailing-slash redirect (fixes Claude Desktop connection)

### DIFF
--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -108,8 +108,9 @@ def _http_error_handler(request: HttpRequest, exc: HttpError) -> HttpResponse:
 
 
 # Path of the MCP endpoint, used to scope the OAuth challenge below. The
-# router is mounted at ``/mcp`` under the ``/api/v1/`` prefix, and the
-# endpoint itself is ``POST /`` — so the resolved path is ``/api/v1/mcp/``.
+# router is mounted at ``/mcp`` under the ``/api/v1/`` prefix and registers
+# the endpoint at both ``""`` and ``"/"``, so it resolves at ``/api/v1/mcp``
+# (the advertised canonical form) and ``/api/v1/mcp/`` alike.
 _MCP_ENDPOINT_PATH = "/api/v1/mcp"
 _MCP_RESOURCE_METADATA_PATH = "/.well-known/oauth-protected-resource/api/v1/mcp"
 

--- a/apps/mcp/tests/test_oauth_auth.py
+++ b/apps/mcp/tests/test_oauth_auth.py
@@ -121,6 +121,16 @@ class TestMcpOAuthChallenge:
         assert "resource_metadata=" in challenge
         assert "/.well-known/oauth-protected-resource/api/v1/mcp" in challenge
 
+    def test_unauthenticated_post_to_no_slash_url_advertises_oauth(self):
+        # The metadata's ``resource`` is ``/api/v1/mcp`` and Claude Desktop
+        # POSTs there verbatim. Without the no-slash route alias this answered
+        # 301 (APPEND_SLASH), the client re-issued the POST as GET, and the
+        # OAuth handshake never received its 401 challenge.
+        c = _SecureClient()
+        r = c.post("/api/v1/mcp", data=json.dumps(_rpc("initialize", {})), content_type="application/json")
+        assert r.status_code == 401
+        assert "resource_metadata=" in r.headers.get("WWW-Authenticate", "")
+
     def test_invalid_bearer_returns_401(self):
         c = _SecureClient(HTTP_AUTHORIZATION="Bearer not-a-real-token")
         r = c.post(MCP_URL, data=json.dumps(_rpc("ping")), content_type="application/json")

--- a/apps/mcp/tests/test_transport.py
+++ b/apps/mcp/tests/test_transport.py
@@ -41,6 +41,10 @@ class _SecureClient(Client):
 
 
 MCP_URL = "/api/v1/mcp/"
+# The no-slash form is what the RFC 9728 metadata advertises and what Claude
+# Desktop POSTs to; it must resolve directly (never via APPEND_SLASH's 301,
+# which clients follow as GET).
+MCP_URL_NO_SLASH = "/api/v1/mcp"
 
 
 def _rpc(method: str, params: dict | None = None, *, id_: int | str | None = 1) -> dict:
@@ -162,6 +166,32 @@ class TestMcpAuth:
         assert status == 200
         assert body["jsonrpc"] == "2.0"
         assert body["result"] == {}
+
+
+# ---------------------------------------------------------------------------
+# URL variants — regression for the Claude Desktop outage: a POST to the
+# advertised no-slash URL got a 301 from APPEND_SLASH, the client re-issued
+# it as GET, and the handshake died on a 405 before auth ever ran.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestMcpUrlVariants:
+    def test_post_to_no_slash_url_dispatches_without_redirect(self, client_with_token):
+        r = client_with_token.post(
+            MCP_URL_NO_SLASH,
+            data=json.dumps(_rpc("initialize", {"protocolVersion": "2025-03-26", "capabilities": {}})),
+            content_type="application/json",
+        )
+        assert r.status_code == 200
+        assert r.json()["result"]["serverInfo"]["name"] == "brightbean-studio"
+
+    def test_get_returns_405_on_both_variants(self, client_with_token):
+        # Streamable HTTP permits a plain 405 for GET (we offer no SSE
+        # stream); what it must never be is a redirect.
+        for url in (MCP_URL_NO_SLASH, MCP_URL):
+            r = client_with_token.get(url)
+            assert r.status_code == 405
 
 
 # ---------------------------------------------------------------------------

--- a/apps/mcp/transport.py
+++ b/apps/mcp/transport.py
@@ -136,6 +136,11 @@ METHODS = {
 # ---------------------------------------------------------------------------
 
 
+# The no-slash alias matters: the RFC 9728 metadata and the README both
+# advertise ``/api/v1/mcp``, and a bare ``@router.post("/")`` would leave that
+# URL to CommonMiddleware's APPEND_SLASH 301 — which HTTP clients follow as a
+# GET, killing the MCP handshake before the 401 challenge is ever issued.
+@router.post("", include_in_schema=False)
 @router.post(
     "/",
     summary="MCP Streamable HTTP endpoint (JSON-RPC over POST)",


### PR DESCRIPTION
## Problem

Claude Desktop fails to connect to the Studio MCP server ("Authorization with the MCP server failed", ref `ofid_bd54e6c2d76dfd45`). Production logs show the failure chain:

1. Claude Desktop sends `POST /api/v1/mcp` — the URL the RFC 9728 protected-resource metadata **and** the README advertise (no trailing slash).
2. The ninja route only existed at `/api/v1/mcp/`, so `CommonMiddleware` (`APPEND_SLASH=True` default) answered **301** → `/api/v1/mcp/`.
3. Per HTTP semantics for 301, the client re-issues the request as **GET**, which hits the POST-only route → **405**.

No POST ever reached the handler — including the unauthenticated one that must receive the `401 + WWW-Authenticate: Bearer resource_metadata="…"` challenge that starts Desktop's OAuth flow (#61/#62). The OAuth machinery is fine; the transport URL was the blocker.

## Fix

Register the MCP endpoint at `""` alongside `"/"` (validated on django-ninja 1.6.2 — produces both `mcp` and `mcp/` URL patterns). The alias is `include_in_schema=False` so OpenAPI stays clean; router-level `McpAuth`, rate limits, and audit logging apply identically since it's the same view function. This mirrors the sibling repo's outcome (`social-intelligence-app` serves both `/mcp` and `/mcp/` with no redirect).

| Request | Before | After |
|---|---|---|
| `POST /api/v1/mcp` | 301 → GET → 405 | dispatches (401 challenge / 200) |
| `POST /api/v1/mcp/` | dispatches | dispatches (unchanged) |
| `GET /api/v1/mcp{,/}` | 301/405 | 405 directly (spec-compliant, no SSE stream offered) |

## Verification

- `pytest apps/mcp` — 63 passed; the 3 new regression tests **fail without the alias** (confirmed by stashing the fix) and pin the exact production failure.
- `pytest apps/api apps/oauth_server` — 124 passed.
- Local runserver smoke test: `curl -X POST http://localhost:8765/api/v1/mcp` → `401` with `WWW-Authenticate: Bearer resource_metadata="…/.well-known/oauth-protected-resource/api/v1/mcp"` (previously 301); `GET` → 405.

## After deploy

`curl -i -X POST https://studio.brightbean.xyz/api/v1/mcp -H 'Content-Type: application/json' -d '{"jsonrpc":"2.0","id":1,"method":"ping"}'` should return 401 + WWW-Authenticate (not 301), and retrying the connector in Claude Desktop should complete: `POST → 401 → OAuth → POST → 200` in the Heroku logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)