### PR TITLE
Run scheduled background work on the worker across all deploy targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
 | Platform | Config file | Notes |
 |----------|-------------|-------|
 | **Heroku** | `Procfile` + `app.json` | Deploy-button ready. Must use Basic+ dynos (Eco dynos break the worker). |
-| **Railway** | `railway.toml` | Three services: web, worker, managed PostgreSQL. |
+| **Railway** | `railway.toml` | The [one-click template](https://railway.com/deploy/brightbean-studio) provisions three services: web (Gunicorn, runs `migrate` on startup), worker (`python manage.py process_tasks`), and managed PostgreSQL. The web service's startup `migrate` fires the `post_migrate` hooks that register the recurring tasks, so scheduling works out of the box. |
 | **Render** | `render.yaml` | Blueprint with web, worker, PostgreSQL. Must use paid tier. |
 
 All platforms with ephemeral filesystems require `STORAGE_BACKEND=s3` - see `.env.example` for S3 configuration.

--- a/apps/accounts/apps.py
+++ b/apps/accounts/apps.py
@@ -7,4 +7,19 @@ class AccountsConfig(AppConfig):
     verbose_name = "Accounts"
 
     def ready(self):
+        from django.db.models.signals import post_migrate
+
         import apps.accounts.signals  # noqa: F401
+
+        post_migrate.connect(self._register_tasks, sender=self)
+
+    @staticmethod
+    def _register_tasks(sender, **kwargs):
+        from apps.accounts.tasks import SESSION_CLEANUP_INTERVAL_SECONDS, clear_expired_sessions
+        from apps.common.background import register_recurring_task
+
+        register_recurring_task(
+            clear_expired_sessions,
+            repeat=SESSION_CLEANUP_INTERVAL_SECONDS,
+            verbose_name="clear_expired_sessions",
+        )

--- a/apps/accounts/tasks.py
+++ b/apps/accounts/tasks.py
@@ -1,0 +1,20 @@
+"""Background tasks for the accounts app."""
+
+import logging
+
+from background_task import background
+from django.core.management import call_command
+
+logger = logging.getLogger(__name__)
+
+# How often the recurring expired-session purge runs; registered on a repeating
+# schedule by apps.accounts.apps.AccountsConfig. Replaces the VPS-only
+# docker-compose ``maintenance`` loop so it runs on every deploy target.
+SESSION_CLEANUP_INTERVAL_SECONDS = 24 * 60 * 60  # daily
+
+
+@background(schedule=0)
+def clear_expired_sessions():
+    """Delete expired Django sessions (wraps the ``clearsessions`` command)."""
+    call_command("clearsessions")
+    logger.info("Cleared expired sessions")

--- a/apps/approvals/apps.py
+++ b/apps/approvals/apps.py
@@ -5,3 +5,19 @@ class ApprovalsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "apps.approvals"
     verbose_name = "Approvals"
+
+    def ready(self):
+        from django.db.models.signals import post_migrate
+
+        post_migrate.connect(self._register_tasks, sender=self)
+
+    @staticmethod
+    def _register_tasks(sender, **kwargs):
+        from apps.approvals.tasks import APPROVAL_REMINDER_INTERVAL_SECONDS, run_approval_reminders_cycle
+        from apps.common.background import register_recurring_task
+
+        register_recurring_task(
+            run_approval_reminders_cycle,
+            repeat=APPROVAL_REMINDER_INTERVAL_SECONDS,
+            verbose_name="run_approval_reminders_cycle",
+        )

--- a/apps/approvals/tasks.py
+++ b/apps/approvals/tasks.py
@@ -3,6 +3,7 @@
 import logging
 from datetime import timedelta
 
+from background_task import background
 from django.utils import timezone
 
 from apps.composer.models import Post
@@ -165,3 +166,18 @@ def _escalate(post, stage):
                 "stage": stage,
             },
         )
+
+
+# How often the recurring approval-reminder check runs; registered on a repeating
+# schedule by apps.approvals.apps.ApprovalsConfig.
+APPROVAL_REMINDER_INTERVAL_SECONDS = 60 * 60  # hourly
+
+
+@background(schedule=0)
+def run_approval_reminders_cycle():
+    """Send reminders/escalations for stalled approvals (registered hourly).
+
+    Wraps ``check_approval_reminders`` so the plain function stays callable
+    synchronously from the ``run_approval_reminders`` command and from tests.
+    """
+    check_approval_reminders()

--- a/apps/common/background.py
+++ b/apps/common/background.py
@@ -1,0 +1,35 @@
+"""Shared helper for registering recurring django-background-tasks.
+
+Centralizes the idempotent ``post_migrate`` registration pattern so each app
+calls one function instead of copy-pasting the exists-check + error handling.
+"""
+
+import logging
+
+from django.db import OperationalError, ProgrammingError
+
+logger = logging.getLogger(__name__)
+
+
+def register_recurring_task(task_func, *, repeat, verbose_name):
+    """Idempotently schedule a ``@background`` task to repeat every ``repeat`` seconds.
+
+    Safe to call from a ``post_migrate`` handler. A fresh DB without the
+    background-task tables raises a DB error, which we swallow quietly (the next
+    ``migrate`` re-runs registration). Any OTHER failure is logged at
+    ``exception`` rather than swallowed silently — the worker is the only thing
+    that runs these, so a missed registration means the task never runs, and
+    that must be visible (production logs the ``apps`` logger at INFO).
+    """
+    from background_task.models import Task
+
+    try:
+        if not Task.objects.filter(verbose_name=verbose_name).exists():
+            task_func(repeat=repeat, verbose_name=verbose_name)
+            logger.info("Registered recurring task %s (every %ds)", verbose_name, repeat)
+    except (OperationalError, ProgrammingError):
+        # Fresh DB: the background-task tables don't exist yet. The next migrate
+        # re-runs this registration, so skip quietly.
+        logger.debug("Skipping %s registration (database not ready)", verbose_name)
+    except Exception:
+        logger.exception("Failed to register recurring task %s", verbose_name)

