### PR TITLE
fix: Use POST for composer live preview

### DIFF
--- a/apps/composer/tests/test_preview.py
+++ b/apps/composer/tests/test_preview.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.test import RequestFactory
+from django.urls import reverse
+
+from apps.composer.views import preview
+from apps.social_accounts.models import SocialAccount
+
+from .test_unsplash import ComposerTestCase
+
+
+class ComposerPreviewTests(ComposerTestCase):
+    def setUp(self):
+        super().setUp()
+        self.factory = RequestFactory()
+        self.preview_url = reverse("composer:preview", kwargs={"workspace_id": self.workspace.id})
+        self.account = SocialAccount.objects.create(
+            workspace=self.workspace,
+            platform="facebook",
+            account_platform_id="facebook-page-1",
+            account_name="Facebook Page",
+        )
+
+    def _preview_post(self, data):
+        request = self.factory.post(self.preview_url, data)
+        request.user = self.user
+        SessionMiddleware(lambda req: None).process_request(request)
+        request.session.save()
+        return preview(request, self.workspace.id)
+
+    def test_compose_page_posts_live_preview_form_data(self):
+        template = Path("templates/composer/compose.html").read_text()
+
+        self.assertIn("hx-post=\"{% url 'composer:preview' workspace_id=workspace.id %}\"", template)
+        self.assertNotIn("hx-get=\"{% url 'composer:preview' workspace_id=workspace.id %}\"", template)
+
+    def test_preview_accepts_large_caption_in_post_body(self):
+        caption = "Long preview caption. " * 300
+
+        response = self._preview_post(
+            {
+                "title": "Preview title",
+                "caption": caption,
+                "selected_accounts": str(self.account.id),
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn("Facebook Page", content)
+        self.assertIn("6600/63206", content)
+        self.assertIn("Long preview caption. Long preview caption.", content)
+
+    def test_preview_rejects_get_requests(self):
+        response = self.client.get(
+            self.preview_url,
+            {
+                "caption": "This belongs in the request body.",
+                "selected_accounts": str(self.account.id),
+            },
+        )
+
+        self.assertEqual(response.status_code, 405)

--- a/apps/composer/views.py
+++ b/apps/composer/views.py
@@ -1008,7 +1008,7 @@ def autosave(request, workspace_id, post_id=None):
 
 
 @login_required
-@require_GET
+@require_POST
 def preview(request, workspace_id):
     """Live preview endpoint - renders platform-specific preview from form state.
 
@@ -1016,10 +1016,10 @@ def preview(request, workspace_id):
     Stateless - no DB queries except social account lookup.
     """
     workspace = _get_workspace(request, workspace_id)
-    title = request.GET.get("title", "")
-    caption = request.GET.get("caption", "")
-    first_comment = request.GET.get("first_comment", "")
-    selected_ids = _parse_selected_account_ids(request.GET.get("selected_accounts", ""))
+    title = request.POST.get("title", "")
+    caption = request.POST.get("caption", "")
+    first_comment = request.POST.get("first_comment", "")
+    selected_ids = _parse_selected_account_ids(request.POST.get("selected_accounts", ""))
 
     # Build preview data per platform
     previews = []
@@ -1031,8 +1031,8 @@ def preview(request, workspace_id):
         for account in accounts:
             override_title_key = f"override_title_{account.id}"
             override_key = f"override_caption_{account.id}"
-            effective_title = request.GET.get(override_title_key, "") or title
-            effective_caption = request.GET.get(override_key, "") or caption
+            effective_title = request.POST.get(override_title_key, "") or title
+            effective_caption = request.POST.get(override_key, "") or caption
             char_limit = account.char_limit
             field_config = account.field_config
             previews.append(
@@ -1055,7 +1055,7 @@ def preview(request, workspace_id):
     from apps.media_library.models import MediaAsset
 
     media_items = []
-    post_id_str = request.GET.get("_autosave_post_id", "")
+    post_id_str = request.POST.get("_autosave_post_id", "")
 
     if post_id_str:
         try:

--- a/templates/composer/compose.html
+++ b/templates/composer/compose.html
@@ -1440,7 +1440,7 @@
         </div>
 
         <div id="preview-panel" class="flex-1 overflow-y-auto p-4 space-y-4 panel-scroll"
-             hx-get="{% url 'composer:preview' workspace_id=workspace.id %}"
+             hx-post="{% url 'composer:preview' workspace_id=workspace.id %}"
              hx-trigger="previewUpdate from:body"
              hx-include="#composer-form"
              hx-vals='js:{"title": document.querySelector("input[name=title]")?.value || "", "caption": document.querySelector("[name=caption]")?.value || "", "selected_accounts": document.querySelector("[name=selected_accounts]")?.value || "", "_autosave_post_id": document.querySelector("[name=_autosave_post_id]")?.value || ""}'>


### PR DESCRIPTION
## Summary

Switch the composer live preview request from GET to POST so large captions and form payloads are sent in the request body instead of the URL.

## Root Cause

The preview panel included the full composer form in an HTMX GET request. Long captions could push the request line beyond the server limit and trigger errors like:

```text
Invalid request from ip=100.64.0.13: Request Line is too large (8192 > 4094)
```

## Changes

- Change the composer preview HTMX trigger from `hx-get` to `hx-post`.
- Update the `preview` view to require POST and read form state from `request.POST`.
- Add focused regression tests for POST previews, large caption handling, and GET rejection.

## Validation

- `.venv/bin/python -m pytest apps/composer/tests/test_preview.py -vv --tb=short`
- `.venv/bin/python -m ruff check apps/composer/views.py apps/composer/tests/test_preview.py`
- `.venv/bin/python -m ruff format --check apps/composer/views.py apps/composer/tests/test_preview.py`