### PR TITLE
CI: Node 24 action pins + resilient postgres pull

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,12 +23,12 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
           cache: "pip"
@@ -51,12 +51,12 @@ jobs:
       SECRET_KEY: test-secret-key-not-for-production
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
           cache: "pip"
@@ -73,7 +73,10 @@ jobs:
     timeout-minutes: 15
     services:
       postgres:
-        image: postgres:16-alpine
+        # Pulled via AWS's public mirror of Docker Hub official images —
+        # avoids anonymous Docker Hub pulls, whose timeouts/rate limits
+        # broke main CI on 2026-06-10 (run 27262568530).
+        image: public.ecr.aws/docker/library/postgres:16-alpine
         env:
           POSTGRES_DB: brightbean_test
           POSTGRES_USER: postgres
@@ -94,12 +97,12 @@ jobs:
       DB_PASSWORD: postgres
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
           cache: "pip"
@@ -117,15 +120,15 @@ jobs:
     needs: [lint, typecheck, test]
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349 # v3.7.1
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
       - name: Build image
-        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           push: false
@@ -145,7 +148,7 @@ jobs:
       GITLEAKS_VERSION: "8.24.3"
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0
           persist-credentials: false


### PR DESCRIPTION
## What

- Bumps every SHA-pinned action in `ci.yml` to its latest **Node 24** release, ahead of GitHub forcing Node 24 on **June 16, 2026** (Node 20 removed from runners Sept 16):
  - `actions/checkout` v4.2.2 → v6.0.3
  - `actions/setup-python` v5.3.0 → v6.2.0
  - `docker/setup-buildx-action` v3.7.1 → v4.1.0
  - `docker/build-push-action` v6.10.0 → v7.2.0
- Pulls the pytest job's `postgres:16-alpine` service image through AWS's public mirror of Docker Hub official images (`public.ecr.aws/docker/library/...`). An anonymous Docker Hub pull timeout broke main CI on 2026-06-10 ([run 27262568530](https://github.com/brightbeanxyz/brightbean-studio/actions/runs/27262568530)); the mirror avoids Docker Hub's anonymous rate limits entirely.

## Why now

The deprecation annotation appears on every current run; after June 16 these pinned versions may break outright.

## Verification

CI on this branch must be green **without** the "Node.js 20 actions are deprecated" annotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)