### PR TITLE
Fix inbox banner duplication & members dropdown clipping; add drafts delete menu

### DIFF
--- a/apps/inbox/views.py
+++ b/apps/inbox/views.py
@@ -155,7 +155,7 @@ def inbox_feed(request, workspace_id):
 
     context = {
         "workspace": workspace,
-        "messages": messages,
+        "inbox_messages": messages,
         "sla_config": sla_config,
         "team_members": team_members,
         "social_accounts": social_accounts,
@@ -414,7 +414,7 @@ def bulk_action(request, workspace_id):
         :MESSAGES_PER_PAGE
     ]
 
-    context = {"workspace": workspace, "messages": messages}
+    context = {"workspace": workspace, "inbox_messages": messages}
     return render(request, "inbox/partials/_message_list.html", context)
 
 

--- a/templates/calendar/partials/_delete_post_modal.html
+++ b/templates/calendar/partials/_delete_post_modal.html
@@ -1,0 +1,64 @@
+{% comment %}
+Delete-post confirmation modal for the Publish list tabs.
+Listens for the `open-delete-modal` window event (detail: postId, accountId),
+POSTs to composer:post_delete, then dispatches `post-deleted` so that
+publishList().reloadTab() in calendar.html refreshes the active tab (no full reload).
+Include once per tab partial that renders `_post_actions_menu.html`.
+Expects context: workspace, csrf_token.
+{% endcomment %}
+<div x-data="{ showDeleteModal: false, deletePostId: null, deleteAccountId: null, deleting: false }" style="display: contents;"
+     @open-delete-modal.window="showDeleteModal = true; deletePostId = $event.detail.postId; deleteAccountId = $event.detail.accountId || null">
+    <template x-teleport="body">
+        <div x-show="showDeleteModal" class="fixed inset-0 z-[60] flex items-center justify-center"
+             @keydown.escape.window="showDeleteModal = false"
+             style="display: none;">
+            <div class="fixed inset-0 bg-black/30 backdrop-blur-sm" @click="showDeleteModal = false"
+                 x-show="showDeleteModal"
+                 x-transition:enter="transition ease-out duration-150"
+                 x-transition:enter-start="opacity-0"
+                 x-transition:enter-end="opacity-100"
+                 x-transition:leave="transition ease-in duration-100"
+                 x-transition:leave-start="opacity-100"
+                 x-transition:leave-end="opacity-0"></div>
+            <div class="relative bg-white rounded-2xl shadow-xl border border-stone-200 p-6 w-full max-w-sm mx-4"
+                 x-show="showDeleteModal"
+                 x-transition:enter="transition ease-out duration-150"
+                 x-transition:enter-start="opacity-0 scale-95"
+                 x-transition:enter-end="opacity-100 scale-100"
+                 x-transition:leave="transition ease-in duration-100"
+                 x-transition:leave-start="opacity-100 scale-100"
+                 x-transition:leave-end="opacity-0 scale-95">
+                <div class="text-center">
+                    <div class="w-12 h-12 mx-auto rounded-full bg-red-50 flex items-center justify-center mb-4">
+                        <svg class="w-6 h-6 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
+                    </div>
+                    <h3 class="text-base font-semibold text-stone-900 mb-1">Delete post?</h3>
+                    <p class="text-sm text-stone-500 mb-6">This action cannot be undone. The post and all associated data will be permanently removed.</p>
+                </div>
+                <div class="flex gap-3">
+                    <button @click="showDeleteModal = false"
+                            class="flex-1 px-4 py-2 text-sm font-semibold text-stone-700 bg-stone-100 rounded-full hover:bg-stone-200 transition-colors cursor-pointer">
+                        Cancel
+                    </button>
+                    <button :disabled="deleting"
+                            @click="
+                                deleting = true;
+                                const acctParam = deleteAccountId ? '?account=' + deleteAccountId : '';
+                                fetch('/workspace/{{ workspace.id }}/compose/' + deletePostId + '/delete/' + acctParam, {
+                                    method: 'POST',
+                                    headers: { 'X-CSRFToken': '{{ csrf_token }}' }
+                                }).then(() => {
+                                    showDeleteModal = false;
+                                    deleting = false;
+                                    window.dispatchEvent(new CustomEvent('post-deleted'));
+                                }).catch(() => { deleting = false; });
+                            "
+                            :class="deleting && 'opacity-50 cursor-not-allowed'"
+                            class="flex-1 px-4 py-2 text-sm font-semibold text-white bg-red-500 rounded-full hover:bg-red-600 transition-colors cursor-pointer">
+                        <span x-text="deleting ? 'Deleting...' : 'Delete'"></span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    </template>
+</div>