--- a/apps/composer/services.py
+++ b/apps/composer/services.py
@@ -142,9 +142,7 @@ def create_post(
                 return None
 
         resolved = [(mid, _to_uuid(mid)) for mid in media_ids]
-        found = list(
-            MediaAsset.objects.filter(id__in=[u for _, u in resolved if u is not None], workspace=workspace)
-        )
+        found = list(MediaAsset.objects.filter(id__in=[u for _, u in resolved if u is not None], workspace=workspace))
         asset_map = {a.id: a for a in found}
         missing = [mid for mid, u in resolved if u is None or u not in asset_map]
         if missing:
@@ -175,6 +173,9 @@ def create_post(
             platform_specific_first_comment=override.get("first_comment"),
         )
         for position, (_mid, u) in enumerate(resolved):
+            # ``u`` is validated non-None and present in ``asset_map`` above
+            # (the ``missing`` check raises otherwise); narrow for mypy.
+            assert u is not None
             PostMedia.objects.create(
                 post=post,
                 media_asset=asset_map[u],

--- a/apps/inbox/apps.py
+++ b/apps/inbox/apps.py
@@ -5,3 +5,19 @@ class InboxConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "apps.inbox"
     verbose_name = "Inbox"
+
+    def ready(self):
+        from django.db.models.signals import post_migrate
+
+        post_migrate.connect(self._register_tasks, sender=self)
+
+    @staticmethod
+    def _register_tasks(sender, **kwargs):
+        from apps.common.background import register_recurring_task
+        from apps.inbox.tasks import INBOX_SYNC_INTERVAL_SECONDS, run_inbox_sync_cycle
+
+        register_recurring_task(
+            run_inbox_sync_cycle,
+            repeat=INBOX_SYNC_INTERVAL_SECONDS,
+            verbose_name="run_inbox_sync_cycle",
+        )

--- a/apps/inbox/management/commands/backfill_inbox.py
+++ b/apps/inbox/management/commands/backfill_inbox.py
@@ -60,7 +60,9 @@ class Command(BaseCommand):
                 )
                 count = 0
                 for msg in messages:
-                    engine._upsert_message(account, msg)
+                    # Backfill is explicit history seeding — never notify (the
+                    # periodic sync alerts for genuinely new messages instead).
+                    engine._upsert_message(account, msg, notify=False)
                     count += 1
                 self.stdout.write(self.style.SUCCESS(f"  {account.platform}/{account.account_name}: {count} messages"))
             except NotImplementedError:

--- a/apps/inbox/management/commands/run_inbox_sync.py
+++ b/apps/inbox/management/commands/run_inbox_sync.py
@@ -42,8 +42,7 @@ class Command(BaseCommand):
         self.stdout.write(self.style.SUCCESS("Inbox sync worker started."))
 
         while running:
-            engine.sync_all()
-            engine.check_sla()
+            engine.run_cycle()
 
             if once:
                 break

--- a/apps/inbox/tasks.py
+++ b/apps/inbox/tasks.py
@@ -1,7 +1,9 @@
 """Inbox sync engine - polls connected accounts for new messages."""
 
 import logging
+from datetime import timedelta
 
+from background_task import background
 from django.utils import timezone
 
 from apps.members.models import WorkspaceMembership
@@ -15,9 +17,33 @@ from .sentiment import analyze_sentiment
 
 logger = logging.getLogger(__name__)
 
+# On an account's first-ever sync we may pull a historical backlog; notifications
+# are suppressed for it, EXCEPT messages newer than this window — so a long-quiet
+# account's genuinely-new first message still alerts instead of being swallowed.
+INBOX_BACKLOG_NOTIFY_WINDOW = timedelta(hours=1)
+
+
+def _is_recent(ts):
+    """True if a provider message timestamp falls within the backlog-notify window."""
+    if ts is None:
+        return False
+    if timezone.is_naive(ts):
+        ts = timezone.make_aware(ts, timezone.get_default_timezone())
+    return ts >= timezone.now() - INBOX_BACKLOG_NOTIFY_WINDOW
+
 
 class InboxSyncEngine:
     """Syncs inbox messages from all connected social accounts."""
+
+    def run_cycle(self):
+        """Run one full inbox cycle: poll every connected account, then check SLAs.
+
+        Single shared entry point for the ``run_inbox_sync`` management command
+        and the recurring ``run_inbox_sync_cycle`` background task, so the two
+        never diverge.
+        """
+        self.sync_all()
+        self.check_sla()
 
     def sync_all(self):
         """Poll each connected account for new messages."""
@@ -45,6 +71,7 @@ class InboxSyncEngine:
             .values_list("received_at", flat=True)
             .first()
         )
+        is_first_sync = last_msg is None
 
         try:
             messages = provider.get_messages(
@@ -62,9 +89,15 @@ class InboxSyncEngine:
             return
 
         for msg in messages:
-            self._upsert_message(account, msg)
+            # Suppress notifications for the historical backlog pulled on an
+            # account's first sync, but still alert for genuinely recent messages:
+            # a long-quiet account's first real message also has last_msg=None, so
+            # a blanket first-sync mute would silently swallow it. backfill_inbox
+            # seeds explicit history silently (notify=False).
+            notify_new = not is_first_sync or _is_recent(msg.timestamp)
+            self._upsert_message(account, msg, notify=notify_new)
 
-    def _upsert_message(self, account, msg):
+    def _upsert_message(self, account, msg, notify=True):
         """Create or update an inbox message, deduplicating by platform_message_id."""
         obj, created = InboxMessage.objects.update_or_create(
             social_account=account,
@@ -83,7 +116,8 @@ class InboxSyncEngine:
         if created:
             obj.sentiment = analyze_sentiment(obj.body)
             obj.save(update_fields=["sentiment"])
-            self._notify_new_message(obj)
+            if notify:
+                self._notify_new_message(obj)
 
     def _notify_new_message(self, message):
         """Send notification for a new inbox message."""
@@ -149,3 +183,19 @@ class InboxSyncEngine:
                     "workspace_id": str(message.workspace_id),
                 },
             )
+
+
+# How often the recurring inbox-sync cycle runs; registered on a repeating
+# schedule by apps.inbox.apps.InboxConfig. Polling is the always-on baseline
+# documented in architecture.md (webhooks, where configured, supplement it).
+INBOX_SYNC_INTERVAL_SECONDS = 5 * 60  # every 5 minutes
+
+
+@background(schedule=0)
+def run_inbox_sync_cycle():
+    """Run one inbox cycle on the shared ``process_tasks`` worker (every deploy target).
+
+    Delegates to ``InboxSyncEngine.run_cycle`` — the same entry point the
+    ``run_inbox_sync`` management command uses — so the two never diverge.
+    """
+    InboxSyncEngine().run_cycle()

