### PR TITLE
Fix posting-time delete 404 and harden posting-slot endpoints

### DIFF
--- a/apps/calendar/tests.py
+++ b/apps/calendar/tests.py
@@ -43,10 +43,13 @@ class PostingSlotModelTest(TestCase):
 
 
 class PostingSlotCrossWorkspaceTests(TestCase):
-    """Slot endpoints must scope to the requesting workspace.
+    """Slot endpoints must scope every mutation to the requesting workspace.
 
-    Regression for permission-timing leak: a 404 must come from the workspace-
-    scoped query, not from a post-lookup membership check.
+    The workspace-scoped query is the single authority: a slot outside the
+    caller's workspace (or already gone) is a uniform no-op that never mutates
+    and never leaks existence via a post-lookup membership check. Treating the
+    miss as a no-op also makes delete/update idempotent, so a stale grid
+    self-heals instead of 404ing.
     """
 
     def setUp(self):
@@ -99,11 +102,9 @@ class PostingSlotCrossWorkspaceTests(TestCase):
             workspace_role=WorkspaceMembership.WorkspaceRole.OWNER,
         )
 
-    def test_delete_slot_from_own_workspace_returns_404_for_slot_in_other_workspace(self):
-        """User A scopes the delete URL to workspace A but passes B's slot id."""
+    def test_delete_own_workspace_slot_succeeds(self):
+        """Happy path: an owner deletes a slot in their own workspace."""
         self.client.force_login(self.user_a)
-        # workspace A in URL but slot belongs to workspace A — sanity check happy path
-        # (deletes a slot the user is allowed to delete)
         url = reverse(
             "calendar:delete_posting_slot",
             kwargs={"workspace_id": self.workspace_a.id, "slot_id": self.slot_a.id},
@@ -112,8 +113,12 @@ class PostingSlotCrossWorkspaceTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertFalse(PostingSlot.objects.filter(id=self.slot_a.id).exists())
 
-    def test_delete_slot_belonging_to_different_workspace_returns_404(self):
-        """A new slot in workspace A; user B (different workspace) tries to delete via /workspace/<B>/."""
+    def test_delete_slot_belonging_to_different_workspace_is_noop(self):
+        """A slot outside the caller's workspace must never be deleted.
+
+        The workspace-scoped query finds nothing, so the endpoint is a uniform
+        no-op: it never mutates and never 404-leaks the foreign slot's existence.
+        """
         slot_a2 = PostingSlot.objects.create(
             social_account=self.account_a,
             day_of_week=1,
@@ -121,19 +126,18 @@ class PostingSlotCrossWorkspaceTests(TestCase):
         )
         self.client.force_login(self.user_b)
         # User B uses their OWN workspace_id in the URL (auth passes), but the
-        # slot_id is from workspace A. Pre-fix this leaked existence via 404
-        # only AFTER the lookup; post-fix the workspace-scoped query never
-        # finds it.
+        # slot_id is from workspace A — the scoped query never finds it.
         url = reverse(
             "calendar:delete_posting_slot",
             kwargs={"workspace_id": self.workspace_b.id, "slot_id": slot_a2.id},
         )
         response = self.client.post(url)
-        self.assertEqual(response.status_code, 404)
-        # Slot must still exist
+        self.assertEqual(response.status_code, 200)
+        # Load-bearing invariant (not the 200 status): the foreign slot is untouched.
         self.assertTrue(PostingSlot.objects.filter(id=slot_a2.id).exists())
 
-    def test_update_slot_belonging_to_different_workspace_returns_404(self):
+    def test_update_slot_belonging_to_different_workspace_is_noop(self):
+        """A slot outside the caller's workspace must never be modified."""
         slot_a2 = PostingSlot.objects.create(
             social_account=self.account_a,
             day_of_week=2,
@@ -145,6 +149,91 @@ class PostingSlotCrossWorkspaceTests(TestCase):
             kwargs={"workspace_id": self.workspace_b.id, "slot_id": slot_a2.id},
         )
         response = self.client.post(url, data={"time": "13:30"})
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 200)
+        # Load-bearing invariant (not the 200 status): the foreign slot is unchanged.
         slot_a2.refresh_from_db()
         self.assertEqual(slot_a2.time, time(11, 0))