--- a/templates/calendar/partials/_post_actions_menu.html
+++ b/templates/calendar/partials/_post_actions_menu.html
@@ -1,0 +1,38 @@
+{% comment %}
+Per-post kebab actions menu (Edit + Delete) for the Publish list tabs.
+The dropdown is teleported to <body> with fixed positioning so it escapes any
+overflow-clipped container. Delete dispatches the `open-delete-modal` window event;
+include `_delete_post_modal.html` once in the same tab partial to handle it.
+Expects context: workspace, post_id, account_id.
+{% endcomment %}
+<div x-data="{ open: false, menuStyle: {} }" class="relative"
+     @click.outside="open = false"
+     @scroll.window="open = false"
+     @keydown.escape.window="open = false">
+    <button @click.stop="
+        open = !open;
+        if (open) {
+            const r = $el.getBoundingClientRect();
+            menuStyle = { position: 'fixed', top: (r.bottom + 4) + 'px', left: (r.right - 144) + 'px', zIndex: 9999 };
+        }
+    "
+            class="p-1.5 rounded-full border border-stone-200 text-stone-400 hover:border-stone-300 hover:text-stone-600 transition-colors cursor-pointer">
+        <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20"><circle cx="10" cy="4" r="1.5"/><circle cx="10" cy="10" r="1.5"/><circle cx="10" cy="16" r="1.5"/></svg>
+    </button>
+    <template x-teleport="body">
+        <div :style="open ? menuStyle : { display: 'none' }"
+             @click.outside="open = false"
+             class="w-36 bg-white rounded-xl border border-stone-200 shadow-lg py-1">
+            <a href="{% url 'composer:compose_edit' workspace_id=workspace.id post_id=post_id %}?account={{ account_id }}"
+               class="flex items-center gap-2 px-3 py-2 text-sm text-stone-700 hover:bg-stone-50 transition-colors">
+                <svg class="w-4 h-4 text-stone-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"/></svg>
+                Edit
+            </a>
+            <button @click.stop="open = false; $dispatch('open-delete-modal', { postId: '{{ post_id }}', accountId: '{{ account_id }}' })"
+                    class="flex items-center gap-2 w-full px-3 py-2 text-sm text-red-600 hover:bg-red-50 transition-colors cursor-pointer">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
+                Delete
+            </button>
+        </div>
+    </template>
+</div>

--- a/templates/calendar/partials/publish_drafts.html
+++ b/templates/calendar/partials/publish_drafts.html
@@ -13,6 +13,7 @@ Shows all draft platform posts in a table. Loaded via HTMX into #tab-content.
                 <th class="px-4 py-3 text-xs font-semibold text-stone-400 uppercase tracking-wider">Platform</th>
                 <th class="px-4 py-3 text-xs font-semibold text-stone-400 uppercase tracking-wider">Author</th>
                 <th class="px-4 py-3 text-xs font-semibold text-stone-400 uppercase tracking-wider">Last Updated</th>
+                <th class="px-4 py-3 w-10"></th>
             </tr>
         </thead>
         <tbody>
@@ -67,6 +68,9 @@ Shows all draft platform posts in a table. Loaded via HTMX into #tab-content.
                 <td class="px-4 py-3 text-xs text-stone-500 tabular-nums whitespace-nowrap">
                     {{ pp.post.updated_at|timesince }} ago
                 </td>
