### PR TITLE
Resolve queue & recurrence schedule times in the workspace timezone

### DIFF
--- a/apps/calendar/services.py
+++ b/apps/calendar/services.py
@@ -1,5 +1,6 @@
 """Queue scheduling services for the Content Calendar (F-2.3)."""
 
+import zoneinfo
 from datetime import datetime, time, timedelta
 
 from django.db import models
@@ -44,14 +45,23 @@ def _next_slot_datetimes(social_account, after_dt, count=30):
 
     Starting from `after_dt`, walks forward through the week to find
     upcoming slot times based on the account's PostingSlot configuration.
+
+    Slot times are naive wall-clock times in the account's workspace timezone
+    (see ``PostingSlot.time``), so they are resolved in that zone regardless of
+    the tzinfo carried by ``after_dt`` — the caller's baseline only sets the
+    "not before" instant. ``after_dt`` is always timezone-aware (callers pass
+    ``timezone.now()`` or a tz-aware floor).
     """
     slots = PostingSlot.objects.filter(social_account=social_account, is_active=True).order_by("day_of_week", "time")
     if not slots.exists():
         return []
 
+    ws_tz = zoneinfo.ZoneInfo(social_account.workspace.effective_timezone or "UTC")
+    after_local = after_dt.astimezone(ws_tz)
+
     slot_list = list(slots)
     results = []
-    current_date = after_dt.date()
+    current_date = after_local.date()
 
     # Walk up to 60 days forward to find enough slots
     for day_offset in range(60):
@@ -62,10 +72,9 @@ def _next_slot_datetimes(social_account, after_dt, count=30):
             if slot.day_of_week != weekday:
                 continue
 
-            slot_dt = datetime.combine(check_date, slot.time)
-            if after_dt.tzinfo:
-                slot_dt = slot_dt.replace(tzinfo=after_dt.tzinfo)
-
+            # Interpret the slot's wall-clock time in the workspace zone (DST
+            # offsets resolve per-date), then compare as instants (both aware).
+            slot_dt = datetime.combine(check_date, slot.time).replace(tzinfo=ws_tz)
             if slot_dt <= after_dt:
                 continue
 

--- a/apps/calendar/tasks.py
+++ b/apps/calendar/tasks.py
@@ -1,7 +1,8 @@
 """Background tasks for the Content Calendar (F-2.3)."""
 
 import logging
-from datetime import timedelta
+import zoneinfo
+from datetime import datetime, timedelta
 
 from dateutil.relativedelta import relativedelta
 from django.utils import timezone
@@ -24,7 +25,6 @@ def generate_recurring_posts():
     """
     rules = RecurrenceRule.objects.filter(is_active=True).select_related("post")
     now = timezone.now()
-    cutoff = now.date() + timedelta(days=LOOKAHEAD_DAYS)
     generated_total = 0
 
     for rule in rules:
@@ -32,38 +32,44 @@ def generate_recurring_posts():
         if not source.scheduled_at:
             continue
 
-        # Respect end_date
+        # Recurrence dates and times are computed in the post's workspace
+        # timezone so the wall-clock time is preserved across DST boundaries
+        # (a 09:00-local series stays at 09:00 local, not drifting by the DST
+        # offset). ``scheduled_at`` is stored as UTC, so convert it back first.
+        ws_tz = zoneinfo.ZoneInfo(source.workspace.effective_timezone or "UTC")
+        local_start = source.scheduled_at.astimezone(ws_tz)
+        base_date = local_start.date()
+        base_time = local_start.time()
+        today_local = now.astimezone(ws_tz).date()
+
+        # Bound the lookahead horizon in the workspace's local calendar so it
+        # lands on the same local day for every timezone, not the UTC date.
+        cutoff = today_local + timedelta(days=LOOKAHEAD_DAYS)
         end = rule.end_date or cutoff
         if end > cutoff:
             end = cutoff
 
-        # Compute recurrence dates
-        base_date = source.scheduled_at.date()
-        base_time = source.scheduled_at.time()
-        base_tz = source.scheduled_at.tzinfo
-
         dates = _compute_recurrence_dates(base_date, rule.frequency, rule.interval, end)
 