--- a/apps/inbox/tests/test_sync.py
+++ b/apps/inbox/tests/test_sync.py
@@ -1,0 +1,74 @@
+"""The inbox sync engine suppresses first-sync history but never the first real message."""
+
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from django.utils import timezone
+
+from apps.inbox.models import InboxMessage
+from apps.inbox.tasks import InboxSyncEngine
+from apps.social_accounts.models import SocialAccount
+
+
+@pytest.fixture
+def workspace(db, organization):
+    from apps.workspaces.models import Workspace
+
+    return Workspace.objects.create(name="Sync WS", organization=organization)
+
+
+@pytest.fixture
+def connected_account(db, workspace):
+    return SocialAccount.objects.create(
+        workspace=workspace,
+        platform="instagram",
+        account_platform_id="ig-sync-1",
+        account_name="Sync Test",
+        connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+    )
+
+
+def _msg(message_id, *, minutes_ago=0, text="hello"):
+    """A minimal stand-in for the message objects providers return."""
+    return SimpleNamespace(
+        platform_message_id=message_id,
+        sender_name="Sender",
+        sender_id="sender-1",
+        text=text,
+        message_type=InboxMessage.MessageType.DM,
+        timestamp=timezone.now() - timedelta(minutes=minutes_ago),
+        extra={},
+    )
+
+
+@pytest.mark.django_db
+def test_first_sync_suppresses_old_backlog_then_notifies_new(connected_account):
+    with patch("apps.inbox.tasks.get_provider") as get_provider:
+        provider = get_provider.return_value
+
+        # First-ever sync pulls an OLD historical backlog -> seed it silently.
+        provider.get_messages.return_value = [_msg("h1", minutes_ago=1440), _msg("h2", minutes_ago=2880)]
+        with patch.object(InboxSyncEngine, "_notify_new_message") as notify_new:
+            InboxSyncEngine().sync_all()
+        assert InboxMessage.objects.filter(social_account=connected_account).count() == 2
+        notify_new.assert_not_called()
+
+        # Once the account has history, a genuinely new message notifies.
+        provider.get_messages.return_value = [_msg("n1", minutes_ago=0)]
+        with patch.object(InboxSyncEngine, "_notify_new_message") as notify_new:
+            InboxSyncEngine().sync_all()
+        notify_new.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_first_message_on_quiet_account_still_notifies(connected_account):
+    # Regression: a long-quiet account has no prior messages, so last_msg is None
+    # and it's still the "first sync" — but its first genuinely-recent message must
+    # alert, not be silently swallowed as if it were backlog.
+    with patch("apps.inbox.tasks.get_provider") as get_provider:
+        get_provider.return_value.get_messages.return_value = [_msg("first", minutes_ago=0)]
+        with patch.object(InboxSyncEngine, "_notify_new_message") as notify_new:
+            InboxSyncEngine().sync_all()
+        notify_new.assert_called_once()

--- a/apps/mcp/handlers.py
+++ b/apps/mcp/handlers.py
@@ -876,6 +876,10 @@ def _finalize_media_upload(args: dict, context: dict[str, Any]) -> dict:
                 locked.media_asset = asset
                 locked.save(update_fields=["finalized_at", "media_asset"])
 
+    # ``asset`` is non-None in both branches above (the replay branch is guarded
+    # by ``media_asset_id``); assert it so mypy narrows the nullable FK.
+    assert asset is not None
+
     # Ensure processing is queued — for a fresh asset, or to self-heal a replay
     # whose original enqueue was lost (asset still stuck at 'pending').
     if asset.processing_status == MediaAsset.ProcessingStatus.PENDING:

--- a/apps/mcp/tests/test_presigned_tools.py
+++ b/apps/mcp/tests/test_presigned_tools.py
@@ -94,9 +94,7 @@ class TestRequestMediaUpload:
     def test_disabled_on_local_storage(self):
         # No s3_seam fixture → is_s3_backend() is the real (local) value.
         user, _ws, _sa = _make_user_with_workspace("req-local@example.com", OWNER)
-        _status, body = _call(
-            _client(user), "request_media_upload", {"filename": "clip.mp4", "media_type": "video"}
-        )
+        _status, body = _call(_client(user), "request_media_upload", {"filename": "clip.mp4", "media_type": "video"})
         assert body["error"]["code"] == INVALID_PARAMS
         assert "local mode" in body["error"]["message"].lower()
 

--- a/apps/media_library/apps.py
+++ b/apps/media_library/apps.py
@@ -1,8 +1,4 @@
-import logging
-
 from django.apps import AppConfig
-
-logger = logging.getLogger(__name__)
 
 
 class MediaLibraryConfig(AppConfig):
@@ -13,31 +9,27 @@ class MediaLibraryConfig(AppConfig):
     def ready(self):
         from django.db.models.signals import post_migrate
 
-        post_migrate.connect(self._register_pending_upload_sweep, sender=self)
+        post_migrate.connect(self._register_tasks, sender=self)
 
     @staticmethod
-    def _register_pending_upload_sweep(sender, **kwargs):
-        """Register the recurring presigned-upload sweep after migrations.
+    def _register_tasks(sender, **kwargs):
+        from apps.common.background import register_recurring_task
+        from apps.media_library.tasks import (
+            ORPHANED_MEDIA_SWEEP_INTERVAL_SECONDS,
+            PENDING_UPLOAD_SWEEP_INTERVAL_SECONDS,
+            run_orphaned_media_sweep,
+            sweep_pending_uploads,
+        )
 
-        Mirrors ``apps.api.apps``: re-registered idempotently on every migrate.
-        Without this, expired-but-never-finalized ``PendingUpload`` rows and
-        their partially-uploaded objects accumulate forever.
-        """
-        try:
-            from background_task.models import Task
-
-            from apps.media_library.tasks import (
-                PENDING_UPLOAD_SWEEP_INTERVAL_SECONDS,
-                sweep_pending_uploads,
-            )
-
-            if not Task.objects.filter(verbose_name="sweep_pending_uploads").exists():
-                sweep_pending_uploads(
-                    repeat=PENDING_UPLOAD_SWEEP_INTERVAL_SECONDS,
-                    verbose_name="sweep_pending_uploads",
-                )
-                logger.info("Registered pending-upload sweep (every %ds)", PENDING_UPLOAD_SWEEP_INTERVAL_SECONDS)
-        except Exception:
-            # post_migrate can fire before the background-task tables exist on a
-            # fresh DB; skip quietly so first-run setup doesn't error.
-            logger.debug("Skipping pending-upload sweep registration (DB not ready)")
+        # Reap expired, never-finalized presigned uploads (hourly) and media
+        # assets no longer referenced by any post/idea/template (daily).
+        register_recurring_task(
+            sweep_pending_uploads,
+            repeat=PENDING_UPLOAD_SWEEP_INTERVAL_SECONDS,
+            verbose_name="sweep_pending_uploads",
+        )
+        register_recurring_task(
+            run_orphaned_media_sweep,
+            repeat=ORPHANED_MEDIA_SWEEP_INTERVAL_SECONDS,
+            verbose_name="run_orphaned_media_sweep",
+        )