+                <td class="px-4 py-3 text-right" @click.stop>
+                    {% include "calendar/partials/_post_actions_menu.html" with post_id=pp.post_id account_id=pp.social_account_id %}
+                </td>
             </tr>
             {% endfor %}
         </tbody>
@@ -89,4 +93,5 @@ Shows all draft platform posts in a table. Loaded via HTMX into #tab-content.
     </div>
     {% endif %}
     {% endif %}
+    {% include "calendar/partials/_delete_post_modal.html" %}
 </div>

--- a/templates/calendar/partials/publish_queue.html
+++ b/templates/calendar/partials/publish_queue.html
@@ -89,44 +89,7 @@ Shows all scheduled platform posts grouped by date. Loaded via HTMX into #tab-co
                                 <svg class="w-3.5 h-3.5 rotate-90" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"/></svg>
                                 Publish
                             </a>
-                            <div x-data="{ open: false, menuStyle: {} }" class="relative"
-                                 @click.outside="open = false"
-                                 @scroll.window="open = false"
-                                 @keydown.escape.window="open = false">
-                                <button @click.stop="
-                                    open = !open;
-                                    if (open) {
-                                        const r = $el.getBoundingClientRect();
-                                        menuStyle = { position: 'fixed', top: (r.bottom + 4) + 'px', left: (r.right - 144) + 'px', zIndex: 9999 };
-                                    }
-                                "
-                                        class="p-1.5 rounded-full border border-stone-200 text-stone-400 hover:border-stone-300 hover:text-stone-600 transition-colors cursor-pointer">
-                                    <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 20 20"><circle cx="10" cy="4" r="1.5"/><circle cx="10" cy="10" r="1.5"/><circle cx="10" cy="16" r="1.5"/></svg>
-                                </button>
-                                <template x-teleport="body">
-                                    <div x-show="open"
-                                         :style="menuStyle"
-                                         @click.outside="open = false"
-                                         x-transition:enter="transition ease-out duration-100"
-                                         x-transition:enter-start="opacity-0 scale-95"
-                                         x-transition:enter-end="opacity-100 scale-100"
-                                         x-transition:leave="transition ease-in duration-75"
-                                         x-transition:leave-start="opacity-100 scale-100"
-                                         x-transition:leave-end="opacity-0 scale-95"
-                                         class="w-36 bg-white rounded-xl border border-stone-200 shadow-lg py-1">
-                                        <a href="{% url 'composer:compose_edit' workspace_id=workspace.id post_id=pp.post_id %}?account={{ pp.social_account_id }}"
-                                           class="flex items-center gap-2 px-3 py-2 text-sm text-stone-700 hover:bg-stone-50 transition-colors">
-                                            <svg class="w-4 h-4 text-stone-400" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"/></svg>
-                                            Edit
-                                        </a>
-                                        <button @click.stop="open = false; $dispatch('open-delete-modal', { postId: '{{ pp.post_id }}', accountId: '{{ pp.social_account_id }}' })"
-                                                class="flex items-center gap-2 w-full px-3 py-2 text-sm text-red-600 hover:bg-red-50 transition-colors cursor-pointer">
-                                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
-                                            Delete
-                                        </button>
-                                    </div>
-                                </template>
-                            </div>
+                            {% include "calendar/partials/_post_actions_menu.html" with post_id=pp.post_id account_id=pp.social_account_id %}
                         </div>
                     </div>
                 </div>
@@ -155,60 +118,4 @@ Shows all scheduled platform posts grouped by date. Loaded via HTMX into #tab-co
     {% endif %}
 </div>
 