-        # Filter out dates already generated (posts with same source scheduled time)
-        existing_dates = set(
-            Post.objects.filter(
-                workspace=source.workspace,
-                caption=source.caption,
-                scheduled_at__date__in=dates,
+        # Filter out dates already generated (posts with same source caption).
+        # Extract dates in the workspace zone so they line up with the ws-local
+        # recurrence dates above rather than UTC calendar days.
+        with timezone.override(ws_tz):
+            existing_dates = set(
+                Post.objects.filter(
+                    workspace=source.workspace,
+                    caption=source.caption,
+                    scheduled_at__date__in=dates,
+                )
+                .exclude(id=source.id)
+                .values_list("scheduled_at__date", flat=True)
             )
-            .exclude(id=source.id)
-            .values_list("scheduled_at__date", flat=True)
-        )
 
         for d in dates:
-            if d in existing_dates or d <= now.date():
+            if d in existing_dates or d <= today_local:
                 continue
 
-            from datetime import datetime
-
-            scheduled_dt = datetime.combine(d, base_time)
-            if base_tz:
-                scheduled_dt = scheduled_dt.replace(tzinfo=base_tz)
+            scheduled_dt = datetime.combine(d, base_time).replace(tzinfo=ws_tz)
 
             # Clone the post
             new_post = Post.objects.create(

--- a/apps/calendar/tests.py
+++ b/apps/calendar/tests.py
@@ -1,13 +1,18 @@
 """Tests for the Content Calendar app (T-1A.2)."""
 
-from datetime import time
+import zoneinfo
+from datetime import date, datetime, time
+from unittest.mock import patch
 
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 
 from apps.accounts.models import User
-from apps.calendar.models import PostingSlot
+from apps.calendar.models import PostingSlot, Queue, QueueEntry, RecurrenceRule
+from apps.calendar.services import add_to_queue
+from apps.calendar.tasks import generate_recurring_posts
+from apps.composer.models import PlatformPost, Post
 from apps.members.models import OrgMembership, WorkspaceMembership
 from apps.organizations.models import Organization
 from apps.social_accounts.models import SocialAccount
@@ -235,3 +240,149 @@ class PostingSlotCrossWorkspaceTests(TestCase):
         self.assertEqual(response.status_code, 403)
         # The slot must survive an unauthorized delete attempt.
         self.assertTrue(PostingSlot.objects.filter(id=self.slot_a.id).exists())
+
+
+class QueueSlotTimezoneTests(TestCase):
+    """Queue slot assignment must resolve PostingSlot times in the workspace
+    timezone (which falls back to the org's default_timezone), not UTC.
+
+    Regression for the bug where ``assign_queue_slots`` passed ``timezone.now()``
+    (UTC) as the baseline, so a "09:00" slot was scheduled at 09:00 UTC instead
+    of 09:00 in the org's local zone.
+    """
+
+    def setUp(self):
+        self.org = Organization.objects.create(name="TZ Org", default_timezone="America/New_York")
+        self.workspace = Workspace.objects.create(organization=self.org, name="TZ WS")
+        self.account = SocialAccount.objects.create(
+            workspace=self.workspace,
+            platform="instagram",
+            account_platform_id="ig-tz",
+            account_name="TZ",
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+        self.queue = Queue.objects.create(
+            workspace=self.workspace,
+            name="TZ Queue",
+            social_account=self.account,
+        )
+        # A 09:00 slot on every weekday, so "the next available slot" is always
+        # a 09:00 local time no matter what day/time the test actually runs.
+        for day in range(7):
+            PostingSlot.objects.create(social_account=self.account, day_of_week=day, time=time(9, 0))
+
+    def test_queue_slot_resolved_in_workspace_timezone(self):
+        post = Post.objects.create(workspace=self.workspace, caption="queued")
+        PlatformPost.objects.create(post=post, social_account=self.account)
+
+        add_to_queue(post, self.queue)
+
+        ny = zoneinfo.ZoneInfo("America/New_York")
+        entry = QueueEntry.objects.get(queue=self.queue, post=post)
+        self.assertIsNotNone(entry.assigned_slot_datetime)
+
+        local = entry.assigned_slot_datetime.astimezone(ny)
+        self.assertEqual((local.hour, local.minute), (9, 0))
+        # The stored instant is 09:00 NY expressed in UTC (13:00 EST / 14:00
+        # EDT) — never a literal 09:00 UTC, which is the pre-fix bug.
+        utc = entry.assigned_slot_datetime.astimezone(zoneinfo.ZoneInfo("UTC"))
+        self.assertIn(utc.hour, (13, 14))
+
+        # The per-platform scheduled_at (what the publisher fires on) matches.
+        pp = PlatformPost.objects.get(post=post, social_account=self.account)
+        self.assertEqual(pp.scheduled_at, entry.assigned_slot_datetime)
+
+    def test_workspace_override_takes_precedence_over_org(self):
+        # An explicit workspace timezone overrides the org default.
+        self.workspace.timezone = "Asia/Tokyo"
+        self.workspace.save(update_fields=["timezone"])
+        post = Post.objects.create(workspace=self.workspace, caption="queued-tokyo")
+        PlatformPost.objects.create(post=post, social_account=self.account)
+
+        add_to_queue(post, self.queue)
+
+        entry = QueueEntry.objects.get(queue=self.queue, post=post)
+        local = entry.assigned_slot_datetime.astimezone(zoneinfo.ZoneInfo("Asia/Tokyo"))
+        self.assertEqual((local.hour, local.minute), (9, 0))
+
+
+class RecurringPostTimezoneTests(TestCase):
+    """``generate_recurring_posts`` must preserve the source post's *local*
+    wall-clock time across DST boundaries, not drift by the UTC offset.
+
+    The task is not yet wired to run in production, but its time math must be
+    correct for when recurrence generation is enabled.
+    """
+
+    def test_recurrence_preserves_local_time_across_dst(self):
+        org = Organization.objects.create(name="DST Org", default_timezone="America/New_York")
+        ws = Workspace.objects.create(organization=org, name="DST WS")
+        ny = zoneinfo.ZoneInfo("America/New_York")
+
+        # Source scheduled 09:00 NY on 2026-03-02 (EST, before the 2026-03-08
+        # spring-forward). Every weekly recurrence then lands in EDT.
+        source = Post.objects.create(
+            workspace=ws,
+            caption="dst-recurrence",
+            scheduled_at=datetime(2026, 3, 2, 9, 0, tzinfo=ny),
+        )
+        RecurrenceRule.objects.create(
+            post=source,
+            frequency=RecurrenceRule.Frequency.WEEKLY,
+            interval=1,
+            end_date=date(2026, 4, 30),
+        )
+
+        fixed_now = datetime(2026, 3, 1, 12, 0, tzinfo=zoneinfo.ZoneInfo("UTC"))
+        with patch("apps.calendar.tasks.timezone.now", return_value=fixed_now):
+            generated = generate_recurring_posts()
+
+        self.assertGreater(generated, 0)
+        clones = list(Post.objects.filter(workspace=ws, caption="dst-recurrence").exclude(id=source.id))
+        self.assertTrue(clones)
+        for clone in clones:
+            local = clone.scheduled_at.astimezone(ny)
+            self.assertEqual(
+                (local.hour, local.minute),
+                (9, 0),
+                msg=f"clone on {local.date()} drifted to {local.time()} (expected 09:00 local)",
+            )
+        # Confirms at least one recurrence is past the DST transition, so the
+        # assertion above actually exercises the boundary.
+        self.assertTrue(any(c.scheduled_at.astimezone(ny).date() >= date(2026, 3, 9) for c in clones))
+
+    def test_lookahead_horizon_uses_workspace_local_date(self):
+        # The LOOKAHEAD_DAYS horizon must be measured in the workspace's local
+        # calendar, not UTC. Otherwise a workspace whose local date differs from
+        # the UTC date at run time gets a horizon off by one local day.
+        org = Organization.objects.create(name="Horizon Org", default_timezone="Asia/Tokyo")
+        ws = Workspace.objects.create(organization=org, name="Horizon WS")
+        tokyo = zoneinfo.ZoneInfo("Asia/Tokyo")
+
+        source = Post.objects.create(
+            workspace=ws,
+            caption="horizon",
+            scheduled_at=datetime(2026, 6, 16, 9, 0, tzinfo=tokyo),
+        )
+        RecurrenceRule.objects.create(
+            post=source,
+            frequency=RecurrenceRule.Frequency.DAILY,
+            interval=1,
+        )
+
+        # 2026-06-16 20:00 UTC is already 2026-06-17 in Tokyo (UTC+9), so the
+        # workspace-local "today" is one day ahead of the UTC date. Shrink the
+        # horizon to keep the generated set tiny.
+        fixed_now = datetime(2026, 6, 16, 20, 0, tzinfo=zoneinfo.ZoneInfo("UTC"))
+        with (
+            patch("apps.calendar.tasks.timezone.now", return_value=fixed_now),
+            patch("apps.calendar.tasks.LOOKAHEAD_DAYS", 3),
+        ):
+            generate_recurring_posts()
+
+        clones = Post.objects.filter(workspace=ws, caption="horizon").exclude(id=source.id)
+        local_dates = sorted(c.scheduled_at.astimezone(tokyo).date() for c in clones)
+        self.assertTrue(local_dates)
+        # today_local = 2026-06-17, horizon +3 local days → furthest is 2026-06-20.
+        # A UTC-based cutoff (the pre-fix bug) would stop a day short at 06-19.
+        self.assertEqual(local_dates[-1], date(2026, 6, 20))


### PR DESCRIPTION
## What does this PR do?

Resolves posting-queue slot times and recurring-post times in the **workspace timezone** (which falls back to the organization's `default_timezone`) instead of UTC.

- `_next_slot_datetimes` (`apps/calendar/services.py`) now derives the zone from the account's workspace and zones each slot in it. Previously `assign_queue_slots` passed `timezone.now()` (UTC) as the baseline and the helper just stamped the naive slot time with that tzinfo, so a "09:00" slot was scheduled at 09:00 **UTC**. This is the live path for **Add to queue** / **Add to queue (priority)** and queue **reordering**.
- `generate_recurring_posts` (`apps/calendar/tasks.py`) now does all date/time math — base time, dedup query, lookahead horizon, and the "already past" skip — in the post's workspace zone.

## Why?

On the social-account page, users set recurring posting slots (e.g. "Monday 09:00") that are documented as workspace-local times. The scheduling code interpreted them as UTC, so for any org not on UTC, queued posts published at the wrong wall-clock time, off by the org's UTC offset (e.g. a 09:00 Europe/Berlin slot fired at 11:00 local in summer). The publisher fires on `scheduled_at <= now()`, so the stored instant directly determines publish time.

The recurrence task shared the same root cause in two forms: it cloned recurrences from the source's UTC time-of-day (drifting by the DST offset when a series crosses a DST boundary) and bounded the 90-day lookahead by the UTC date (off by one local day for non-UTC workspaces). That task is not yet wired to a scheduler, so the bug was latent — fixed now so it is correct when enabled.

## How to test

```
docker start brightbean-studio-postgres-1
pytest apps/calendar
```

New regression tests in `apps/calendar/tests.py`:
- `QueueSlotTimezoneTests` — a 09:00 slot for a New York org resolves to 09:00 NY (13:00/14:00 UTC), and an explicit workspace timezone (Tokyo) overrides the org default.
- `RecurringPostTimezoneTests::test_recurrence_preserves_local_time_across_dst` — a weekly 09:00-local series stays at 09:00 local across the March DST transition.
- `RecurringPostTimezoneTests::test_lookahead_horizon_uses_workspace_local_date` — the lookahead horizon is measured in workspace-local days, not the UTC date.

## Checklist

- [x] Tests pass (`pytest apps/calendar` — 14 passed; `pytest apps/composer` — 83 passed, since it shares the `_next_slot_datetimes` helper)
- [x] Lint passes (`ruff check .` and `ruff format --check .`)
- [x] Documentation updated (if applicable) — n/a (no user-facing behavior docs; `PostingSlot.time` help text already states "in workspace timezone")

🤖 Generated with [Claude Code](https://claude.com/claude-code)