--- a/apps/media_library/management/commands/cleanup_orphaned_media.py
+++ b/apps/media_library/management/commands/cleanup_orphaned_media.py
@@ -5,6 +5,10 @@ referenced by any post, idea, platform post, or template.  They accumulate
 when users upload files in the composer but never save a post, or when posts
 are deleted without cleaning up the underlying assets.
 
+The detection/deletion logic lives in
+``apps.media_library.services.sweep_orphaned_media`` and is shared with the
+recurring background task (``run_orphaned_media_sweep``) so the two never drift.
+
 Usage:
     python manage.py cleanup_orphaned_media --once --dry-run
     python manage.py cleanup_orphaned_media --once --min-age-days 7
@@ -13,15 +17,10 @@ Usage:
 
 import signal
 import time
-import uuid
-from datetime import timedelta
 
 from django.core.management.base import BaseCommand
-from django.db import connection
-from django.utils import timezone
 
-from apps.media_library.models import MediaAsset
-from apps.media_library.services import ProtectedAssetError, delete_asset
+from apps.media_library.services import ORPHANED_MEDIA_MIN_AGE_DAYS, sweep_orphaned_media
 
 
 class Command(BaseCommand):
@@ -36,8 +35,8 @@ class Command(BaseCommand):
         parser.add_argument(
             "--min-age-days",
             type=int,
-            default=14,
-            help="Only consider assets older than N days (default: 14, matches SESSION_COOKIE_AGE).",
+            default=ORPHANED_MEDIA_MIN_AGE_DAYS,
+            help=f"Only consider assets older than N days (default: {ORPHANED_MEDIA_MIN_AGE_DAYS}).",
         )
         parser.add_argument(
             "--batch-size",
@@ -77,195 +76,29 @@ class Command(BaseCommand):
             self.stdout.write(self.style.WARNING("[cleanup] DRY RUN mode - no deletions will be performed"))
 
         while self.running:
-            self._run_cleanup(dry_run, min_age_days, batch_size)
+            result = sweep_orphaned_media(
+                min_age_days=min_age_days,
+                batch_size=batch_size,
+                dry_run=dry_run,
+                log=lambda msg: self.stdout.write(f"[cleanup] {msg}"),
+                should_continue=lambda: self.running,
+            )
+            mb = result["bytes"] / (1024 * 1024)
+            if dry_run:
+                self.stdout.write(
+                    self.style.WARNING(
+                        f"[cleanup] DRY RUN complete: {result['orphaned']} orphaned asset(s) "
+                        f"(~{mb:.1f} MB) would be deleted"
+                    )
+                )
+            else:
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"[cleanup] {result['deleted']} deleted, {result['skipped']} skipped, "
+                        f"{result['errors']} errors (of {result['orphaned']} orphaned, ~{mb:.1f} MB)"
+                    )
+                )
             if run_once:
                 break
             self.stdout.write(f"[cleanup] Next run in {interval}s...")
             time.sleep(interval)