-<!-- Delete confirmation modal -->
-<div x-data="{ showDeleteModal: false, deletePostId: null, deleteAccountId: null, deleting: false }" style="display: contents;"
-     @open-delete-modal.window="showDeleteModal = true; deletePostId = $event.detail.postId; deleteAccountId = $event.detail.accountId || null">
-    <template x-teleport="body">
-        <div x-show="showDeleteModal" class="fixed inset-0 z-[60] flex items-center justify-center"
-             @keydown.escape.window="showDeleteModal = false"
-             style="display: none;">
-            <div class="fixed inset-0 bg-black/30 backdrop-blur-sm" @click="showDeleteModal = false"
-                 x-show="showDeleteModal"
-                 x-transition:enter="transition ease-out duration-150"
-                 x-transition:enter-start="opacity-0"
-                 x-transition:enter-end="opacity-100"
-                 x-transition:leave="transition ease-in duration-100"
-                 x-transition:leave-start="opacity-100"
-                 x-transition:leave-end="opacity-0"></div>
-            <div class="relative bg-white rounded-2xl shadow-xl border border-stone-200 p-6 w-full max-w-sm mx-4"
-                 x-show="showDeleteModal"
-                 x-transition:enter="transition ease-out duration-150"
-                 x-transition:enter-start="opacity-0 scale-95"
-                 x-transition:enter-end="opacity-100 scale-100"
-                 x-transition:leave="transition ease-in duration-100"
-                 x-transition:leave-start="opacity-100 scale-100"
-                 x-transition:leave-end="opacity-0 scale-95">
-                <div class="text-center">
-                    <div class="w-12 h-12 mx-auto rounded-full bg-red-50 flex items-center justify-center mb-4">
-                        <svg class="w-6 h-6 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5"><path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
-                    </div>
-                    <h3 class="text-base font-semibold text-stone-900 mb-1">Delete post?</h3>
-                    <p class="text-sm text-stone-500 mb-6">This action cannot be undone. The post and all associated data will be permanently removed.</p>
-                </div>
-                <div class="flex gap-3">
-                    <button @click="showDeleteModal = false"
-                            class="flex-1 px-4 py-2 text-sm font-semibold text-stone-700 bg-stone-100 rounded-full hover:bg-stone-200 transition-colors cursor-pointer">
-                        Cancel
-                    </button>
-                    <button :disabled="deleting"
-                            @click="
-                                deleting = true;
-                                const acctParam = deleteAccountId ? '?account=' + deleteAccountId : '';
-                                fetch('/workspace/{{ workspace.id }}/compose/' + deletePostId + '/delete/' + acctParam, {
-                                    method: 'POST',
-                                    headers: { 'X-CSRFToken': '{{ csrf_token }}' }
-                                }).then(() => {
-                                    showDeleteModal = false;
-                                    deleting = false;
-                                    window.dispatchEvent(new CustomEvent('post-deleted'));
-                                }).catch(() => { deleting = false; });
-                            "
-                            :class="deleting && 'opacity-50 cursor-not-allowed'"
-                            class="flex-1 px-4 py-2 text-sm font-semibold text-white bg-red-500 rounded-full hover:bg-red-600 transition-colors cursor-pointer">
-                        <span x-text="deleting ? 'Deleting...' : 'Delete'"></span>
-                    </button>
-                </div>
-            </div>
-        </div>
-    </template>
-</div>
+{% include "calendar/partials/_delete_post_modal.html" %}

--- a/templates/inbox/partials/_message_list.html
+++ b/templates/inbox/partials/_message_list.html
@@ -1,6 +1,6 @@
 {% load humanize %}
-{% if messages %}
-{% for msg in messages %}
+{% if inbox_messages %}
+{% for msg in inbox_messages %}
 {% include "inbox/partials/_message_row.html" with message=msg %}
 {% endfor %}
 {% else %}

--- a/templates/members/partials/member_row.html
+++ b/templates/members/partials/member_row.html
@@ -1,6 +1,6 @@
 <div class="px-6 py-4 group" id="member-{{ member.membership.id }}"
      style="border-bottom: 1px solid var(--border);"
-     x-data="{ showActions: false, showWorkspaces: false }">
+     x-data="{ showActions: false, showWorkspaces: false, menuStyle: {} }">
     <!-- Row 1: Member info -->
     <div class="flex items-center gap-4">
         <!-- Avatar / Initials -->
@@ -36,16 +36,21 @@
         <!-- Actions -->
         {% if is_admin and member.user.id != current_user.id %}
         <div class="flex-shrink-0 relative">