+
+    def test_delete_already_gone_slot_is_idempotent_self_heal(self):
+        """Re-deleting an own-workspace slot that is already gone refreshes the
+        grid (HX-Trigger) instead of 404ing — the stale-page / double-click fix.
+        """
+        url = reverse(
+            "calendar:delete_posting_slot",
+            kwargs={"workspace_id": self.workspace_a.id, "slot_id": self.slot_a.id},
+        )
+        self.client.force_login(self.user_a)
+        first = self.client.post(url, HTTP_HX_REQUEST="true")
+        self.assertEqual(first.status_code, 204)
+        self.assertIn("slotsUpdated", first.headers.get("HX-Trigger", ""))
+        self.assertFalse(PostingSlot.objects.filter(id=self.slot_a.id).exists())
+        # Second delete of the now-missing slot must NOT 404; with the posted
+        # account id it still emits the grid-refresh trigger so the stale row clears.
+        second = self.client.post(
+            url, data={"social_account_id": str(self.account_a.id)}, HTTP_HX_REQUEST="true"
+        )
+        self.assertEqual(second.status_code, 204)
+        self.assertIn(str(self.account_a.id), second.headers.get("HX-Trigger", ""))
+
+    def test_delete_real_slot_emits_account_scoped_trigger(self):
+        """The happy-path HX-Trigger carries the account id under ``detail`` so the
+        grid's ``slotsUpdated[detail.accountId==...]`` filter matches and refreshes.
+        """
+        import json
+
+        url = reverse(
+            "calendar:delete_posting_slot",
+            kwargs={"workspace_id": self.workspace_a.id, "slot_id": self.slot_a.id},
+        )
+        self.client.force_login(self.user_a)
+        resp = self.client.post(url, HTTP_HX_REQUEST="true")
+        self.assertEqual(resp.status_code, 204)
+        payload = json.loads(resp.headers["HX-Trigger"])
+        self.assertEqual(payload["slotsUpdated"]["accountId"], str(self.account_a.id))
+
+    def test_update_already_gone_slot_is_idempotent_self_heal(self):
+        """Editing the time of an own-workspace slot that is already gone refreshes
+        the grid (HX-Trigger) instead of 404ing — mirrors the delete self-heal.
+        """
+        url = reverse(
+            "calendar:update_posting_slot",
+            kwargs={"workspace_id": self.workspace_a.id, "slot_id": self.slot_a.id},
+        )
+        self.client.force_login(self.user_a)
+        self.slot_a.delete()
+        resp = self.client.post(
+            url,
+            data={"time": "08:15", "social_account_id": str(self.account_a.id)},
+            HTTP_HX_REQUEST="true",
+        )
+        self.assertEqual(resp.status_code, 204)
+        self.assertIn(str(self.account_a.id), resp.headers.get("HX-Trigger", ""))
+
+    def test_slot_mutation_denied_for_member_without_manage_permission(self):
+        """A workspace member whose role lacks manage_social_accounts cannot mutate
+        posting slots, even though they pass the membership check.
+        """
+        viewer = User.objects.create_user(
+            email="viewer@example.com",
+            password="testpass123",
+            tos_accepted_at=timezone.now(),
+        )
+        OrgMembership.objects.create(
+            user=viewer,
+            organization=self.org_a,
+            org_role=OrgMembership.OrgRole.MEMBER,
+        )
+        WorkspaceMembership.objects.create(
+            user=viewer,
+            workspace=self.workspace_a,
+            workspace_role=WorkspaceMembership.WorkspaceRole.VIEWER,
+        )
+        self.client.force_login(viewer)
+        url = reverse(
+            "calendar:delete_posting_slot",
+            kwargs={"workspace_id": self.workspace_a.id, "slot_id": self.slot_a.id},
+        )
+        response = self.client.post(url)
+        self.assertEqual(response.status_code, 403)
+        # The slot must survive an unauthorized delete attempt.
+        self.assertTrue(PostingSlot.objects.filter(id=self.slot_a.id).exists())