-
-    def _run_cleanup(self, dry_run, min_age_days, batch_size):
-        cutoff = timezone.now() - timedelta(days=min_age_days)
-        self.stdout.write(
-            f"[cleanup] Scanning assets older than {min_age_days} days (cutoff: {cutoff.strftime('%Y-%m-%d %H:%M')})"
-        )
-
-        # Phase 1: Collect FK-referenced asset IDs
-        fk_referenced = self._get_fk_referenced_ids()
-        self.stdout.write(f"[cleanup] FK-referenced assets: {len(fk_referenced)}")
-
-        # Phase 2: Collect JSON-referenced asset IDs
-        json_referenced = self._get_json_referenced_ids()
-        self.stdout.write(f"[cleanup] JSON-referenced assets: {len(json_referenced)}")
-
-        all_referenced = fk_referenced | json_referenced
-
-        # Phase 3: Query orphaned assets
-        orphaned_qs = MediaAsset.objects.filter(created_at__lt=cutoff).exclude(id__in=all_referenced)
-        orphaned_ids = list(orphaned_qs.values_list("id", flat=True))
-        total_count = len(orphaned_ids)
-
-        if total_count == 0:
-            self.stdout.write(self.style.SUCCESS("[cleanup] No orphaned assets found."))
-            return
-
-        # Calculate total size
-        total_bytes = orphaned_qs.aggregate(total=__import__("django").db.models.Sum("file_size"))["total"] or 0
-        total_mb = total_bytes / (1024 * 1024)
-
-        self.stdout.write(f"[cleanup] Orphaned candidates: {total_count} (~{total_mb:.1f} MB)")
-
-        if dry_run:
-            # Show details for up to 50 assets
-            sample = MediaAsset.objects.filter(id__in=orphaned_ids[:50])
-            for asset in sample:
-                self.stdout.write(
-                    f"[cleanup]   Would delete: {asset.id} "
-                    f"({asset.filename}, {asset.media_type}, "
-                    f"{asset.file_size / (1024 * 1024):.1f} MB, "
-                    f"created {asset.created_at.strftime('%Y-%m-%d')})"
-                )
-            if total_count > 50:
-                self.stdout.write(f"[cleanup]   ... and {total_count - 50} more")
-            self.stdout.write(
-                self.style.WARNING(
-                    f"[cleanup] DRY RUN complete: {total_count} assets (~{total_mb:.1f} MB) would be deleted"
-                )
-            )
-            return
-
-        # Delete in batches
-        deleted = 0
-        skipped = 0
-        errors = 0
-
-        for i in range(0, total_count, batch_size):
-            if not self.running:
-                self.stdout.write(self.style.WARNING("[cleanup] Interrupted, stopping..."))
-                break
-
-            batch_ids = orphaned_ids[i : i + batch_size]
-            batch = MediaAsset.objects.filter(id__in=batch_ids)
-
-            for asset in batch:
-                if not self.running:
-                    break
-                try:
-                    asset_info = f"{asset.id} ({asset.filename})"
-                    delete_asset(asset)
-                    deleted += 1
-                    self.stdout.write(f"[cleanup] Deleted: {asset_info}")
-                except ProtectedAssetError:
-                    skipped += 1
-                    self.stdout.write(self.style.WARNING(f"[cleanup] Skipped (protected): {asset.id}"))
-                except Exception as e:
-                    errors += 1
-                    self.stdout.write(self.style.ERROR(f"[cleanup] Error deleting {asset.id}: {e}"))
-
-        self.stdout.write(
-            self.style.SUCCESS(
-                f"[cleanup] Complete: {deleted} deleted, {skipped} skipped, {errors} errors "
-                f"(out of {total_count} orphaned)"
-            )
-        )
-
-    def _get_fk_referenced_ids(self):
-        """Collect all asset IDs referenced via foreign keys."""
-        from apps.composer.models import Idea, IdeaMedia, PostMedia
-
-        referenced = set()
-        referenced.update(PostMedia.objects.values_list("media_asset_id", flat=True))
-        referenced.update(IdeaMedia.objects.values_list("media_asset_id", flat=True))
-        referenced.update(Idea.objects.filter(media_asset__isnull=False).values_list("media_asset_id", flat=True))
-        return referenced
-
-    def _get_json_referenced_ids(self):
-        """Collect all asset IDs embedded in JSON fields."""
-        if connection.vendor == "postgresql":
-            return self._get_json_referenced_ids_postgres()
-        return self._get_json_referenced_ids_python()
-
-    def _get_json_referenced_ids_postgres(self):
-        """Extract asset IDs from JSON fields using PostgreSQL jsonb functions."""
-        referenced = set()
-
-        with connection.cursor() as cursor:
-            # PlatformPost.platform_extra -> thumbnail_asset_id
-            cursor.execute("""
-                SELECT DISTINCT platform_extra->>'thumbnail_asset_id'
-                FROM composer_platform_post
-                WHERE platform_extra IS NOT NULL
-                  AND platform_extra->>'thumbnail_asset_id' IS NOT NULL
-            """)
-            for (val,) in cursor.fetchall():
-                referenced.add(self._to_uuid(val))
-
-            # PlatformPost.platform_extra -> cover_image_asset_id
-            cursor.execute("""
-                SELECT DISTINCT platform_extra->>'cover_image_asset_id'
-                FROM composer_platform_post
-                WHERE platform_extra IS NOT NULL
-                  AND platform_extra->>'cover_image_asset_id' IS NOT NULL
-            """)
-            for (val,) in cursor.fetchall():
-                referenced.add(self._to_uuid(val))
-
-            # PlatformPost.platform_specific_media (JSON array of IDs)
-            cursor.execute("""
-                SELECT DISTINCT elem::text
-                FROM composer_platform_post,
-                     jsonb_array_elements_text(platform_specific_media) AS elem
-                WHERE platform_specific_media IS NOT NULL
-                  AND jsonb_typeof(platform_specific_media) = 'array'
-            """)
-            for (val,) in cursor.fetchall():
-                referenced.add(self._to_uuid(val))
-
-            # PostTemplate.template_data -> media_asset_ids (JSON array)
-            cursor.execute("""
-                SELECT DISTINCT elem::text
-                FROM composer_post_template,
-                     jsonb_array_elements_text(template_data->'media_asset_ids') AS elem
-                WHERE template_data IS NOT NULL
-                  AND template_data ? 'media_asset_ids'
-                  AND jsonb_typeof(template_data->'media_asset_ids') = 'array'
-            """)
-            for (val,) in cursor.fetchall():
-                referenced.add(self._to_uuid(val))
-
-        referenced.discard(None)
-        return referenced
-
-    def _get_json_referenced_ids_python(self):
-        """Extract asset IDs from JSON fields by iterating in Python (SQLite fallback)."""
-        from apps.composer.models import PlatformPost, PostTemplate
-
-        referenced = set()
-
-        for pp in PlatformPost.objects.exclude(platform_extra=None).only("platform_extra"):
-            extra = pp.platform_extra or {}
-            if extra.get("thumbnail_asset_id"):
-                referenced.add(self._to_uuid(extra["thumbnail_asset_id"]))
-            if extra.get("cover_image_asset_id"):
-                referenced.add(self._to_uuid(extra["cover_image_asset_id"]))
-
-        for pp in PlatformPost.objects.exclude(platform_specific_media=None).only("platform_specific_media"):
-            if isinstance(pp.platform_specific_media, list):
-                for val in pp.platform_specific_media:
-                    referenced.add(self._to_uuid(val))
-
-        for tmpl in PostTemplate.objects.exclude(template_data=None).only("template_data"):
-            data = tmpl.template_data or {}
-            for val in data.get("media_asset_ids", []):
-                referenced.add(self._to_uuid(val))
-
-        referenced.discard(None)
-        return referenced
-
-    def _to_uuid(self, val):
-        """Safely convert a string to UUID, returning None on failure."""
-        if not val:
-            return None
-        try:
-            return uuid.UUID(str(val))
-        except (ValueError, AttributeError):
-            return None

--- a/apps/media_library/services.py
+++ b/apps/media_library/services.py
@@ -5,10 +5,15 @@ import logging
 import os
 import subprocess
 import tempfile
+import uuid
+from datetime import timedelta
 
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.core.files.base import ContentFile
+from django.db import connection
+from django.db.models import Sum
+from django.utils import timezone
 
 from .models import MediaAsset, MediaAssetVersion, MediaFolder
 from .validators import validate_file
@@ -223,7 +228,9 @@ def inspect_uploaded_object(pending) -> dict:
     return {"size": size, "media_type": file_type, "mime": mime}
 
 