-            <button @click="showActions = !showActions"
+            <button @click="showActions = !showActions; if (showActions) { const r = $el.getBoundingClientRect(); menuStyle = { position: 'fixed', top: (r.bottom + 4) + 'px', left: (r.right - 208) + 'px', zIndex: 9999 } }"
                     class="btn-neutral-100 p-1.5 rounded-lg transition-colors cursor-pointer"
                     style="color: var(--text-tertiary);">
                 <svg width="16" height="16" fill="currentColor" viewBox="0 0 24 24"><circle cx="12" cy="5" r="2"/><circle cx="12" cy="12" r="2"/><circle cx="12" cy="19" r="2"/></svg>
             </button>
 
-            <!-- Dropdown -->
+            <!-- Dropdown (teleported to body so it escapes the card's overflow:hidden) -->
+            <template x-teleport="body">
             <div x-show="showActions" @click.outside="showActions = false"
+                 @keydown.escape.window="showActions = false"
+                 @scroll.window="showActions = false"
                  x-transition
-                 class="absolute right-0 top-full mt-1 w-52 py-1 rounded-lg shadow-lg z-10"
+                 x-init="window.htmx && htmx.process($el)"
+                 :style="menuStyle"
+                 class="w-52 py-1 rounded-lg shadow-lg"
                  style="background: var(--surface-0); border: 1px solid var(--border);">
 
                 <!-- Change Role -->
@@ -92,6 +97,7 @@
                     </button>
                 </form>
             </div>
+            </template>
         </div>
         {% endif %}
     </div>


### PR DESCRIPTION
Three independent Publish/Studio UI fixes.

## 1. Inbox — stray "Comment from @…" banners at the top
The feed view passed the `InboxMessage` queryset under the context key `"messages"`, which **shadows Django's messages-framework variable** that `base.html` renders as flash banners. Since `InboxMessage.__str__` → `"Comment from @user"`, the feed items were painted twice — once correctly in the list, once as stray banners at the top.

**Fix:** renamed the context key to `inbox_messages` in `inbox_feed` and `bulk_action` (`apps/inbox/views.py`) and in `_message_list.html`. Genuine Django flash messages now render normally; the duplicate banners are gone.

## 2. Members — last-row kebab dropdown was clipped
The dropdown was clipped by `overflow: hidden` on the members card. Converted it to the codebase's existing `x-teleport="body"` + fixed-positioning pattern so it escapes the overflow container.

Because **htmx does not re-scan Alpine-teleported nodes**, the dropdown's `hx-post`/`hx-get` controls (role change, remove, manage workspaces) would be left unwired on htmx-swapped rows and fall back to native form submission. Added `x-init="window.htmx && htmx.process($el)"` on the teleported menu so htmx re-wires them every time Alpine initializes the node (caught & fixed via Codex review).

## 3. Drafts — per-row delete menu
Added a kebab menu (Edit + Delete) to each Drafts-table row. Delete opens a confirmation modal that deletes the draft via the existing `composer:post_delete` endpoint and removes the row through the existing `post-deleted` → `reloadTab()` flow (an htmx partial swap, **no full page reload**).

The Queue tab's kebab + modal were extracted into shared partials (`_post_actions_menu.html`, `_delete_post_modal.html`) reused by both tabs. While doing so, fixed a latent `x-show` + `:style` conflict that could leave the teleported menu stuck at `display:none` — visibility is now driven through a single `:style` binding (this also hardens the existing Queue menu).

## Notes for reviewers
- All interactivity uses **Alpine + htmx only** — no inline `onclick`/`<script>`, so it stays within the project CSP (`'unsafe-eval'` for Alpine, nonce'd scripts only).
- The `publish_queue.html` diff is mostly a move: ~120 lines of inline kebab/modal markup replaced by two `{% include %}`s of the new shared partials. Behavior is unchanged.
- Verified end-to-end in a local browser against a copy of the dev DB: inbox banners gone (feed intact); members dropdown teleported & unclipped, role-change htmx form still wired after a row swap; drafts kebab → Delete → confirm → row removed without full reload; Queue tab unaffected. No CSP violations in console on any page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)