--- a/apps/calendar/tests.py
+++ b/apps/calendar/tests.py
@@ -169,9 +169,7 @@ class PostingSlotCrossWorkspaceTests(TestCase):
         self.assertFalse(PostingSlot.objects.filter(id=self.slot_a.id).exists())
         # Second delete of the now-missing slot must NOT 404; with the posted
         # account id it still emits the grid-refresh trigger so the stale row clears.
-        second = self.client.post(
-            url, data={"social_account_id": str(self.account_a.id)}, HTTP_HX_REQUEST="true"
-        )
+        second = self.client.post(url, data={"social_account_id": str(self.account_a.id)}, HTTP_HX_REQUEST="true")
         self.assertEqual(second.status_code, 204)
         self.assertIn(str(self.account_a.id), second.headers.get("HX-Trigger", ""))
 

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -56,6 +56,22 @@ def _slots_updated_response(account_id):
     )
 
 
+def _missing_slot_response(request, payload):
+    """Idempotent no-op response for a slot that is already gone.
+
+    Reached on a stale page, a concurrent delete, or a double-click. The
+    workspace-scoped lookup found no slot, so nothing is mutated here. For htmx
+    we refresh the caller's grid via the ``slotsUpdated`` trigger so the phantom
+    row clears; we fall back to a bare 204 only when no ``social_account_id`` was
+    posted (the real forms always post it, so the grid can be targeted).
+    Non-htmx callers get *payload*.
+    """
+    if request.htmx:
+        account_id = request.POST.get("social_account_id")
+        return _slots_updated_response(account_id) if account_id else HttpResponse(status=204)
+    return JsonResponse(payload)
+
+
 def _get_workspace(request, workspace_id):
     """Resolve workspace and enforce membership check."""
     workspace = get_object_or_404(Workspace, id=workspace_id)
@@ -846,6 +862,7 @@ def posting_slots(request, workspace_id):
 
 @login_required
 @require_POST
+@require_permission("manage_social_accounts")
 def save_posting_slot(request, workspace_id):
     """Create or update a posting slot."""
     workspace = _get_workspace(request, workspace_id)
@@ -881,14 +898,21 @@ def save_posting_slot(request, workspace_id):
 
 @login_required
 @require_POST
+@require_permission("manage_social_accounts")
 def delete_posting_slot(request, workspace_id, slot_id):
-    """Delete a posting slot."""
+    """Delete a posting slot.
+
+    Idempotent: a slot that is already gone (stale page, concurrent delete, or a
+    double-click) still returns the grid-refresh trigger so the phantom row
+    clears instead of 404ing.
+    """
     workspace = _get_workspace(request, workspace_id)
-    slot = get_object_or_404(
-        PostingSlot,
+    slot = PostingSlot.objects.filter(
         id=slot_id,
         social_account__workspace=workspace,
-    )
+    ).first()
+    if slot is None:
+        return _missing_slot_response(request, {"deleted": False})
 
     account_id = str(slot.social_account_id)
     slot.delete()
@@ -898,6 +922,7 @@ def delete_posting_slot(request, workspace_id, slot_id):
 
 
 @login_required
+@require_permission("manage_social_accounts")
 def account_posting_slots_partial(request, workspace_id):
     """Return the posting slots grid partial for a single account (HTMX)."""
     workspace = _get_workspace(request, workspace_id)
@@ -916,8 +941,14 @@ def account_posting_slots_partial(request, workspace_id):
 
 @login_required
 @require_POST
+@require_permission("manage_social_accounts")
 def toggle_posting_slot_day(request, workspace_id):
-    """Toggle is_active for all posting slots of an account on a given day."""
+    """Toggle is_active for all posting slots of an account on a given day.
+
+    Account-level op: unlike delete/update (which self-heal a vanished *slot*),
+    this acts on the *account*, so a 404 on a missing account is intentional —
+    if the account itself is gone the whole card is stale, not just the grid.
+    """
     workspace = _get_workspace(request, workspace_id)
     account_id = request.POST.get("social_account_id")
     day = request.POST.get("day_of_week")
@@ -946,14 +977,20 @@ def toggle_posting_slot_day(request, workspace_id):
 
 @login_required
 @require_POST
+@require_permission("manage_social_accounts")
 def update_posting_slot(request, workspace_id, slot_id):