-def register_uploaded_asset(*, pending, inspected, uploaded_by, folder=None, alt_text: str = "", title: str = "", tags=None):
+def register_uploaded_asset(
+    *, pending, inspected, uploaded_by, folder=None, alt_text: str = "", title: str = "", tags=None
+):
     """Create a ``MediaAsset`` for an already-stored object from validated metadata.
 
     ``inspected`` is the dict returned by :func:`inspect_uploaded_object`. This
@@ -613,3 +620,189 @@ def trim_video(input_path, output_path, start_seconds, end_seconds):
     )
     if result.returncode != 0:
         raise RuntimeError(f"FFmpeg trim failed: {result.stderr.decode()}")
+
+
+# Minimum asset age (days) the orphaned-media sweep considers — the single source
+# shared by the management command's default and the recurring background task.
+ORPHANED_MEDIA_MIN_AGE_DAYS = 14
+
+
+def sweep_orphaned_media(
+    *, min_age_days=ORPHANED_MEDIA_MIN_AGE_DAYS, batch_size=100, dry_run=False, log=None, should_continue=None
+):
+    """Detect and delete media assets not referenced by any post, idea, or template.
+
+    Orphans are ``MediaAsset`` rows older than ``min_age_days`` that no foreign
+    key or JSON field points at. Shared by the ``cleanup_orphaned_media``
+    management command and the recurring background task so the two never drift.
+
+    Args:
+        min_age_days: only consider assets older than this (default 14).
+        batch_size: delete in batches of this many.
+        dry_run: when True, report candidates without deleting.
+        log: optional ``callable(str)`` for progress lines (defaults to the
+            module logger at debug level).
+        should_continue: optional ``callable() -> bool``; deletion stops early
+            when it returns False (lets the command honor SIGINT/SIGTERM).
+
+    Returns a dict: ``{orphaned, deleted, skipped, errors, bytes}``.
+    """
+    emit = log or (lambda msg: logger.debug("%s", msg))
+    keep_going = should_continue or (lambda: True)
+
+    cutoff = timezone.now() - timedelta(days=min_age_days)
+    emit(f"Scanning assets older than {min_age_days} days (cutoff: {cutoff:%Y-%m-%d %H:%M})")
+
+    referenced = _fk_referenced_asset_ids() | _json_referenced_asset_ids()
+    emit(f"Referenced assets: {len(referenced)}")
+
+    orphaned_qs = MediaAsset.objects.filter(created_at__lt=cutoff).exclude(id__in=referenced)
+    orphaned_ids = list(orphaned_qs.values_list("id", flat=True))
+    total = len(orphaned_ids)
+    total_bytes = orphaned_qs.aggregate(total=Sum("file_size"))["total"] or 0
+
+    result = {"orphaned": total, "deleted": 0, "skipped": 0, "errors": 0, "bytes": total_bytes}
+
+    if total == 0:
+        emit("No orphaned assets found.")
+        return result
+
+    emit(f"Orphaned candidates: {total} (~{total_bytes / (1024 * 1024):.1f} MB)")
+
+    if dry_run:
+        for asset in MediaAsset.objects.filter(id__in=orphaned_ids[:50]):
+            emit(
+                f"  Would delete: {asset.id} ({asset.filename}, {asset.media_type}, "
+                f"{asset.file_size / (1024 * 1024):.1f} MB, created {asset.created_at:%Y-%m-%d})"
+            )
+        if total > 50:
+            emit(f"  ... and {total - 50} more")
+        return result
+
+    for i in range(0, total, batch_size):
+        if not keep_going():
+            emit("Interrupted, stopping...")
+            break
+        for asset in MediaAsset.objects.filter(id__in=orphaned_ids[i : i + batch_size]):
+            if not keep_going():
+                break
+            try:
+                asset_info = f"{asset.id} ({asset.filename})"
+                delete_asset(asset)
+                result["deleted"] += 1
+                emit(f"Deleted: {asset_info}")
+            except ProtectedAssetError:
+                result["skipped"] += 1
+                emit(f"Skipped (protected): {asset.id}")
+            except Exception as exc:
+                result["errors"] += 1
+                emit(f"Error deleting {asset.id}: {exc}")
+
+    emit(
+        f"Complete: {result['deleted']} deleted, {result['skipped']} skipped, "
+        f"{result['errors']} errors (of {total} orphaned)"
+    )
+    return result
+
+
+def _fk_referenced_asset_ids():
+    """Collect all asset IDs referenced via foreign keys."""
+    from apps.composer.models import Idea, IdeaMedia, PostMedia
+
+    referenced = set()
+    referenced.update(PostMedia.objects.values_list("media_asset_id", flat=True))
+    referenced.update(IdeaMedia.objects.values_list("media_asset_id", flat=True))
+    referenced.update(Idea.objects.filter(media_asset__isnull=False).values_list("media_asset_id", flat=True))
+    return referenced
+
+
+def _json_referenced_asset_ids():
+    """Collect all asset IDs embedded in JSON fields."""
+    if connection.vendor == "postgresql":
+        return _json_referenced_asset_ids_postgres()
+    return _json_referenced_asset_ids_python()
+
+
+def _json_referenced_asset_ids_postgres():
+    """Extract asset IDs from JSON fields using PostgreSQL jsonb functions."""
+    referenced = set()
+
+    with connection.cursor() as cursor:
+        cursor.execute("""
+            SELECT DISTINCT platform_extra->>'thumbnail_asset_id'
+            FROM composer_platform_post
+            WHERE platform_extra IS NOT NULL
+              AND platform_extra->>'thumbnail_asset_id' IS NOT NULL
+        """)
+        for (val,) in cursor.fetchall():
+            referenced.add(_to_uuid(val))
+
+        cursor.execute("""
+            SELECT DISTINCT platform_extra->>'cover_image_asset_id'
+            FROM composer_platform_post
+            WHERE platform_extra IS NOT NULL
+              AND platform_extra->>'cover_image_asset_id' IS NOT NULL
+        """)
+        for (val,) in cursor.fetchall():
+            referenced.add(_to_uuid(val))
+
+        cursor.execute("""
+            SELECT DISTINCT elem::text
+            FROM composer_platform_post,
+                 jsonb_array_elements_text(platform_specific_media) AS elem
+            WHERE platform_specific_media IS NOT NULL
+              AND jsonb_typeof(platform_specific_media) = 'array'
+        """)
+        for (val,) in cursor.fetchall():
+            referenced.add(_to_uuid(val))
+
+        cursor.execute("""
+            SELECT DISTINCT elem::text
+            FROM composer_post_template,
+                 jsonb_array_elements_text(template_data->'media_asset_ids') AS elem
+            WHERE template_data IS NOT NULL
+              AND template_data ? 'media_asset_ids'
+              AND jsonb_typeof(template_data->'media_asset_ids') = 'array'
+        """)
+        for (val,) in cursor.fetchall():
+            referenced.add(_to_uuid(val))
+
+    referenced.discard(None)
+    return referenced
+
+
+def _json_referenced_asset_ids_python():
+    """Extract asset IDs from JSON fields by iterating in Python (SQLite fallback)."""
+    from apps.composer.models import PlatformPost, PostTemplate
+
+    referenced = set()
+
+    for pp in PlatformPost.objects.exclude(platform_extra=None).only("platform_extra"):
+        extra = pp.platform_extra or {}
+        if extra.get("thumbnail_asset_id"):
+            referenced.add(_to_uuid(extra["thumbnail_asset_id"]))
+        if extra.get("cover_image_asset_id"):
+            referenced.add(_to_uuid(extra["cover_image_asset_id"]))
+
+    for pp in PlatformPost.objects.exclude(platform_specific_media=None).only("platform_specific_media"):
+        if isinstance(pp.platform_specific_media, list):
+            for val in pp.platform_specific_media:
+                referenced.add(_to_uuid(val))
+
+    for tmpl in PostTemplate.objects.exclude(template_data=None).only("template_data"):
+        data = tmpl.template_data or {}
+        for val in data.get("media_asset_ids", []):
+            referenced.add(_to_uuid(val))
+
+    referenced.discard(None)
+    return referenced
+
+
+def _to_uuid(val):
+    """Safely convert a string to UUID, returning None on failure."""
+    if not val:
+        return None
+    try:
+        return uuid.UUID(str(val))
+    except (ValueError, AttributeError):
+        return None

--- a/apps/media_library/storage.py
+++ b/apps/media_library/storage.py
@@ -43,7 +43,9 @@ def _normalize(storage_key: str) -> str:
     """
     from storages.utils import clean_name
 
