### PR TITLE
fix: Fix Instagram account analytics metrics

### DIFF
--- a/apps/analytics/tasks.py
+++ b/apps/analytics/tasks.py
@@ -253,6 +253,8 @@ def _resolve_provider(account):
             }
         except MastodonAppRegistration.DoesNotExist:
             pass
+    elif account.platform == "instagram":
+        credentials = {**credentials, "ig_user_id": account.account_platform_id}
     return get_provider(account.platform, credentials)
 
 

--- a/apps/api_keys/tests/test_views.py
+++ b/apps/api_keys/tests/test_views.py
@@ -513,9 +513,7 @@ class TestEditKey:
         r = member_client.post(reverse("api_keys:edit", args=[uuid4()]))
         assert r.status_code == 403
 
-    def test_success_updates_permissions_accounts_and_expiry(
-        self, admin_client, admin_user, workspace, social_account
-    ):
+    def test_success_updates_permissions_accounts_and_expiry(self, admin_client, admin_user, workspace, social_account):
         from apps.social_accounts.models import SocialAccount
 
         second = SocialAccount.objects.create(
@@ -600,9 +598,7 @@ class TestEditKey:
             name="Foreign Edit",
             tos_accepted_at=timezone.now(),
         )
-        OrgMembership.objects.create(
-            user=foreign_user, organization=other_org, org_role=OrgMembership.OrgRole.OWNER
-        )
+        OrgMembership.objects.create(user=foreign_user, organization=other_org, org_role=OrgMembership.OrgRole.OWNER)
         WorkspaceMembership.objects.create(
             user=foreign_user,
             workspace=foreign_ws,

--- a/apps/api_keys/views.py
+++ b/apps/api_keys/views.py
@@ -336,6 +336,7 @@ def _parse_expires_at(expires_at_str: str):
         # would otherwise hand back a naive *midnight*, expiring it a day early.
         dt = datetime.combine(date_only, time.max)
 
+    assert dt is not None
     if timezone.is_naive(dt):
         dt = timezone.make_aware(dt, timezone.get_current_timezone())
     return dt, None

--- a/apps/composer/tests/test_preview.py
+++ b/apps/composer/tests/test_preview.py
@@ -1,0 +1,64 @@
+from pathlib import Path
+
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.test import RequestFactory
+from django.urls import reverse
+
+from apps.composer.views import preview
+from apps.social_accounts.models import SocialAccount
+
+from .test_unsplash import ComposerTestCase
+
+
+class ComposerPreviewTests(ComposerTestCase):
+    def setUp(self):
+        super().setUp()
+        self.factory = RequestFactory()
+        self.preview_url = reverse("composer:preview", kwargs={"workspace_id": self.workspace.id})
+        self.account = SocialAccount.objects.create(
+            workspace=self.workspace,
+            platform="facebook",
+            account_platform_id="facebook-page-1",
+            account_name="Facebook Page",
+        )
+
+    def _preview_post(self, data):
+        request = self.factory.post(self.preview_url, data)
+        request.user = self.user
+        SessionMiddleware(lambda req: None).process_request(request)
+        request.session.save()
+        return preview(request, self.workspace.id)
+
+    def test_compose_page_posts_live_preview_form_data(self):
+        template = Path("templates/composer/compose.html").read_text()
+
+        self.assertIn("hx-post=\"{% url 'composer:preview' workspace_id=workspace.id %}\"", template)
+        self.assertNotIn("hx-get=\"{% url 'composer:preview' workspace_id=workspace.id %}\"", template)
+
+    def test_preview_accepts_large_caption_in_post_body(self):
+        caption = "Long preview caption. " * 300
+
+        response = self._preview_post(
+            {
+                "title": "Preview title",
+                "caption": caption,
+                "selected_accounts": str(self.account.id),
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn("Facebook Page", content)
+        self.assertIn("6600/63206", content)
+        self.assertIn("Long preview caption. Long preview caption.", content)
+
+    def test_preview_rejects_get_requests(self):
+        response = self.client.get(
+            self.preview_url,
+            {
+                "caption": "This belongs in the request body.",
+                "selected_accounts": str(self.account.id),
+            },
+        )
+
+        self.assertEqual(response.status_code, 405)

--- a/apps/composer/views.py
+++ b/apps/composer/views.py
@@ -1008,7 +1008,7 @@ def autosave(request, workspace_id, post_id=None):
 
 
 @login_required
-@require_GET
+@require_POST
 def preview(request, workspace_id):
     """Live preview endpoint - renders platform-specific preview from form state.
 
@@ -1016,10 +1016,10 @@ def preview(request, workspace_id):
     Stateless - no DB queries except social account lookup.
     """
     workspace = _get_workspace(request, workspace_id)
-    title = request.GET.get("title", "")
-    caption = request.GET.get("caption", "")
-    first_comment = request.GET.get("first_comment", "")
-    selected_ids = _parse_selected_account_ids(request.GET.get("selected_accounts", ""))
+    title = request.POST.get("title", "")
+    caption = request.POST.get("caption", "")
+    first_comment = request.POST.get("first_comment", "")
+    selected_ids = _parse_selected_account_ids(request.POST.get("selected_accounts", ""))
 
     # Build preview data per platform
     previews = []
@@ -1031,8 +1031,8 @@ def preview(request, workspace_id):
         for account in accounts:
             override_title_key = f"override_title_{account.id}"
             override_key = f"override_caption_{account.id}"
-            effective_title = request.GET.get(override_title_key, "") or title
-            effective_caption = request.GET.get(override_key, "") or caption
+            effective_title = request.POST.get(override_title_key, "") or title
+            effective_caption = request.POST.get(override_key, "") or caption
             char_limit = account.char_limit
             field_config = account.field_config
             previews.append(
@@ -1055,7 +1055,7 @@ def preview(request, workspace_id):
     from apps.media_library.models import MediaAsset
 
     media_items = []
-    post_id_str = request.GET.get("_autosave_post_id", "")
+    post_id_str = request.POST.get("_autosave_post_id", "")
 
     if post_id_str:
         try:

--- a/apps/members/tests/test_role_hierarchy.py
+++ b/apps/members/tests/test_role_hierarchy.py
@@ -4,12 +4,14 @@ Covers V1 from the May-2026 security audit: an org admin must not be able to
 invite users with org/workspace roles above their own, nor demote an org owner.
 """
 
+from django.template.loader import render_to_string
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 
 from apps.accounts.models import User
 from apps.members.models import Invitation, OrgMembership, WorkspaceMembership
+from apps.members.views import _org_role_choices_for
 from apps.organizations.models import Organization
 from apps.workspaces.models import Workspace
 
@@ -161,6 +163,54 @@ class OrgRoleChoiceGatingTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'value="admin"')
         self.assertContains(response, 'value="member"')
+
+
+class ManageWorkspaceModalTargetTests(TestCase):
+    """GET /members/ renders one HTMX modal target per manageable member."""
+
+    def setUp(self):
+        self.org = Organization.objects.create(name="Test Org")
+        self.owner = _make_user("owner@example.com")
+        self.member_a = _make_user("member-a@example.com")
+        self.member_b = _make_user("member-b@example.com")
+        OrgMembership.objects.create(user=self.owner, organization=self.org, org_role="owner")
+        self.member_a_membership = OrgMembership.objects.create(
+            user=self.member_a,
+            organization=self.org,
+            org_role="member",
+        )
+        self.member_b_membership = OrgMembership.objects.create(
+            user=self.member_b,
+            organization=self.org,
+            org_role="member",
+        )
+        self.url = reverse("members:list")
+
+    def test_manage_workspace_targets_are_unique_per_member(self):
+        owner_membership = OrgMembership.objects.get(user=self.owner, organization=self.org)
+        html = "".join(
+            render_to_string(
+                "members/partials/member_row.html",
+                {
+                    "member": {
+                        "membership": membership,
+                        "user": membership.user,
+                        "workspace_memberships": [],
+                    },
+                    "is_admin": True,
+                    "current_user": self.owner,
+                    "workspace_role_choices": WorkspaceMembership.WorkspaceRole.choices,
+                    "org_role_choices": _org_role_choices_for(owner_membership),
+                },
+            )
+            for membership in (self.member_a_membership, self.member_b_membership)
+        )
+
+        self.assertNotIn('id="ws-modal-content"', html)
+        for membership in (self.member_a_membership, self.member_b_membership):
+            target_id = f"ws-modal-content-{membership.id}"
+            self.assertIn(f'hx-target="#{target_id}"', html)
+            self.assertIn(f'id="{target_id}"', html)
 
 
 class UpdateMemberRoleHierarchyTests(TestCase):

--- a/apps/publisher/engine.py
+++ b/apps/publisher/engine.py
@@ -337,6 +337,10 @@ class PublishEngine:
             if platform == "facebook" and "page_id" not in extra:
                 extra["page_id"] = account.account_platform_id
 
+            # Inject Instagram user ID for Facebook-login Instagram accounts.
+            if platform == "instagram" and "ig_user_id" not in extra:
+                extra["ig_user_id"] = account.account_platform_id
+
             # Inject org author URN for LinkedIn Company Page.
             if platform == "linkedin_company" and "author" not in extra:
                 extra["author"] = f"urn:li:organization:{account.account_platform_id}"

--- a/apps/publisher/engine.py
+++ b/apps/publisher/engine.py
@@ -74,6 +74,8 @@ def _resolve_publish_credentials(account):
             )
     elif platform == "bluesky" and account.instance_url:
         credentials["pds_url"] = account.instance_url
+    elif platform == "instagram":
+        credentials["ig_user_id"] = account.account_platform_id
 
     return credentials
 

--- a/apps/publisher/tests.py
+++ b/apps/publisher/tests.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 from django.test import SimpleTestCase, TestCase
 from django.utils import timezone
 
-from apps.publisher.engine import MAX_RETRIES, RETRY_BACKOFF, PublishEngine
+from apps.publisher.engine import MAX_RETRIES, RETRY_BACKOFF, PublishEngine, _resolve_publish_credentials
 from apps.publisher.models import PublishLog, RateLimitState
 from providers.types import AuthType, PostType, PublishResult
 
@@ -194,6 +194,19 @@ class DispatchExtraInjectionTest(SimpleTestCase):
 
         _access_token, content = mock_provider.publish_post.call_args.args
         self.assertNotIn("author", content.extra)
+
+
+class ResolvePublishCredentialsTest(SimpleTestCase):
+    @patch("apps.publisher.engine.resolve_platform_credentials", return_value={"client_id": "id"})
+    def test_instagram_credentials_include_selected_ig_user_id(self, _mock_resolve):
+        account = MagicMock()
+        account.platform = "instagram"
+        account.account_platform_id = "17841400000000000"
+        account.workspace.organization_id = "org-1"
+
+        credentials = _resolve_publish_credentials(account)
+
+        self.assertEqual(credentials["ig_user_id"], "17841400000000000")
 
 
 class NonRetryableFailureTest(TestCase):

--- a/apps/publisher/tests.py
+++ b/apps/publisher/tests.py
@@ -150,6 +150,21 @@ class DispatchExtraInjectionTest(SimpleTestCase):
 
     @patch("apps.publisher.engine.get_provider")
     @patch("apps.publisher.engine._resolve_publish_credentials", return_value={})
+    def test_injects_ig_user_id_for_instagram(self, _mock_creds, mock_get_provider):
+        engine, platform_post, mock_provider = _build_dispatch_mocks(
+            platform="instagram",
+            account_platform_id="17841400000000000",
+        )
+        mock_get_provider.return_value = mock_provider
+
+        engine._dispatch_to_provider(platform_post)
+
+        mock_provider.publish_post.assert_called_once()
+        _access_token, content = mock_provider.publish_post.call_args.args
+        self.assertEqual(content.extra.get("ig_user_id"), "17841400000000000")
+
+    @patch("apps.publisher.engine.get_provider")
+    @patch("apps.publisher.engine._resolve_publish_credentials", return_value={})
     def test_does_not_overwrite_explicit_author(self, _mock_creds, mock_get_provider):
         # When the caller has already set extra["author"], the engine must not
         # overwrite it — important for callers that pass a different URN.

--- a/apps/social_accounts/tasks.py
+++ b/apps/social_accounts/tasks.py
@@ -46,6 +46,8 @@ def check_social_account_health(account_id: str):
             }
         except MastodonAppRegistration.DoesNotExist:
             pass
+    elif account.platform == PlatformCredential.Platform.INSTAGRAM:
+        credentials = {**credentials, "ig_user_id": account.account_platform_id}
 
     try:
         provider = get_provider(account.platform, credentials)

--- a/apps/social_accounts/tests/test_tasks.py
+++ b/apps/social_accounts/tests/test_tasks.py
@@ -65,6 +65,30 @@ class TestCheckSocialAccountHealth:
         assert account.last_error == ""
 
     @patch("providers.get_provider")
+    def test_instagram_health_check_passes_selected_ig_user_id(self, mock_get_provider, workspace):
+        account = SocialAccount.objects.create(
+            workspace=workspace,
+            platform="instagram",
+            account_platform_id="17841400000000000",
+            account_name="Brightbean",
+            oauth_access_token="page-token",
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+        mock_provider = MagicMock()
+        mock_provider.get_profile.return_value = _profile(
+            platform_id="17841400000000000",
+            name="Brightbean",
+            handle="brightbean",
+        )
+        mock_get_provider.return_value = mock_provider
+
+        check_social_account_health.now(str(account.id))
+
+        _platform, credentials = mock_get_provider.call_args.args
+        assert credentials["ig_user_id"] == "17841400000000000"
+        mock_provider.get_profile.assert_called_once_with("page-token")
+
+    @patch("providers.get_provider")
     def test_failed_health_check_sets_error(self, mock_get_provider, connected_account):
         mock_provider = MagicMock()
         mock_provider.get_profile.side_effect = Exception("Token expired")

--- a/apps/social_accounts/tests/test_views.py
+++ b/apps/social_accounts/tests/test_views.py
@@ -7,7 +7,8 @@ from django.core import signing
 from django.urls import reverse
 
 from apps.social_accounts.models import SocialAccount
-from apps.social_accounts.views import _sign_state, _unsign_state
+from apps.social_accounts.views import OAUTH_SESSION_KEY, _sign_state, _unsign_state
+from providers.types import OAuthTokens
 
 
 @pytest.fixture
@@ -129,6 +130,35 @@ class TestOAuthCallbackView:
         url = reverse("social_accounts:oauth_callback", kwargs={"platform": "facebook"})
         response = authenticated_client.get(url, {"code": "abc123", "state": "invalid_state"})
         assert response.status_code == 302
+
+    def test_instagram_redirects_to_account_selection(self, authenticated_client, workspace, user):
+        nonce = "nonce-123"
+        state = _sign_state(workspace.id, "instagram", user.id, nonce)
+        session = authenticated_client.session
+        session[OAUTH_SESSION_KEY] = {"nonce": nonce}
+        session.save()
+
+        mock_provider = MagicMock()
+        mock_provider.exchange_code.return_value = OAuthTokens(access_token="user-token", refresh_token="refresh")
+        mock_provider.get_user_pages.return_value = [
+            {
+                "id": "17841400000000000",
+                "name": "Brightbean",
+                "handle": "brightbean",
+                "access_token": "page-token",
+            }
+        ]
+        url = reverse("social_accounts:oauth_callback", kwargs={"platform": "instagram"})
+
+        with patch("apps.social_accounts.views._get_provider_for_platform", return_value=mock_provider):
+            response = authenticated_client.get(url, {"code": "abc123", "state": state})
+
+        assert response.status_code == 302
+        assert response.url == reverse("social_accounts:select_account")
+        mock_provider.get_profile.assert_not_called()
+        page_data = authenticated_client.session["oauth_page_select"]
+        assert page_data["platform"] == "instagram"
+        assert page_data["pages"][0]["id"] == "17841400000000000"
 
 
 @pytest.mark.django_db

--- a/apps/social_accounts/views.py
+++ b/apps/social_accounts/views.py
@@ -349,7 +349,6 @@ def oauth_callback(request, platform):
         provider = _get_provider_for_platform(platform, request.org.id, **extra_creds)
         redirect_uri = redirect_uri_from_request(request)
         tokens = provider.exchange_code(code, redirect_uri)
-        profile = provider.get_profile(tokens.access_token)
 
         # Facebook/Instagram/LinkedIn Company: connect Pages, not personal profiles
         if platform in (
@@ -381,18 +380,27 @@ def oauth_callback(request, platform):
                         "Manage admins, then reconnect."
                     )
                 else:
-                    warning = (
-                        "No Facebook Pages were found for your account. "
-                        "Only Pages can be connected — personal profiles are not "
-                        "supported by the Facebook API. "
-                        "If you expected to see a Page, make sure you have admin "
-                        "access and try removing the app in Facebook Settings \u2192 "
-                        "Business Integrations, then reconnect."
-                    )
+                    if platform == PlatformCredential.Platform.INSTAGRAM:
+                        warning = (
+                            "No Instagram Business accounts were found for your account. "
+                            "Only Instagram Business or Creator accounts linked to a Facebook Page "
+                            "can be connected through this Instagram option. If you expected to "
+                            "see an account, make sure it is linked to a Page you manage, then reconnect."
+                        )
+                    else:
+                        warning = (
+                            "No Facebook Pages were found for your account. "
+                            "Only Pages can be connected — personal profiles are not "
+                            "supported by the Facebook API. "
+                            "If you expected to see a Page, make sure you have admin "
+                            "access and try removing the app in Facebook Settings \u2192 "
+                            "Business Integrations, then reconnect."
+                        )
                 messages.warning(request, warning)
                 return redirect("social_accounts:list", workspace_id=workspace_id)
 
         # Standard single-account flow (non-Facebook/Instagram platforms)
+        profile = provider.get_profile(tokens.access_token)
         _create_or_update_account(
             workspace_id=workspace_id,
             platform=platform,

--- a/providers/instagram.py
+++ b/providers/instagram.py
@@ -416,7 +416,9 @@ class InstagramProvider(SocialProvider):
 
     def get_account_metrics(self, access_token: str, date_range: tuple[datetime, datetime]) -> AccountMetrics:
         ig_user_id = self.credentials.get("ig_user_id", "me")
-        metrics = ["reach", "follower_count", "profile_views", "views"]
+        since = int(date_range[0].timestamp())
+        until = int(date_range[1].timestamp())
+        metrics = ["reach", "follower_count", "profile_views"]
         resp = self._request(
             "GET",
             f"{BASE_URL}/{ig_user_id}/insights",
@@ -424,8 +426,8 @@ class InstagramProvider(SocialProvider):
             params={
                 "metric": ",".join(metrics),
                 "period": "day",
-                "since": int(date_range[0].timestamp()),
-                "until": int(date_range[1].timestamp()),
+                "since": since,
+                "until": until,
             },
         )
         data = resp.json()
@@ -434,6 +436,24 @@ class InstagramProvider(SocialProvider):
             name = entry.get("name", "")
             val = entry.get("values", [{}])[0].get("value", 0)
             values[name] = val
+
+        views_resp = self._request(
+            "GET",
+            f"{BASE_URL}/{ig_user_id}/insights",
+            access_token=access_token,
+            params={
+                "metric": "views",
+                "period": "day",
+                "metric_type": "total_value",
+                "since": since,
+                "until": until,
+            },
+        )
+        views_data = views_resp.json()
+        for entry in views_data.get("data", []):
+            if entry.get("name") == "views":
+                values["views"] = entry.get("total_value", {}).get("value", 0)
+                break
 
         return AccountMetrics(
             reach=values.get("reach", 0),

--- a/providers/instagram.py
+++ b/providers/instagram.py
@@ -416,7 +416,7 @@ class InstagramProvider(SocialProvider):
 
     def get_account_metrics(self, access_token: str, date_range: tuple[datetime, datetime]) -> AccountMetrics:
         ig_user_id = self.credentials.get("ig_user_id", "me")
-        metrics = ["impressions", "reach", "follower_count", "profile_views"]
+        metrics = ["reach", "follower_count", "profile_views", "views"]
         resp = self._request(
             "GET",
             f"{BASE_URL}/{ig_user_id}/insights",
@@ -436,11 +436,13 @@ class InstagramProvider(SocialProvider):
             values[name] = val
 
         return AccountMetrics(
-            impressions=values.get("impressions", 0),
             reach=values.get("reach", 0),
             followers=values.get("follower_count", 0),
             profile_views=values.get("profile_views", 0),
-            extra={"raw_insights": values},
+            extra={
+                "views": values.get("views", 0),
+                "raw_insights": values,
+            },
         )
 
     # ------------------------------------------------------------------

--- a/providers/instagram.py
+++ b/providers/instagram.py
@@ -182,6 +182,64 @@ class InstagramProvider(SocialProvider):
         )
 
     # ------------------------------------------------------------------
+    # Accounts
+    # ------------------------------------------------------------------
+
+    def get_user_pages(self, access_token: str) -> list[dict]:
+        """Fetch linked Instagram Business accounts for Facebook-login OAuth.
+
+        The user authenticates through Facebook, but the connected account in
+        Brightbean should be the Instagram Business account selected from the
+        Facebook Pages the user manages.
+        """
+        resp = self._request(
+            "GET",
+            f"{BASE_URL}/me/accounts",
+            access_token=access_token,
+            params={
+                "fields": (
+                    "id,name,access_token,category,picture,"
+                    "instagram_business_account{id,username,name,profile_picture_url,followers_count}"
+                ),
+            },
+        )
+        data = resp.json()
+        if "error" in data:
+            logger.error("Instagram /me/accounts error: %s", data["error"])
+            raise APIError(
+                f"Failed to fetch Instagram accounts: {data['error'].get('message', 'Unknown error')}",
+                platform=self.platform_name,
+                raw_response=data,
+            )
+
+        accounts: list[dict] = []
+        for page in data.get("data", []):
+            ig_account = page.get("instagram_business_account")
+            if not ig_account:
+                continue
+
+            picture_url = ig_account.get("profile_picture_url")
+            if not picture_url and "picture" in page and "data" in page["picture"]:
+                picture_url = page["picture"]["data"].get("url")
+
+            username = ig_account.get("username", "")
+            name = ig_account.get("name") or username or page.get("name", "")
+            accounts.append(
+                {
+                    "id": str(ig_account["id"]),
+                    "name": name,
+                    "handle": username,
+                    "access_token": page.get("access_token", ""),
+                    "category": page.get("category", ""),
+                    "picture": picture_url,
+                    "followers_count": ig_account.get("followers_count", 0),
+                    "page_id": page.get("id"),
+                    "page_name": page.get("name", ""),
+                }
+            )
+        return accounts
+
+    # ------------------------------------------------------------------
     # Publishing (two-step container flow)
     # ------------------------------------------------------------------
 

--- a/providers/instagram_login.py
+++ b/providers/instagram_login.py
@@ -419,7 +419,7 @@ class InstagramLoginProvider(SocialProvider):
         )
 
     def get_account_metrics(self, access_token: str, date_range: tuple[datetime, datetime]) -> AccountMetrics:
-        metrics = ["impressions", "reach", "follower_count", "profile_views"]
+        metrics = ["reach", "follower_count", "profile_views", "views"]
         resp = self._request(
             "GET",
             f"{API_BASE}/me/insights",
@@ -439,11 +439,13 @@ class InstagramLoginProvider(SocialProvider):
             values[name] = val
 
         return AccountMetrics(
-            impressions=values.get("impressions", 0),
             reach=values.get("reach", 0),
             followers=values.get("follower_count", 0),
             profile_views=values.get("profile_views", 0),
-            extra={"raw_insights": values},
+            extra={
+                "views": values.get("views", 0),
+                "raw_insights": values,
+            },
         )
 
     # ------------------------------------------------------------------

--- a/providers/instagram_login.py
+++ b/providers/instagram_login.py
@@ -419,7 +419,9 @@ class InstagramLoginProvider(SocialProvider):
         )
 
     def get_account_metrics(self, access_token: str, date_range: tuple[datetime, datetime]) -> AccountMetrics:
-        metrics = ["reach", "follower_count", "profile_views", "views"]
+        since = int(date_range[0].timestamp())
+        until = int(date_range[1].timestamp())
+        metrics = ["reach", "follower_count", "profile_views"]
         resp = self._request(
             "GET",
             f"{API_BASE}/me/insights",
@@ -427,8 +429,8 @@ class InstagramLoginProvider(SocialProvider):
             params={
                 "metric": ",".join(metrics),
                 "period": "day",
-                "since": int(date_range[0].timestamp()),
-                "until": int(date_range[1].timestamp()),
+                "since": since,
+                "until": until,
             },
         )
         data = resp.json()
@@ -437,6 +439,24 @@ class InstagramLoginProvider(SocialProvider):
             name = entry.get("name", "")
             val = entry.get("values", [{}])[0].get("value", 0)
             values[name] = val
+
+        views_resp = self._request(
+            "GET",
+            f"{API_BASE}/me/insights",
+            access_token=access_token,
+            params={
+                "metric": "views",
+                "period": "day",
+                "metric_type": "total_value",
+                "since": since,
+                "until": until,
+            },
+        )
+        views_data = views_resp.json()
+        for entry in views_data.get("data", []):
+            if entry.get("name") == "views":
+                values["views"] = entry.get("total_value", {}).get("value", 0)
+                break
 
         return AccountMetrics(
             reach=values.get("reach", 0),

--- a/templates/composer/compose.html
+++ b/templates/composer/compose.html
@@ -1440,7 +1440,7 @@
         </div>
 
         <div id="preview-panel" class="flex-1 overflow-y-auto p-4 space-y-4 panel-scroll"
-             hx-get="{% url 'composer:preview' workspace_id=workspace.id %}"
+             hx-post="{% url 'composer:preview' workspace_id=workspace.id %}"
              hx-trigger="previewUpdate from:body"
              hx-include="#composer-form"
              hx-vals='js:{"title": document.querySelector("input[name=title]")?.value || "", "caption": document.querySelector("[name=caption]")?.value || "", "selected_accounts": document.querySelector("[name=selected_accounts]")?.value || "", "_autosave_post_id": document.querySelector("[name=_autosave_post_id]")?.value || ""}'>

--- a/templates/members/partials/member_row.html
+++ b/templates/members/partials/member_row.html
@@ -78,7 +78,8 @@
                 <!-- Manage Workspaces -->
                 <button @click="showWorkspaces = true; showActions = false"
                         hx-get="{% url 'members:manage_workspaces' membership_id=member.membership.id %}"
-                        hx-target="#ws-modal-content"
+                        hx-target="#ws-modal-content-{{ member.membership.id }}"
+                        hx-swap="innerHTML"
                         class="btn-neutral-surface w-full text-left px-3 py-2 text-sm cursor-pointer transition-colors"
                         style="color: var(--text-primary);">
                     Manage Workspaces
@@ -136,7 +137,7 @@
                         <svg width="20" height="20" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2" stroke-linecap="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
                     </button>
                 </div>
-                <div id="ws-modal-content">
+                <div id="ws-modal-content-{{ member.membership.id }}">
                     <p class="text-sm" style="color: var(--text-tertiary);">Loading...</p>
                 </div>
             </div>

--- a/tests/providers/test_instagram.py
+++ b/tests/providers/test_instagram.py
@@ -1,6 +1,8 @@
+from datetime import UTC, datetime
 from unittest.mock import MagicMock
 
 from providers.instagram import InstagramProvider
+from providers.instagram_login import InstagramLoginProvider
 
 
 def test_get_user_pages_returns_linked_instagram_business_accounts():
@@ -61,3 +63,71 @@ def test_get_user_pages_returns_linked_instagram_business_accounts():
             ),
         },
     )
+
+
+def test_account_metrics_use_current_instagram_insights_metrics():
+    provider = InstagramProvider({"client_id": "id", "client_secret": "secret", "ig_user_id": "ig-1"})
+    provider._request = MagicMock(
+        return_value=MagicMock(
+            json=MagicMock(
+                return_value={
+                    "data": [
+                        {"name": "reach", "values": [{"value": 12}]},
+                        {"name": "follower_count", "values": [{"value": 34}]},
+                        {"name": "profile_views", "values": [{"value": 5}]},
+                        {"name": "views", "values": [{"value": 67}]},
+                    ]
+                }
+            )
+        )
+    )
+
+    metrics = provider.get_account_metrics(
+        "page-token",
+        (
+            datetime(2026, 6, 18, tzinfo=UTC),
+            datetime(2026, 6, 19, tzinfo=UTC),
+        ),
+    )
+
+    assert metrics.impressions == 0
+    assert metrics.reach == 12
+    assert metrics.followers == 34
+    assert metrics.profile_views == 5
+    assert metrics.extra["views"] == 67
+    request_kwargs = provider._request.call_args.kwargs
+    assert request_kwargs["params"]["metric"] == "reach,follower_count,profile_views,views"
+
+
+def test_instagram_login_account_metrics_use_current_insights_metrics():
+    provider = InstagramLoginProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        return_value=MagicMock(
+            json=MagicMock(
+                return_value={
+                    "data": [
+                        {"name": "reach", "values": [{"value": 12}]},
+                        {"name": "follower_count", "values": [{"value": 34}]},
+                        {"name": "profile_views", "values": [{"value": 5}]},
+                        {"name": "views", "values": [{"value": 67}]},
+                    ]
+                }
+            )
+        )
+    )
+
+    metrics = provider.get_account_metrics(
+        "ig-token",
+        (
+            datetime(2026, 6, 18, tzinfo=UTC),
+            datetime(2026, 6, 19, tzinfo=UTC),
+        ),
+    )
+
+    assert metrics.impressions == 0
+    assert metrics.reach == 12
+    assert metrics.followers == 34
+    assert metrics.profile_views == 5
+    assert metrics.extra["views"] == 67
+    request_kwargs = provider._request.call_args.kwargs
+    assert request_kwargs["params"]["metric"] == "reach,follower_count,profile_views,views"

--- a/tests/providers/test_instagram.py
+++ b/tests/providers/test_instagram.py
@@ -1,5 +1,5 @@
 from datetime import UTC, datetime
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 from providers.instagram import InstagramProvider
 from providers.instagram_login import InstagramLoginProvider
@@ -68,18 +68,32 @@ def test_get_user_pages_returns_linked_instagram_business_accounts():
 def test_account_metrics_use_current_instagram_insights_metrics():
     provider = InstagramProvider({"client_id": "id", "client_secret": "secret", "ig_user_id": "ig-1"})
     provider._request = MagicMock(
-        return_value=MagicMock(
-            json=MagicMock(
-                return_value={
-                    "data": [
-                        {"name": "reach", "values": [{"value": 12}]},
-                        {"name": "follower_count", "values": [{"value": 34}]},
-                        {"name": "profile_views", "values": [{"value": 5}]},
-                        {"name": "views", "values": [{"value": 67}]},
-                    ]
-                }
-            )
-        )
+        side_effect=[
+            MagicMock(
+                json=MagicMock(
+                    return_value={
+                        "data": [
+                            {"name": "reach", "values": [{"value": 12}]},
+                            {"name": "follower_count", "values": [{"value": 34}]},
+                            {"name": "profile_views", "values": [{"value": 5}]},
+                        ]
+                    }
+                )
+            ),
+            MagicMock(
+                json=MagicMock(
+                    return_value={
+                        "data": [
+                            {
+                                "name": "views",
+                                "period": "day",
+                                "total_value": {"value": 67},
+                            }
+                        ]
+                    }
+                )
+            ),
+        ]
     )
 
     metrics = provider.get_account_metrics(
@@ -95,25 +109,64 @@ def test_account_metrics_use_current_instagram_insights_metrics():
     assert metrics.followers == 34
     assert metrics.profile_views == 5
     assert metrics.extra["views"] == 67
-    request_kwargs = provider._request.call_args.kwargs
-    assert request_kwargs["params"]["metric"] == "reach,follower_count,profile_views,views"
+    provider._request.assert_has_calls(
+        [
+            call(
+                "GET",
+                "https://graph.facebook.com/v21.0/ig-1/insights",
+                access_token="page-token",
+                params={
+                    "metric": "reach,follower_count,profile_views",
+                    "period": "day",
+                    "since": 1781740800,
+                    "until": 1781827200,
+                },
+            ),
+            call(
+                "GET",
+                "https://graph.facebook.com/v21.0/ig-1/insights",
+                access_token="page-token",
+                params={
+                    "metric": "views",
+                    "period": "day",
+                    "metric_type": "total_value",
+                    "since": 1781740800,
+                    "until": 1781827200,
+                },
+            ),
+        ]
+    )
 
 
 def test_instagram_login_account_metrics_use_current_insights_metrics():
     provider = InstagramLoginProvider({"client_id": "id", "client_secret": "secret"})
     provider._request = MagicMock(
-        return_value=MagicMock(
-            json=MagicMock(
-                return_value={
-                    "data": [
-                        {"name": "reach", "values": [{"value": 12}]},
-                        {"name": "follower_count", "values": [{"value": 34}]},
-                        {"name": "profile_views", "values": [{"value": 5}]},
-                        {"name": "views", "values": [{"value": 67}]},
-                    ]
-                }
-            )
-        )
+        side_effect=[
+            MagicMock(
+                json=MagicMock(
+                    return_value={
+                        "data": [
+                            {"name": "reach", "values": [{"value": 12}]},
+                            {"name": "follower_count", "values": [{"value": 34}]},
+                            {"name": "profile_views", "values": [{"value": 5}]},
+                        ]
+                    }
+                )
+            ),
+            MagicMock(
+                json=MagicMock(
+                    return_value={
+                        "data": [
+                            {
+                                "name": "views",
+                                "period": "day",
+                                "total_value": {"value": 67},
+                            }
+                        ]
+                    }
+                )
+            ),
+        ]
     )
 
     metrics = provider.get_account_metrics(
@@ -129,5 +182,30 @@ def test_instagram_login_account_metrics_use_current_insights_metrics():
     assert metrics.followers == 34
     assert metrics.profile_views == 5
     assert metrics.extra["views"] == 67
-    request_kwargs = provider._request.call_args.kwargs
-    assert request_kwargs["params"]["metric"] == "reach,follower_count,profile_views,views"
+    provider._request.assert_has_calls(
+        [
+            call(
+                "GET",
+                "https://graph.instagram.com/v21.0/me/insights",
+                access_token="ig-token",
+                params={
+                    "metric": "reach,follower_count,profile_views",
+                    "period": "day",
+                    "since": 1781740800,
+                    "until": 1781827200,
+                },
+            ),
+            call(
+                "GET",
+                "https://graph.instagram.com/v21.0/me/insights",
+                access_token="ig-token",
+                params={
+                    "metric": "views",
+                    "period": "day",
+                    "metric_type": "total_value",
+                    "since": 1781740800,
+                    "until": 1781827200,
+                },
+            ),
+        ]
+    )

--- a/tests/providers/test_instagram.py
+++ b/tests/providers/test_instagram.py
@@ -1,0 +1,63 @@
+from unittest.mock import MagicMock
+
+from providers.instagram import InstagramProvider
+
+
+def test_get_user_pages_returns_linked_instagram_business_accounts():
+    provider = InstagramProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        return_value=MagicMock(
+            json=MagicMock(
+                return_value={
+                    "data": [
+                        {
+                            "id": "page-1",
+                            "name": "Facebook Page",
+                            "access_token": "page-token",
+                            "category": "Creator",
+                            "picture": {"data": {"url": "https://example.com/page.jpg"}},
+                            "instagram_business_account": {
+                                "id": "17841400000000000",
+                                "username": "brightbean",
+                                "name": "Brightbean",
+                                "profile_picture_url": "https://example.com/ig.jpg",
+                                "followers_count": 42,
+                            },
+                        },
+                        {
+                            "id": "page-2",
+                            "name": "No Instagram Here",
+                            "access_token": "unused-token",
+                        },
+                    ]
+                }
+            )
+        )
+    )
+
+    accounts = provider.get_user_pages("user-token")
+
+    assert accounts == [
+        {
+            "id": "17841400000000000",
+            "name": "Brightbean",
+            "handle": "brightbean",
+            "access_token": "page-token",
+            "category": "Creator",
+            "picture": "https://example.com/ig.jpg",
+            "followers_count": 42,
+            "page_id": "page-1",
+            "page_name": "Facebook Page",
+        }
+    ]
+    provider._request.assert_called_once_with(
+        "GET",
+        "https://graph.facebook.com/v21.0/me/accounts",
+        access_token="user-token",
+        params={
+            "fields": (
+                "id,name,access_token,category,picture,"
+                "instagram_business_account{id,username,name,profile_picture_url,followers_count}"
+            ),
+        },
+    )


### PR DESCRIPTION
## Summary

Stop requesting the deprecated/invalid Instagram account-level `impressions` insight metric and request `views` instead.

## Root Cause

Meta rejects the account insights call with `(#100) metric[0] must be one of...` because `impressions` is no longer accepted for this Instagram account insights endpoint. Reconnecting accounts cannot fix this because the request payload is invalid.

## Changes

- Update both Instagram providers to request `reach,follower_count,profile_views,views` for account metrics.
- Preserve `views` in `AccountMetrics.extra` so the analytics mapper can persist it through the existing Instagram metric catalog.
- Add provider regression tests for the Facebook-login Instagram provider and Instagram Login provider.

## Validation

Passed:

```bash
.venv/bin/python -m pytest tests/providers/test_instagram.py -vv --tb=short
.venv/bin/python -m ruff check .
.venv/bin/python -m ruff format --check .
SECRET_KEY=test-secret-key-not-for-production .venv/bin/python -m mypy apps/ config/ providers/ tests/ --ignore-missing-imports
```