-    """Update a posting slot's time."""
+    """Update a posting slot's time.
+
+    Idempotent: a slot that is already gone refreshes the grid (clearing the
+    phantom row) instead of 404ing.
+    """
     workspace = _get_workspace(request, workspace_id)
-    slot = get_object_or_404(
-        PostingSlot,
+    slot = PostingSlot.objects.filter(
         id=slot_id,
         social_account__workspace=workspace,
-    )
+    ).first()
+    if slot is None:
+        return _missing_slot_response(request, {"updated": False})
 
     time_str = request.POST.get("time")
     if not time_str:

--- a/templates/social_accounts/partials/_posting_slots_grid.html
+++ b/templates/social_accounts/partials/_posting_slots_grid.html
@@ -9,7 +9,7 @@ Context: account (with prefetched posting_slots), workspace_id.
 
 <div id="slots-grid-{{ account.id }}"
      hx-get="{% url 'calendar:account_slots_partial' workspace_id=workspace_id %}?social_account_id={{ account.id }}"
-     hx-trigger="slotsUpdated[accountId=='{{ account.id }}'] from:body"
+     hx-trigger="slotsUpdated[detail.accountId=='{{ account.id }}'] from:body"
      hx-swap="outerHTML">
 
     <div class="overflow-x-auto">
@@ -57,6 +57,7 @@ Context: account (with prefetched posting_slots), workspace_id.
                                     <form hx-post="{% url 'calendar:delete_posting_slot' workspace_id=workspace_id slot_id=slot.id %}"
                                           hx-swap="none" class="inline">
                                         {% csrf_token %}
+                                        <input type="hidden" name="social_account_id" value="{{ account.id }}">
                                         <button type="submit"
                                                 x-show="hovered" x-transition.opacity
                                                 class="w-4 h-4 flex items-center justify-center text-stone-300 hover:text-red-500 transition-all cursor-pointer"
@@ -72,6 +73,7 @@ Context: account (with prefetched posting_slots), workspace_id.
                                       @htmx:after-request="editing = false"
                                       class="flex items-center gap-1">
                                     {% csrf_token %}
+                                    <input type="hidden" name="social_account_id" value="{{ account.id }}">
                                     <input type="time" name="time" value="{{ slot.time|time:'H:i' }}"
                                            class="w-[90px] text-xs px-1.5 py-1 rounded border border-stone-200 outline-none focus:border-orange-400"
                                            @keydown.escape="editing = false">


### PR DESCRIPTION
## Problem

Deleting a posting time on `/social-accounts/<workspace_id>/` logged a 404:

```
POST /workspace/<id>/calendar/posting-slots/<slot>/delete/ 404 (Not Found)
```

## Root cause

The posting-slots grid refreshes itself via an htmx trigger filter, but it read the event id at the wrong path: `slotsUpdated[accountId=='...']`. In htmx 2.x a bare identifier in a trigger filter resolves to `event.accountId` / `window.accountId`, while the server sends the id nested under `detail` (`{"slotsUpdated": {"accountId": ...}}`). So the filter was always `undefined == uuid` → false and the grid **never refreshed** after a slot change. The slot was deleted server-side (204) but stayed on screen; clicking the now-phantom row again hit the already-deleted slot → **404**. The same broken refresh also silently affected add / toggle-day / edit-time.

## Changes

- **Fix the trigger filter** to `slotsUpdated[detail.accountId=='{{ account.id }}']` → the grid refreshes on every slot change.
- **Idempotent delete/update**: an already-gone slot returns the grid-refresh trigger (204) instead of 404, so stale-page / concurrent-delete / double-click cases self-heal. Extracted a shared `_missing_slot_response` helper.
- **Authorization**: gate all posting-slot endpoints (`save` / `delete` / `update` / `toggle` / grid partial) on `manage_social_accounts`. They previously enforced only workspace membership, so `editor` / `contributor` / `client` / `viewer` roles — who can't even see the Posting Schedule UI — could still mutate slots via a direct POST.

## Tests

`pytest apps/calendar` → **10 passing**, including new coverage for the idempotent self-heal (delete + update) and a **403** for a member lacking `manage_social_accounts`. Also ran `apps/social_accounts` (53 passing), `ruff`, and `manage.py check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