-    return default_storage._normalize_name(clean_name(storage_key))
+    # ``_normalize_name`` lives on the S3 backend (this is only called when
+    # ``is_s3_backend()``), not on the base ``Storage`` type mypy infers here.
+    return default_storage._normalize_name(clean_name(storage_key))  # type: ignore[attr-defined]
 
 
 def generate_storage_key(declared_filename: str) -> str:

--- a/apps/media_library/tasks.py
+++ b/apps/media_library/tasks.py
@@ -195,3 +195,24 @@ def sweep_pending_uploads():
         with contextlib.suppress(Exception):
             delete_object(pending.storage_key)
         pending.delete()
+
+
+# How often the recurring orphaned-media sweep runs; registered on a repeating
+# schedule by apps.media_library.apps.MediaLibraryConfig. Replaces the daily
+# docker-compose ``maintenance`` loop so it runs on every deploy target.
+ORPHANED_MEDIA_SWEEP_INTERVAL_SECONDS = 24 * 60 * 60  # daily
+
+
+@background(schedule=0)
+def run_orphaned_media_sweep():
+    """Delete media assets no longer referenced by any post, idea, or template.
+
+    Wraps ``services.sweep_orphaned_media`` (the same code path as the
+    ``cleanup_orphaned_media`` command) so the cleanup runs on the shared
+    ``process_tasks`` worker everywhere, not just the VPS maintenance container.
+    """
+    from .services import sweep_orphaned_media
+
+    # min_age_days falls through to services.ORPHANED_MEDIA_MIN_AGE_DAYS (the
+    # single source), matching the management command's default.
+    sweep_orphaned_media(log=logger.info)

--- a/apps/notifications/apps.py
+++ b/apps/notifications/apps.py
@@ -5,3 +5,19 @@ class NotificationsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "apps.notifications"
     verbose_name = "Notifications"
+
+    def ready(self):
+        from django.db.models.signals import post_migrate
+
+        post_migrate.connect(self._register_tasks, sender=self)
+
+    @staticmethod
+    def _register_tasks(sender, **kwargs):
+        from apps.common.background import register_recurring_task
+        from apps.notifications.tasks import NOTIFICATION_RETRY_INTERVAL_SECONDS, retry_failed_deliveries
+
+        register_recurring_task(
+            retry_failed_deliveries,
+            repeat=NOTIFICATION_RETRY_INTERVAL_SECONDS,
+            verbose_name="retry_failed_deliveries",
+        )

--- a/apps/notifications/engine.py
+++ b/apps/notifications/engine.py
@@ -36,6 +36,10 @@ logger = logging.getLogger(__name__)
 
 MAX_RETRY_ATTEMPTS = 3
 RETRY_BACKOFF_MINUTES = [1, 5, 30]
+# Cap how many deliveries a single retry sweep processes, so a PENDING backlog
+# that accumulated before the periodic retry was scheduled drains gradually
+# across runs instead of bursting all at once.
+RETRY_BATCH_LIMIT = 200
 
 # Default channel enablement per event type.
 # Key: event_type, Value: dict of channel → default enabled.
@@ -327,12 +331,16 @@ def retry_failed_deliveries() -> int:
     Returns the count of retried deliveries.
     """
     now = timezone.now()
-    pending = NotificationDelivery.objects.filter(
-        status=DeliveryStatus.PENDING,
-        next_retry_at__isnull=False,
-        next_retry_at__lte=now,
-        attempts__lt=MAX_RETRY_ATTEMPTS,
-    ).select_related("notification", "notification__user")
+    pending = (
+        NotificationDelivery.objects.filter(
+            status=DeliveryStatus.PENDING,
+            next_retry_at__isnull=False,
+            next_retry_at__lte=now,
+            attempts__lt=MAX_RETRY_ATTEMPTS,
+        )
+        .select_related("notification", "notification__user")
+        .order_by("next_retry_at")[:RETRY_BATCH_LIMIT]
+    )
 
     count = 0
     for delivery in pending:

--- a/apps/notifications/tasks.py
+++ b/apps/notifications/tasks.py
@@ -6,6 +6,7 @@ These are meant to be called by django-background-tasks or a cron schedule.
 import logging
 from datetime import timedelta
 
+from background_task import background
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
@@ -64,10 +65,18 @@ def send_daily_digests():
             logger.exception("Failed to send daily digest to %s", user.email)
 
 
+# How often the recurring delivery-retry sweep runs; registered on a repeating
+# schedule by apps.notifications.apps.NotificationsConfig.
+NOTIFICATION_RETRY_INTERVAL_SECONDS = 60  # every minute
+
+
+@background(schedule=0)
 def retry_failed_deliveries():
     """Retry pending notification deliveries that are past their backoff window.
 
-    Should be scheduled to run every minute.
+    Registered on a 1-minute repeating schedule. ``notify()`` dispatches the
+    first attempt inline; transient email/webhook failures leave the delivery
+    PENDING with a ``next_retry_at`` that only this sweep acts on.
     """
     from .engine import retry_failed_deliveries as _retry
 

--- a/apps/notifications/test_retry_cap.py
+++ b/apps/notifications/test_retry_cap.py
@@ -1,0 +1,47 @@
+"""The failed-delivery retry sweep is capped per run so a backlog drains gradually."""
+
+import datetime
+
+import pytest
+from django.utils import timezone
+
+from apps.notifications.engine import RETRY_BATCH_LIMIT, retry_failed_deliveries
+from apps.notifications.models import Channel, DeliveryStatus, EventType, Notification, NotificationDelivery
+
+
+@pytest.mark.django_db
+def test_retry_caps_batch_and_drains_across_runs(user):
+    notification = Notification.objects.create(user=user, event_type=EventType.POST_FAILED, title="t", body="")
+    past = timezone.now() - datetime.timedelta(minutes=1)
+    future = timezone.now() + datetime.timedelta(minutes=5)
+
+    # cap + 5 deliveries are due now (next_retry_at in the past); one more is NOT
+    # yet due and must never be touched by either sweep.
+    NotificationDelivery.objects.bulk_create(
+        NotificationDelivery(
+            notification=notification,
+            channel=Channel.IN_APP,
+            status=DeliveryStatus.PENDING,
+            next_retry_at=past,
+            attempts=1,
+        )
+        for _ in range(RETRY_BATCH_LIMIT + 5)
+    )
+    not_due = NotificationDelivery.objects.create(
+        notification=notification,
+        channel=Channel.IN_APP,
+        status=DeliveryStatus.PENDING,
+        next_retry_at=future,
+        attempts=1,
+    )
+
+    # First sweep handles only RETRY_BATCH_LIMIT; the 5 over-cap due rows plus the
+    # not-yet-due row remain PENDING (proves it's a per-run throttle, not a filter).
+    assert retry_failed_deliveries() == RETRY_BATCH_LIMIT
+    assert NotificationDelivery.objects.filter(status=DeliveryStatus.PENDING).count() == 6
+
+    # Second sweep drains the remaining 5 due rows; the not-yet-due row is left
+    # untouched (proves the backlog drains across runs and respects next_retry_at).
+    assert retry_failed_deliveries() == 5
+    remaining = NotificationDelivery.objects.filter(status=DeliveryStatus.PENDING)
+    assert [d.pk for d in remaining] == [not_due.pk]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -35,28 +35,6 @@ services:
   postgres:
     restart: unless-stopped
 
-  maintenance:
-    build: .
-    command: >
-      sh -c "
-      while true; do
-        echo \"[maintenance] $$(date): Running clearsessions...\"
-        python manage.py clearsessions
-        echo \"[maintenance] $$(date): Running media cleanup...\"
-        python manage.py cleanup_orphaned_media --once --min-age-days 14
-        echo \"[maintenance] $$(date): Done. Sleeping 24h.\"
-        sleep 86400
-      done
-      "
-    volumes:
-      - media_data:/app/media
-    environment:
-      - DJANGO_SETTINGS_MODULE=config.settings.production
-    depends_on:
-      migrate:
-        condition: service_completed_successfully
-    restart: unless-stopped
-
   caddy:
     image: caddy:2-alpine
     ports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,9 @@
 [tool.ruff]
 target-version = "py312"
 line-length = 120
+# Django generates migrations with its own import ordering/formatting; don't
+# lint or format generated schema migrations.
+extend-exclude = ["*/migrations/*"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "N", "W", "UP", "B", "SIM"]

--- a/railway.toml
+++ b/railway.toml
@@ -1,3 +1,17 @@
+# Build config (Dockerfile) for the Railway one-click template:
+#   https://railway.com/deploy/brightbean-studio
+# The template provisions three services that share this image:
+#   - web:     Gunicorn (Dockerfile CMD), runs `python manage.py migrate` on startup
+#   - worker:  `python manage.py process_tasks`  (django-background-tasks)
+#   - Postgres
+# The web service's startup migrate fires the `post_migrate` hooks that register
+# the recurring jobs (publishing, inbox sync, retries, reminders, cleanups); the
+# worker then runs them, so scheduling works out of the box.
+#
+# Wiring Railway MANUALLY from this repo instead of the template? Replicate both:
+# a worker service running `process_tasks`, and `migrate` on each deploy — the
+# Dockerfile CMD only starts Gunicorn, so neither happens on its own.
+
 [build]
 builder = "dockerfile"
 dockerfilePath = "Dockerfile"


### PR DESCRIPTION
## What does this PR do?

Wires five recurring jobs onto the existing **django-background-tasks** `process_tasks` worker so they actually run on every deploy target (VPS, Heroku, Render, Railway) — **no external scheduler (cron / Heroku Scheduler) needed**:

| Task | Cadence |
|------|---------|
| inbox sync + SLA checks | every 5 min |
| notification delivery retries | every 1 min |
| approval reminders / escalation | hourly |
| orphaned-media cleanup | daily |
| expired-session cleanup | daily |

Each is registered idempotently via a `post_migrate` hook, centralized in a new `apps/common/background.register_recurring_task` helper (replaces ~5 copies of the registration boilerplate and logs unexpected failures instead of swallowing them). The VPS-only docker-compose `maintenance` loop is removed in favor of the worker tasks, and the Railway docs are corrected to describe the one-click template's actual wiring.

The **second commit** is an unrelated cleanup: pre-existing repo-wide `ruff`/`mypy` failures, fixed so CI is green (kept separate for review).

## Why?

These tasks shipped in code but were **never scheduled** (or, for the two cleanups, ran only on the VPS). The result was silent gaps: the inbox only filled via webhooks, failed notification emails/webhooks set a retry time nothing acted on, stalled approvals were never nudged, and session/orphaned-media cleanup never ran off-VPS. Wiring them onto the worker — which already runs everywhere — closes those gaps without new infrastructure.

First-run **guards** prevent backlog floods: inbox suppresses notifications for the historical backlog pulled on an account's first sync but still alerts for genuinely recent messages (so a long-quiet account's first real message isn't silenced); the retry sweep is capped per run so a backlog drains gradually; `backfill_inbox` seeds history silently.

## How to test

- **Registration:** run `migrate`, then check the `background_task` Task table — the five new `verbose_name`s appear with repeats `300 / 60 / 3600 / 86400 / 86400`.
- **Worker:** run `python manage.py process_tasks` against an empty DB; each task fires as a no-op and reschedules (`run_at` advances by its interval), no errors.
- **Unit tests:** `pytest apps/inbox apps/notifications apps/approvals apps/media_library apps/accounts` — covers the inbox first-sync guard (incl. the "first message on a quiet account still notifies" regression) and the retry cap draining across runs.
- **Lint/types:** `ruff check . && ruff format --check . && mypy apps/`.

## Checklist

- [x] Tests pass (`pytest`) — 92 affected-app tests green
- [x] Lint passes (`ruff check .` and `ruff format --check .`); `mypy apps/` clean
- [x] Documentation updated (README "Other Platforms" + railway.toml)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
