### PR TITLE
feat: gap aware queue scheduling

### DIFF
--- a/apps/calendar/migrations/0006_normalise_queue_entry_positions.py
+++ b/apps/calendar/migrations/0006_normalise_queue_entry_positions.py
@@ -1,0 +1,49 @@
+"""Normalise QueueEntry positions to be 0-indexed per queue.
+
+Before the gap-aware scheduling change, add_to_queue computed:
+    position = (max_pos or 0) + 1
+
+This placed the very first entry at position 1, making all legacy queues
+1-indexed (1, 2, 3 …).  assign_queue_slots now uses position as a direct
+slot index, so a queue starting at 1 leaves slot 0 permanently empty and
+shifts every queued post one slot later than expected.
+
+For each queue, shift all positions down by the queue's minimum position so
+the sequence always starts at 0.  Queues that already start at 0 (e.g.
+created after the main change) or are empty are left untouched.
+"""
+
+from django.db import migrations
+
+
+def normalise_positions(apps, schema_editor):
+    QueueEntry = apps.get_model("calendar", "QueueEntry")
+    Queue = apps.get_model("calendar", "Queue")
+
+    for queue in Queue.objects.all():
+        entries = list(QueueEntry.objects.filter(queue=queue).order_by("position"))
+        if not entries:
+            continue
+        min_pos = entries[0].position
+        if min_pos == 0:
+            continue
+        for entry in entries:
+            entry.position -= min_pos
+        QueueEntry.objects.bulk_update(entries, ["position"])
+
+
+def reverse_normalise(apps, schema_editor):
+    # Reversing would require knowing the original offset per queue, which we
+    # no longer have.  Treat as a no-op — positions remain normalised.
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("calendar", "0005_alter_customcalendarevent_color"),
+    ]
+
+    operations = [
+        migrations.RunPython(normalise_positions, reverse_normalise),
+    ]

--- a/apps/calendar/services.py
+++ b/apps/calendar/services.py
@@ -162,6 +162,23 @@ def add_to_queue(post, queue, priority=False):
     assign_queue_slots(queue)
 
 
+def remove_from_queue(post, social_account_ids):
+    """Remove *post* from queues for the given channels, preserving the freed slot as a gap.
+
+    Called when a post leaves the queue (e.g. the user switches from "next
+    available" / "prioritise" to a specific date or "publish now").
+    ``assign_queue_slots`` is intentionally NOT called so the vacated position
+    remains as an empty gap — the next "next available" placement will fill it.
+    """
+    if not social_account_ids:
+        return
+    QueueEntry.objects.filter(
+        queue__social_account_id__in=social_account_ids,
+        queue__is_active=True,
+        post=post,
+    ).delete()
+
+
 def reorder_queue(queue, ordered_entry_ids):
     """Reorder queue entries by a list of entry IDs and recalculate slots."""
     for idx, entry_id in enumerate(ordered_entry_ids):

--- a/apps/calendar/services.py
+++ b/apps/calendar/services.py
@@ -139,7 +139,9 @@ def add_to_queue(post, queue, priority=False):
     If *priority* is False, the post is placed at the earliest unoccupied
     position — filling any gap before appending after the last entry.
     """
-    occupied = set(queue.entries.values_list("position", flat=True))
+    # Exclude the post's own existing entry so that re-queuing an already-queued
+    # post does not treat its current position as a foreign obstacle.
+    occupied = set(queue.entries.exclude(post=post).values_list("position", flat=True))
 
     if priority:
         if 0 in occupied:

--- a/apps/calendar/services.py
+++ b/apps/calendar/services.py
@@ -131,6 +131,10 @@ def assign_queue_slots(queue):
 def add_to_queue(post, queue, priority=False):
     """Add a post to a queue and recalculate slot assignments.
 
+    Re-adding an already queued post is idempotent unless ``priority`` is
+    requested. Editing an existing queued post should not move it into an
+    earlier gap and reshuffle the visible calendar.
+
     If *priority* is True the post is placed at position 0.  Existing entries
     are only shifted down by 1 when position 0 is already occupied, which
     preserves any gaps in the position sequence.  If position 0 is free (a
@@ -139,6 +143,11 @@ def add_to_queue(post, queue, priority=False):
     If *priority* is False, the post is placed at the earliest unoccupied
     position — filling any gap before appending after the last entry.
     """
+    existing_entry = queue.entries.filter(post=post).first()
+    if existing_entry is not None and not priority:
+        assign_queue_slots(queue)
+        return
+
     # Exclude the post's own existing entry so that re-queuing an already-queued
     # post does not treat its current position as a foreign obstacle.
     occupied = set(queue.entries.exclude(post=post).values_list("position", flat=True))

--- a/apps/calendar/services.py
+++ b/apps/calendar/services.py
@@ -88,27 +88,33 @@ def _next_slot_datetimes(social_account, after_dt, count=30):
 def assign_queue_slots(queue):
     """Recalculate assigned_slot_datetime for all entries in a queue.
 
-    Iterates entries in position order and assigns each to the next
-    available PostingSlot datetime for the queue's social account. For each
-    entry, writes the slot datetime to the matching ``PlatformPost`` (the one
-    whose ``social_account`` equals ``queue.social_account``) and keeps
-    ``QueueEntry.assigned_slot_datetime`` in sync. ``Post.scheduled_at`` is
-    then refreshed via ``sync_post_scheduled_at`` as min-of-children.
+    Each entry's ``position`` is treated as a direct index into the upcoming
+    slot sequence, so intentional gaps between positions (created by manual
+    deletes or prioritise operations) are preserved as empty slots in the
+    schedule.  Positions are never normalised here — callers that want compact
+    ordering must set positions explicitly (e.g. ``reorder_queue``).
+
+    For each entry, writes the slot datetime to the matching ``PlatformPost``
+    (the one whose ``social_account`` equals ``queue.social_account``) and
+    keeps ``QueueEntry.assigned_slot_datetime`` in sync.  ``Post.scheduled_at``
+    is then refreshed via ``sync_post_scheduled_at`` as min-of-children.
     """
     from apps.composer.services import sync_post_scheduled_at
 
-    entries = queue.entries.select_related("post").order_by("position")
-    if not entries.exists():
+    entries = list(queue.entries.select_related("post").order_by("position"))
+    if not entries:
         return
 
     now = timezone.now()
-    slot_times = _next_slot_datetimes(queue.social_account, now, count=len(entries) + 10)
+    max_pos = max(e.position for e in entries)
+    slot_times = _next_slot_datetimes(queue.social_account, now, count=max_pos + 10)
 
     touched_posts = []
-    for idx, entry in enumerate(entries):
-        slot_dt = slot_times[idx] if idx < len(slot_times) else None
-        entry.assigned_slot_datetime = slot_dt
-        entry.save(update_fields=["assigned_slot_datetime"])
+    for entry in entries:
+        slot_dt = slot_times[entry.position] if entry.position < len(slot_times) else None
+        if entry.assigned_slot_datetime != slot_dt:
+            entry.assigned_slot_datetime = slot_dt
+            entry.save(update_fields=["assigned_slot_datetime"])
 
         # Write the per-platform scheduled_at on the matching PlatformPost.
         pp = entry.post.platform_posts.filter(social_account=queue.social_account).first()
@@ -125,19 +131,25 @@ def assign_queue_slots(queue):
 def add_to_queue(post, queue, priority=False):
     """Add a post to a queue and recalculate slot assignments.
 
-    If *priority* is True the post is inserted at position 0 (top of the
-    queue) and all existing entries are shifted down.  Otherwise it is
-    appended at the end.
+    If *priority* is True the post is placed at position 0.  Existing entries
+    are only shifted down by 1 when position 0 is already occupied, which
+    preserves any gaps in the position sequence.  If position 0 is free (a
+    gap), the new post fills it with no shifting needed.
+
+    If *priority* is False, the post is placed at the earliest unoccupied
+    position — filling any gap before appending after the last entry.
     """
-    from django.db.models import Max
+    occupied = set(queue.entries.values_list("position", flat=True))
 
     if priority:
-        # Shift all existing entries down by 1
-        queue.entries.update(position=models.F("position") + 1)
+        if 0 in occupied:
+            # Shift all existing entries down by 1, preserving relative gaps.
+            queue.entries.update(position=models.F("position") + 1)
         position = 0
     else:
-        max_pos = queue.entries.aggregate(max_pos=Max("position"))["max_pos"]
-        position = (max_pos or 0) + 1
+        position = 0
+        while position in occupied:
+            position += 1
 
     QueueEntry.objects.update_or_create(
         queue=queue,

--- a/apps/calendar/tests.py
+++ b/apps/calendar/tests.py
@@ -345,10 +345,11 @@ class CalendarChannelSlotViewTests(TestCase):
         context = {"display_timezone": "America/New_York"}
         _day_view_data(self.factory.get("/"), self.workspace, target, context)
 
+        hour_posts = dict((hour, posts) for hour, posts, _slots in context["day_slots"])[9]
         slot_items = dict((hour, slots) for hour, _posts, slots in context["day_slots"])[9]
-        self.assertEqual(len(slot_items), 1)
-        self.assertTrue(slot_items[0]["is_taken"])
-        self.assertEqual(slot_items[0]["time_label"], "09:30")
+        self.assertEqual(slot_items, [])
+        self.assertEqual(len(hour_posts), 1)
+        self.assertTrue(hour_posts[0].takes_calendar_slot)
 
     def test_day_view_channel_filter_limits_slot_badges(self):
         target = date(2026, 6, 15)  # Monday

--- a/apps/calendar/tests.py
+++ b/apps/calendar/tests.py
@@ -4,7 +4,7 @@ import zoneinfo
 from datetime import date, datetime, time
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from django.utils import timezone
 
@@ -12,6 +12,7 @@ from apps.accounts.models import User
 from apps.calendar.models import PostingSlot, Queue, QueueEntry, RecurrenceRule
 from apps.calendar.services import add_to_queue
 from apps.calendar.tasks import generate_recurring_posts
+from apps.calendar.views import _day_view_data
 from apps.composer.models import PlatformPost, Post
 from apps.members.models import OrgMembership, WorkspaceMembership
 from apps.organizations.models import Organization
@@ -304,6 +305,62 @@ class QueueSlotTimezoneTests(TestCase):
         entry = QueueEntry.objects.get(queue=self.queue, post=post)
         local = entry.assigned_slot_datetime.astimezone(zoneinfo.ZoneInfo("Asia/Tokyo"))
         self.assertEqual((local.hour, local.minute), (9, 0))
+
+
+class CalendarChannelSlotViewTests(TestCase):
+    """Day/week calendar data should expose channel posting slots."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.org = Organization.objects.create(name="Calendar Slots Org", default_timezone="America/New_York")
+        self.workspace = Workspace.objects.create(organization=self.org, name="Calendar Slots WS")
+        self.account = SocialAccount.objects.create(
+            workspace=self.workspace,
+            platform="instagram",
+            account_platform_id="ig-calendar-slots",
+            account_name="Instagram",
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+        self.other_account = SocialAccount.objects.create(
+            workspace=self.workspace,
+            platform="linkedin_company",
+            account_platform_id="li-calendar-slots",
+            account_name="LinkedIn",
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+
+    def test_day_view_marks_exact_channel_slot_taken(self):
+        target = date(2026, 6, 15)  # Monday
+        ny = zoneinfo.ZoneInfo("America/New_York")
+        scheduled_at = datetime(2026, 6, 15, 9, 30, tzinfo=ny)
+        PostingSlot.objects.create(social_account=self.account, day_of_week=0, time=time(9, 30))
+        post = Post.objects.create(workspace=self.workspace, caption="scheduled", scheduled_at=scheduled_at)
+        PlatformPost.objects.create(
+            post=post,
+            social_account=self.account,
+            status="scheduled",
+            scheduled_at=scheduled_at,
+        )
+
+        context = {"display_timezone": "America/New_York"}
+        _day_view_data(self.factory.get("/"), self.workspace, target, context)
+
+        slot_items = dict((hour, slots) for hour, _posts, slots in context["day_slots"])[9]
+        self.assertEqual(len(slot_items), 1)
+        self.assertTrue(slot_items[0]["is_taken"])
+        self.assertEqual(slot_items[0]["time_label"], "09:30")
+
+    def test_day_view_channel_filter_limits_slot_badges(self):
+        target = date(2026, 6, 15)  # Monday
+        PostingSlot.objects.create(social_account=self.account, day_of_week=0, time=time(9, 0))
+        PostingSlot.objects.create(social_account=self.other_account, day_of_week=0, time=time(9, 0))
+
+        request = self.factory.get("/", {"channel": str(self.account.id)})
+        context = {"display_timezone": "America/New_York"}
+        _day_view_data(request, self.workspace, target, context)
+
+        slot_items = dict((hour, slots) for hour, _posts, slots in context["day_slots"])[9]
+        self.assertEqual([slot["account"] for slot in slot_items], [self.account])
 
 
 class RecurringPostTimezoneTests(TestCase):

--- a/apps/calendar/tests.py
+++ b/apps/calendar/tests.py
@@ -292,6 +292,26 @@ class QueueSlotTimezoneTests(TestCase):
         pp = PlatformPost.objects.get(post=post, social_account=self.account)
         self.assertEqual(pp.scheduled_at, entry.assigned_slot_datetime)
 
+    def test_readding_existing_queued_post_keeps_position(self):
+        fixed_now = datetime(2026, 6, 15, 8, 0, tzinfo=zoneinfo.ZoneInfo("America/New_York"))
+        post = Post.objects.create(workspace=self.workspace, caption="already queued")
+        pp = PlatformPost.objects.create(
+            post=post,
+            social_account=self.account,
+            status=PlatformPost.Status.SCHEDULED,
+        )
+        QueueEntry.objects.create(queue=self.queue, post=post, position=1)
+
+        with patch("apps.calendar.services.timezone.now", return_value=fixed_now):
+            add_to_queue(post, self.queue)
+
+        entry = QueueEntry.objects.get(queue=self.queue, post=post)
+        pp.refresh_from_db()
+        local = pp.scheduled_at.astimezone(zoneinfo.ZoneInfo("America/New_York"))
+        self.assertEqual(entry.position, 1)
+        self.assertEqual(local.date(), date(2026, 6, 16))
+        self.assertEqual((local.hour, local.minute), (9, 0))
+
     def test_workspace_override_takes_precedence_over_org(self):
         # An explicit workspace timezone overrides the org default.
         self.workspace.timezone = "Asia/Tokyo"

--- a/apps/calendar/tests.py
+++ b/apps/calendar/tests.py
@@ -363,6 +363,41 @@ class CalendarChannelSlotViewTests(TestCase):
         slot_items = dict((hour, slots) for hour, _posts, slots in context["day_slots"])[9]
         self.assertEqual([slot["account"] for slot in slot_items], [self.account])
 
+    def test_day_view_ignores_malformed_channel_filter(self):
+        target = date(2026, 6, 15)  # Monday
+        PostingSlot.objects.create(social_account=self.account, day_of_week=0, time=time(9, 0))
+
+        request = self.factory.get("/", {"channel": "not-a-uuid"})
+        context = {"display_timezone": "America/New_York"}
+        _day_view_data(request, self.workspace, target, context)
+
+        slot_items = dict((hour, slots) for hour, _posts, slots in context["day_slots"])[9]
+        self.assertEqual([slot["account"] for slot in slot_items], [self.account])
+
+    def test_day_view_includes_workspace_slot_from_adjacent_display_date(self):
+        self.workspace.timezone = "America/Los_Angeles"
+        self.workspace.save(update_fields=["timezone"])
+        target = date(2026, 6, 16)  # Tuesday in Tokyo
+        la = zoneinfo.ZoneInfo("America/Los_Angeles")
+        scheduled_at = datetime(2026, 6, 15, 9, 0, tzinfo=la)
+        PostingSlot.objects.create(social_account=self.account, day_of_week=0, time=time(9, 0))
+        post = Post.objects.create(workspace=self.workspace, caption="tokyo-boundary", scheduled_at=scheduled_at)
+        PlatformPost.objects.create(
+            post=post,
+            social_account=self.account,
+            status="scheduled",
+            scheduled_at=scheduled_at,
+        )
+
+        context = {"display_timezone": "Asia/Tokyo"}
+        _day_view_data(self.factory.get("/"), self.workspace, target, context)
+
+        hour_posts = dict((hour, posts) for hour, posts, _slots in context["day_slots"])[1]
+        slot_items = dict((hour, slots) for hour, _posts, slots in context["day_slots"])[1]
+        self.assertEqual(slot_items, [])
+        self.assertEqual(len(hour_posts), 1)
+        self.assertTrue(hour_posts[0].takes_calendar_slot)
+
 
 class RecurringPostTimezoneTests(TestCase):
     """``generate_recurring_posts`` must preserve the source post's *local*

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -2,6 +2,7 @@
 
 import calendar as cal_mod
 import json
+import uuid
 from collections import defaultdict
 from datetime import date, datetime, time, timedelta
 
@@ -96,6 +97,17 @@ def _parse_date(date_str, default=None):
     return default or date.today()
 
 
+def _get_valid_channel_filter(request):
+    """Return a UUID-safe channel filter value, or blank when malformed."""
+    channel = request.GET.get("channel", "").strip()
+    if not channel:
+        return ""
+    try:
+        return str(uuid.UUID(channel))
+    except (TypeError, ValueError, AttributeError):
+        return ""
+
+
 def _get_filtered_posts(workspace, request):
     """Apply calendar filters from query params."""
     qs = (
@@ -172,7 +184,7 @@ def _get_filtered_platform_posts(workspace, request):
         qs = qs.filter(social_account__platform__in=platforms)
 
     # Channel filter (calendar toolbar sends the selected SocialAccount id).
-    channel = request.GET.get("channel")
+    channel = _get_valid_channel_filter(request)
     if channel:
         qs = qs.filter(social_account_id=channel)
 
@@ -213,8 +225,8 @@ def _get_calendar_slot_occurrences(workspace, request, display_tz, visible_dates
     if not visible_dates:
         return defaultdict(list)
 
-    first_date = min(visible_dates)
-    last_date = max(visible_dates)
+    first_date = min(visible_dates) - timedelta(days=1)
+    last_date = max(visible_dates) + timedelta(days=1)
     occurrence_dates = [first_date + timedelta(days=offset) for offset in range((last_date - first_date).days + 1)]
 
     slots = PostingSlot.objects.filter(
@@ -222,7 +234,7 @@ def _get_calendar_slot_occurrences(workspace, request, display_tz, visible_dates
         social_account__connection_status=SocialAccount.ConnectionStatus.CONNECTED,
         is_active=True,
     )
-    channel = request.GET.get("channel")
+    channel = _get_valid_channel_filter(request)
     if channel:
         slots = slots.filter(social_account_id=channel)
 

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -761,9 +761,7 @@ def _day_view_data(request, workspace, target_date, context):
     hours = list(range(0, 24))
 
     # Build a list of (hour, posts, slots) tuples for easy template iteration
-    day_slots = [
-        (hour, posts_by_hour.get(hour, []), slots_by_hour.get((target_date, hour), [])) for hour in hours
-    ]
+    day_slots = [(hour, posts_by_hour.get(hour, []), slots_by_hour.get((target_date, hour), [])) for hour in hours]
 
     from django.utils import timezone as _tz
 

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -171,6 +171,11 @@ def _get_filtered_platform_posts(workspace, request):
     if platforms:
         qs = qs.filter(social_account__platform__in=platforms)
 
+    # Channel filter (calendar toolbar sends the selected SocialAccount id).
+    channel = request.GET.get("channel")
+    if channel:
+        qs = qs.filter(social_account_id=channel)
+
     # Author filter
     authors = request.GET.getlist("author")
     if authors:
@@ -192,6 +197,76 @@ def _get_filtered_platform_posts(workspace, request):
         qs = qs.filter(tag_q)
 
     return qs
+
+
+def _get_calendar_slot_occurrences(workspace, request, display_tz, visible_dates, platform_posts):
+    """Return PostingSlot occurrences grouped by display date/hour.
+
+    PostingSlot times are defined in the workspace timezone. Convert concrete
+    occurrences into the active display timezone before placing them in the
+    day/week timeline, so timezone changes move slots and posts together.
+    """
+    import zoneinfo
+
+    workspace_tz = zoneinfo.ZoneInfo(workspace.effective_timezone or "UTC")
+    visible_dates = set(visible_dates)
+    if not visible_dates:
+        return defaultdict(list)
+
+    first_date = min(visible_dates)
+    last_date = max(visible_dates)
+    occurrence_dates = [first_date + timedelta(days=offset) for offset in range((last_date - first_date).days + 1)]
+
+    taken_keys = set()
+    for pp in platform_posts:
+        if not pp.effective_at:
+            continue
+        local_dt = pp.effective_at.astimezone(display_tz)
+        if local_dt.date() in visible_dates:
+            taken_keys.add((pp.social_account_id, local_dt.date(), local_dt.hour, local_dt.minute))
+
+    slots = PostingSlot.objects.filter(
+        social_account__workspace=workspace,
+        social_account__connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        is_active=True,
+    )
+    channel = request.GET.get("channel")
+    if channel:
+        slots = slots.filter(social_account_id=channel)
+
+    slots = slots.select_related("social_account").order_by(
+        "time",
+        "social_account__platform",
+        "social_account__account_name",
+    )
+
+    slots_by_hour = defaultdict(list)
+    dates_by_weekday = defaultdict(list)
+    for occurrence_date in occurrence_dates:
+        dates_by_weekday[occurrence_date.weekday()].append(occurrence_date)
+
+    for slot in slots:
+        for occurrence_date in dates_by_weekday.get(slot.day_of_week, []):
+            workspace_dt = datetime.combine(occurrence_date, slot.time, tzinfo=workspace_tz)
+            local_dt = workspace_dt.astimezone(display_tz)
+            if local_dt.date() not in visible_dates:
+                continue
+
+            key = (slot.social_account_id, local_dt.date(), local_dt.hour, local_dt.minute)
+            slots_by_hour[(local_dt.date(), local_dt.hour)].append(
+                {
+                    "account": slot.social_account,
+                    "date": local_dt.date(),
+                    "hour": local_dt.hour,
+                    "minute": local_dt.minute,
+                    "time_label": local_dt.strftime("%H:%M"),
+                    "compose_date": workspace_dt.strftime("%Y-%m-%d"),
+                    "compose_time": workspace_dt.strftime("%H:%M"),
+                    "is_taken": key in taken_keys,
+                }
+            )
+
+    return slots_by_hour
 
 
 def _get_publish_context(workspace, request):
@@ -621,16 +696,17 @@ def _week_view_data(request, workspace, target_date, context):
                 key = (local_dt.date(), local_dt.hour)
                 posts_by_slot[key].append(pp)
 
+    slots_by_hour = _get_calendar_slot_occurrences(workspace, request, display_tz, week_days, platform_posts)
     hours = list(range(0, 24))
 
     # Build a grid structure the template can iterate:
-    # week_slots = [(hour, [(day, posts), ...]), ...]
+    # week_slots = [(hour, [(day, posts, slots), ...]), ...]
     week_slots = []
     for hour in hours:
         day_slots = []
         for day in week_days:
             key = (day, hour)
-            day_slots.append((day, posts_by_slot.get(key, [])))
+            day_slots.append((day, posts_by_slot.get(key, []), slots_by_hour.get(key, [])))
         week_slots.append((hour, day_slots))
 
     from django.utils import timezone as _tz
@@ -681,10 +757,13 @@ def _day_view_data(request, workspace, target_date, context):
             if local_dt.date() == target_date:
                 posts_by_hour[local_dt.hour].append(pp)
 
+    slots_by_hour = _get_calendar_slot_occurrences(workspace, request, display_tz, [target_date], platform_posts)
     hours = list(range(0, 24))
 
-    # Build a list of (hour, posts) tuples for easy template iteration
-    day_slots = [(hour, posts_by_hour.get(hour, [])) for hour in hours]
+    # Build a list of (hour, posts, slots) tuples for easy template iteration
+    day_slots = [
+        (hour, posts_by_hour.get(hour, []), slots_by_hour.get((target_date, hour), [])) for hour in hours
+    ]
 
     from django.utils import timezone as _tz
 

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -217,14 +217,6 @@ def _get_calendar_slot_occurrences(workspace, request, display_tz, visible_dates
     last_date = max(visible_dates)
     occurrence_dates = [first_date + timedelta(days=offset) for offset in range((last_date - first_date).days + 1)]
 
-    taken_keys = set()
-    for pp in platform_posts:
-        if not pp.effective_at:
-            continue
-        local_dt = pp.effective_at.astimezone(display_tz)
-        if local_dt.date() in visible_dates:
-            taken_keys.add((pp.social_account_id, local_dt.date(), local_dt.hour, local_dt.minute))
-
     slots = PostingSlot.objects.filter(
         social_account__workspace=workspace,
         social_account__connection_status=SocialAccount.ConnectionStatus.CONNECTED,
@@ -241,6 +233,8 @@ def _get_calendar_slot_occurrences(workspace, request, display_tz, visible_dates
     )
 
     slots_by_hour = defaultdict(list)
+    slot_keys = set()
+    slot_occurrences = []
     dates_by_weekday = defaultdict(list)
     for occurrence_date in occurrence_dates:
         dates_by_weekday[occurrence_date.weekday()].append(occurrence_date)
@@ -253,18 +247,37 @@ def _get_calendar_slot_occurrences(workspace, request, display_tz, visible_dates
                 continue
 
             key = (slot.social_account_id, local_dt.date(), local_dt.hour, local_dt.minute)
-            slots_by_hour[(local_dt.date(), local_dt.hour)].append(
-                {
-                    "account": slot.social_account,
-                    "date": local_dt.date(),
-                    "hour": local_dt.hour,
-                    "minute": local_dt.minute,
-                    "time_label": local_dt.strftime("%H:%M"),
-                    "compose_date": workspace_dt.strftime("%Y-%m-%d"),
-                    "compose_time": workspace_dt.strftime("%H:%M"),
-                    "is_taken": key in taken_keys,
-                }
+            slot_keys.add(key)
+            slot_occurrences.append(
+                (
+                    key,
+                    {
+                        "account": slot.social_account,
+                        "date": local_dt.date(),
+                        "hour": local_dt.hour,
+                        "minute": local_dt.minute,
+                        "time_label": local_dt.strftime("%H:%M"),
+                        "compose_date": workspace_dt.strftime("%Y-%m-%d"),
+                        "compose_time": workspace_dt.strftime("%H:%M"),
+                    },
+                )
             )
+
+    taken_keys = set()
+    for pp in platform_posts:
+        pp.takes_calendar_slot = False
+        if not pp.effective_at:
+            continue
+        local_dt = pp.effective_at.astimezone(display_tz)
+        key = (pp.social_account_id, local_dt.date(), local_dt.hour, local_dt.minute)
+        if key in slot_keys:
+            pp.takes_calendar_slot = True
+            taken_keys.add(key)
+
+    for key, slot in slot_occurrences:
+        if key in taken_keys:
+            continue
+        slots_by_hour[(slot["date"], slot["hour"])].append(slot)
 
     return slots_by_hour
 
@@ -677,7 +690,7 @@ def _week_view_data(request, workspace, target_date, context):
     week_days = [monday + timedelta(days=i) for i in range(7)]
 
     # Widen query by ±1 day to handle timezone boundary shifts
-    platform_posts = (
+    platform_posts = list(
         _get_filtered_platform_posts(workspace, request)
         .filter(
             effective_at__date__gte=week_days[0] - timedelta(days=1),
@@ -740,7 +753,7 @@ def _day_view_data(request, workspace, target_date, context):
     display_tz = zoneinfo.ZoneInfo(context.get("display_timezone", "UTC"))
 
     # Widen query by ±1 day to handle timezone boundary shifts
-    platform_posts = (
+    platform_posts = list(
         _get_filtered_platform_posts(workspace, request)
         .filter(
             effective_at__date__gte=target_date - timedelta(days=1),

--- a/apps/composer/tests/test_account_scope.py
+++ b/apps/composer/tests/test_account_scope.py
@@ -6,11 +6,16 @@ autosave) deleted every sibling PlatformPost — including already-published
 ones, cascading away their PublishLog history.
 """
 
+import zoneinfo
+from datetime import date, datetime, time
+from unittest.mock import patch
+
 from django.test import TestCase
 from django.urls import reverse
 from django.utils import timezone
 
 from apps.accounts.models import User
+from apps.calendar.models import PostingSlot, Queue, QueueEntry
 from apps.composer.models import PlatformPost, Post
 from apps.members.models import OrgMembership, WorkspaceMembership
 from apps.organizations.models import Organization
@@ -197,6 +202,34 @@ class ScopedSaveTests(AccountScopeTestsBase):
         self.yt_pp.refresh_from_db()
         self.assertEqual(self.yt_pp.status, PlatformPost.Status.PUBLISHED)
         self.assertIsNone(self.yt_pp.scheduled_at)
+
+    def test_existing_queued_post_update_keeps_queue_position(self):
+        fixed_now = datetime(2026, 6, 15, 8, 0, tzinfo=zoneinfo.ZoneInfo("UTC"))
+        queue = Queue.objects.create(
+            workspace=self.workspace,
+            name="TikTok Queue",
+            social_account=self.tiktok,
+        )
+        PostingSlot.objects.create(social_account=self.tiktok, day_of_week=0, time=time(9, 0))
+        PostingSlot.objects.create(social_account=self.tiktok, day_of_week=1, time=time(9, 0))
+        self.tt_pp.status = PlatformPost.Status.SCHEDULED
+        self.tt_pp.scheduled_at = datetime(2026, 6, 16, 9, 0, tzinfo=zoneinfo.ZoneInfo("UTC"))
+        self.tt_pp.save(update_fields=["status", "scheduled_at"])
+        QueueEntry.objects.create(queue=queue, post=self.post, position=1, assigned_slot_datetime=self.tt_pp.scheduled_at)
+
+        payload = self._payload(
+            action="add_to_queue",
+            scheduled_date=date(2026, 6, 15).isoformat(),
+            scheduled_time="09:00",
+        )
+        with patch("apps.calendar.services.timezone.now", return_value=fixed_now):
+            response = self.client.post(self.save_url, data=payload)
+        self.assertIn(response.status_code, (200, 204, 302))
+
+        entry = QueueEntry.objects.get(queue=queue, post=self.post)
+        self.tt_pp.refresh_from_db()
+        self.assertEqual(entry.position, 1)
+        self.assertEqual(self.tt_pp.scheduled_at, datetime(2026, 6, 16, 9, 0, tzinfo=zoneinfo.ZoneInfo("UTC")))
 
 
 class TikTokExtrasSyncTests(AccountScopeTestsBase):

--- a/apps/composer/tests/test_account_scope.py
+++ b/apps/composer/tests/test_account_scope.py
@@ -231,6 +231,70 @@ class ScopedSaveTests(AccountScopeTestsBase):
         self.assertEqual(entry.position, 1)
         self.assertEqual(self.tt_pp.scheduled_at, datetime(2026, 6, 16, 9, 0, tzinfo=zoneinfo.ZoneInfo("UTC")))
 
+    def test_unscoped_schedule_removes_queue_entry_for_deselected_channel(self):
+        youtube_queue = Queue.objects.create(
+            workspace=self.workspace,
+            name="YouTube Queue",
+            social_account=self.youtube,
+        )
+        tiktok_queue = Queue.objects.create(
+            workspace=self.workspace,
+            name="TikTok Queue",
+            social_account=self.tiktok,
+        )
+        self.yt_pp.status = PlatformPost.Status.SCHEDULED
+        self.yt_pp.published_at = None
+        self.yt_pp.save(update_fields=["status", "published_at"])
+        self.tt_pp.status = PlatformPost.Status.SCHEDULED
+        self.tt_pp.save(update_fields=["status"])
+        QueueEntry.objects.create(queue=youtube_queue, post=self.post, position=0)
+        QueueEntry.objects.create(queue=tiktok_queue, post=self.post, position=0)
+
+        payload = self._payload(
+            action="schedule",
+            selected_accounts=str(self.tiktok.id),
+            scheduled_date=date(2026, 6, 22).isoformat(),
+            scheduled_time="09:00",
+        )
+        del payload["account_scope"]
+        response = self.client.post(self.save_url, data=payload)
+
+        self.assertIn(response.status_code, (200, 204, 302))
+        self.assertFalse(QueueEntry.objects.filter(queue=youtube_queue, post=self.post).exists())
+        self.assertFalse(QueueEntry.objects.filter(queue=tiktok_queue, post=self.post).exists())
+
+    def test_scoped_schedule_only_removes_scoped_channel_queue_entry(self):
+        youtube_queue = Queue.objects.create(
+            workspace=self.workspace,
+            name="YouTube Queue",
+            social_account=self.youtube,
+        )
+        tiktok_queue = Queue.objects.create(
+            workspace=self.workspace,
+            name="TikTok Queue",
+            social_account=self.tiktok,
+        )
+        self.yt_pp.status = PlatformPost.Status.SCHEDULED
+        self.yt_pp.published_at = None
+        self.yt_pp.save(update_fields=["status", "published_at"])
+        self.tt_pp.status = PlatformPost.Status.SCHEDULED
+        self.tt_pp.save(update_fields=["status"])
+        QueueEntry.objects.create(queue=youtube_queue, post=self.post, position=0)
+        QueueEntry.objects.create(queue=tiktok_queue, post=self.post, position=0)
+
+        response = self.client.post(
+            self.save_url,
+            data=self._payload(
+                action="schedule",
+                scheduled_date=date(2026, 6, 22).isoformat(),
+                scheduled_time="09:00",
+            ),
+        )
+
+        self.assertIn(response.status_code, (200, 204, 302))
+        self.assertTrue(QueueEntry.objects.filter(queue=youtube_queue, post=self.post).exists())
+        self.assertFalse(QueueEntry.objects.filter(queue=tiktok_queue, post=self.post).exists())
+
 
 class TikTokExtrasSyncTests(AccountScopeTestsBase):
     def _tiktok_payload(self, **tiktok_fields):

--- a/apps/composer/views.py
+++ b/apps/composer/views.py
@@ -124,6 +124,26 @@ def _scoped_platform_post_ids(request, post):
     return list(post.platform_posts.filter(social_account_id=scope).values_list("id", flat=True))
 
 
+def _queue_removal_account_ids(request, post):
+    """Return channel IDs whose queue entries should be removed for this save.
+
+    Scoped composer saves only touch the scoped channel. Unscoped saves must
+    also include currently queued channels, even if the user just deselected
+    them, otherwise their QueueEntry rows survive the PlatformPost deletion.
+    """
+    scope = _get_account_scope(request)
+    if scope:
+        return [scope]
+
+    account_ids = set(_parse_selected_account_ids(request.POST.get("selected_accounts", "")))
+    queued_account_ids = post.queue_entries.filter(
+        queue__workspace=post.workspace,
+        queue__is_active=True,
+    ).values_list("queue__social_account_id", flat=True)
+    account_ids.update(str(account_id) for account_id in queued_account_ids)
+    return list(account_ids)
+
+
 def _sync_platform_posts(request, post, workspace, initial_status=None):
     """Sync platform post selections from form data.
 
@@ -691,9 +711,7 @@ def save_post(request, workspace_id, post_id=None):
             if post_id:
                 from apps.calendar.services import remove_from_queue
 
-                scope = _get_account_scope(request)
-                _acc_ids = [scope] if scope else _parse_selected_account_ids(request.POST.get("selected_accounts", ""))
-                remove_from_queue(post, _acc_ids)
+                remove_from_queue(post, _queue_removal_account_ids(request, post))
             pending_target = "scheduled"
             initial_status = "scheduled"
         else:
@@ -711,9 +729,7 @@ def save_post(request, workspace_id, post_id=None):
         if post_id:
             from apps.calendar.services import remove_from_queue
 
-            scope = _get_account_scope(request)
-            _acc_ids = [scope] if scope else _parse_selected_account_ids(request.POST.get("selected_accounts", ""))
-            remove_from_queue(post, _acc_ids)
+            remove_from_queue(post, _queue_removal_account_ids(request, post))
         pending_target = "scheduled"
         initial_status = "scheduled"
     elif action == "add_to_queue":

--- a/apps/composer/views.py
+++ b/apps/composer/views.py
@@ -732,7 +732,7 @@ def save_post(request, workspace_id, post_id=None):
         # If opened from a specific calendar day (month/week/day "+" CTA), each
         # queue should use that day as its floor - re-assign slots accordingly.
         floor_date = form.cleaned_data.get("scheduled_date")
-        if floor_date:
+        if floor_date and not post_id:
             _reassign_queue_slots_from_floor(queues, post, floor_date, workspace)
         # Transition every child whose scheduled_at was filled in to "scheduled".
         _transition_post_children(post, "scheduled", only=_scoped_platform_post_ids(request, post))

--- a/apps/composer/views.py
+++ b/apps/composer/views.py
@@ -445,9 +445,11 @@ def compose(request, workspace_id, post_id=None):
         .order_by("platform", "account_name")
     )
 
-    # When opening from calendar with a specific account, show only that account
-    if account_filter and post_id:
+    # When opening from calendar with a specific account, show only that account.
+    if account_filter:
         social_accounts = social_accounts.filter(id=account_filter)
+        if not post_id and social_accounts.exists():
+            selected_account_ids = [account_filter]
 
     # Platform character limits for JS
     char_limits = {}

--- a/apps/composer/views.py
+++ b/apps/composer/views.py
@@ -686,6 +686,14 @@ def save_post(request, workspace_id, post_id=None):
             # Propagate the manually chosen time to every PlatformPost so all
             # selected platforms publish at the same moment.
             post._schedule_propagate_dt = aware_dt  # handled after post.save()
+            # If the post was previously in a queue, free that slot as a gap so
+            # other "next available" placements can fill it.
+            if post_id:
+                from apps.calendar.services import remove_from_queue
+
+                scope = _get_account_scope(request)
+                _acc_ids = [scope] if scope else _parse_selected_account_ids(request.POST.get("selected_accounts", ""))
+                remove_from_queue(post, _acc_ids)
             pending_target = "scheduled"
             initial_status = "scheduled"
         else:
@@ -699,6 +707,13 @@ def save_post(request, workspace_id, post_id=None):
         now_dt = timezone.now()
         post.scheduled_at = now_dt
         post._schedule_propagate_dt = now_dt  # handled after post.save()
+        # If the post was previously in a queue, free that slot as a gap.
+        if post_id:
+            from apps.calendar.services import remove_from_queue
+
+            scope = _get_account_scope(request)
+            _acc_ids = [scope] if scope else _parse_selected_account_ids(request.POST.get("selected_accounts", ""))
+            remove_from_queue(post, _acc_ids)
         pending_target = "scheduled"
         initial_status = "scheduled"
     elif action == "add_to_queue":

--- a/templates/calendar/calendar.html
+++ b/templates/calendar/calendar.html
@@ -235,6 +235,60 @@
         transform: scale(1.1);
     }
 
+    .calendar-channel-slot {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        max-width: 100%;
+        min-height: 24px;
+        padding: 3px 5px;
+        border-radius: 6px;
+        font-size: 11px;
+        font-weight: 600;
+        border: 1px solid #E7E5E4;
+        background: #FAFAF9;
+        color: #44403C;
+    }
+    .calendar-channel-slot--week {
+        width: 100%;
+        font-size: 10px;
+        gap: 4px;
+    }
+    .calendar-channel-slot.is-open {
+        border-color: #FED7AA;
+        background: #FFF7ED;
+    }
+    .calendar-channel-slot.is-taken {
+        border-color: #BBF7D0;
+        background: #F0FDF4;
+    }
+    .calendar-slot-state {
+        flex-shrink: 0;
+        padding: 1px 5px;
+        border-radius: 9999px;
+        background: rgba(255,255,255,0.72);
+        color: #57534E;
+        font-size: 9px;
+        text-transform: uppercase;
+        letter-spacing: 0;
+    }
+    .calendar-slot-add {
+        flex-shrink: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 18px;
+        height: 18px;
+        border-radius: 9999px;
+        background: #F97316;
+        color: white;
+        box-shadow: 0 1px 4px rgba(249,115,22,0.25);
+    }
+    .calendar-slot-add:hover {
+        background: #EA580C;
+        transform: scale(1.05);
+    }
+
     /* Draggable feedback */
     .post-chip.dragging { opacity: 0.5; transform: rotate(2deg); }
 

--- a/templates/calendar/calendar.html
+++ b/templates/calendar/calendar.html
@@ -245,32 +245,29 @@
         border-radius: 6px;
         font-size: 11px;
         font-weight: 600;
-        border: 1px solid #E7E5E4;
-        background: #FAFAF9;
-        color: #44403C;
+        border: 1px dashed #E7E5E4;
+        background: #FFFFFF;
+        color: #78716C;
     }
     .calendar-channel-slot--week {
         width: 100%;
         font-size: 10px;
         gap: 4px;
     }
-    .calendar-channel-slot.is-open {
-        border-color: #FED7AA;
-        background: #FFF7ED;
+    .calendar-channel-slot.is-past-open {
+        opacity: 0.45;
+        background: #FAFAF9;
     }
-    .calendar-channel-slot.is-taken {
-        border-color: #BBF7D0;
-        background: #F0FDF4;
-    }
-    .calendar-slot-state {
+    .calendar-slot-platform-icon {
         flex-shrink: 0;
-        padding: 1px 5px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 16px;
+        height: 16px;
         border-radius: 9999px;
-        background: rgba(255,255,255,0.72);
-        color: #57534E;
-        font-size: 9px;
-        text-transform: uppercase;
-        letter-spacing: 0;
+        background: #F5F5F4;
+        color: #78716C;
     }
     .calendar-slot-add {
         flex-shrink: 0;
@@ -280,13 +277,24 @@
         width: 18px;
         height: 18px;
         border-radius: 9999px;
-        background: #F97316;
-        color: white;
-        box-shadow: 0 1px 4px rgba(249,115,22,0.25);
+        background: #FFEDD5;
+        color: #C2410C;
     }
     .calendar-slot-add:hover {
-        background: #EA580C;
+        background: #FED7AA;
         transform: scale(1.05);
+    }
+    .calendar-post-slot-check {
+        flex-shrink: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 16px;
+        height: 16px;
+        border-radius: 9999px;
+        background: rgba(255,255,255,0.72);
+        color: #15803D;
+        margin-left: auto;
     }
 
     /* Draggable feedback */

--- a/templates/calendar/partials/day_grid.html
+++ b/templates/calendar/partials/day_grid.html
@@ -24,15 +24,13 @@ Context: day_slots, target_date, workspace.
             {% if slot_items %}
             <div class="flex flex-wrap gap-1.5">
                 {% for slot in slot_items %}
-                <div class="calendar-channel-slot {% if slot.is_taken %}is-taken{% else %}is-open{% endif %}">
-                    <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ slot.account.platform }} flex-shrink-0 text-white">
+                <div class="calendar-channel-slot {% if is_past_day or is_today and hour < current_hour %}is-past-open{% endif %}">
+                    <span class="calendar-slot-platform-icon">
                         {% include "social_accounts/partials/_platform_icon.html" with platform=slot.account.platform size="3" %}
                     </span>
                     <span class="truncate">{{ slot.account.account_name|default:slot.account.account_handle }}</span>
                     <span class="tabular-nums text-stone-500">{{ slot.time_label }}</span>
-                    {% if slot.is_taken %}
-                    <span class="calendar-slot-state">Taken</span>
-                    {% elif not is_past_day and not is_today or not is_past_day and hour >= current_hour %}
+                    {% if not is_past_day and not is_today or not is_past_day and hour >= current_hour %}
                     <a href="{% url 'composer:compose' workspace_id=workspace.id %}?account={{ slot.account.id }}&scheduled_date={{ slot.compose_date }}&scheduled_time={{ slot.compose_time }}"
                        class="calendar-slot-add"
                        title="Schedule post for {{ slot.account.account_name|default:slot.account.account_handle }} at {{ slot.time_label }}">
@@ -65,6 +63,11 @@ Context: day_slots, target_date, workspace.
                 {% endif %}
                 {% endwith %}
                 <span class="truncate">{{ pp.post.title|default:pp.post.caption_snippet|truncatechars:28 }}</span>
+                {% if pp.takes_calendar_slot %}
+                <span class="calendar-post-slot-check" title="Scheduled in a channel slot">
+                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                </span>
+                {% endif %}
             </a>
             {% endfor %}
         </div>

--- a/templates/calendar/partials/day_grid.html
+++ b/templates/calendar/partials/day_grid.html
@@ -4,8 +4,8 @@ Context: day_slots, target_date, workspace.
 {% endcomment %}
 
 <div class="bg-white mx-auto" style="animation: slideUp 200ms cubic-bezier(0.16,1,0.3,1) both; max-height: calc(100vh - 200px); overflow-y: auto;">
-    {% for hour, hour_posts in day_slots %}
-    <div class="flex border-b border-stone-100 min-h-[64px] cal-add-cell {% if hour_posts %}has-posts{% endif %} {% if is_today and hour == current_hour %}bg-orange-50/50{% endif %}"
+{% for hour, hour_posts, slot_items in day_slots %}
+    <div class="flex border-b border-stone-100 min-h-[64px] cal-add-cell {% if hour_posts or slot_items %}has-posts{% endif %} {% if is_today and hour == current_hour %}bg-orange-50/50{% endif %}"
          @dragover.prevent="allowDrop($event)"
          @drop="dropOnSlot($event, '{{ target_date|date:'Y-m-d' }}', {{ hour }})">
         <!-- Time label -->
@@ -14,12 +14,36 @@ Context: day_slots, target_date, workspace.
                 {% if hour < 10 %}0{% endif %}{{ hour }}:00
             </span>
         </div>
-        <!-- Posts in this hour -->
+        <!-- Slots and posts in this hour -->
         <div class="flex-1 p-2 flex flex-col justify-center gap-1">
             {% if not is_past_day and not is_today or not is_past_day and hour >= current_hour %}
             <a href="{% url 'composer:compose' workspace_id=workspace.id %}?scheduled_date={{ target_date|date:'Y-m-d' }}&scheduled_time={{ hour }}:00" class="cal-add-btn cal-add-btn--inline" style="position:static; margin:0 auto;" title="Create post">
                 <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
             </a>
+            {% endif %}
+            {% if slot_items %}
+            <div class="flex flex-wrap gap-1.5">
+                {% for slot in slot_items %}
+                <div class="calendar-channel-slot {% if slot.is_taken %}is-taken{% else %}is-open{% endif %}">
+                    <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ slot.account.platform }} flex-shrink-0 text-white">
+                        {% include "social_accounts/partials/_platform_icon.html" with platform=slot.account.platform size="3" %}
+                    </span>
+                    <span class="truncate">{{ slot.account.account_name|default:slot.account.account_handle }}</span>
+                    <span class="tabular-nums text-stone-500">{{ slot.time_label }}</span>
+                    {% if slot.is_taken %}
+                    <span class="calendar-slot-state">Taken</span>
+                    {% elif not is_past_day and not is_today or not is_past_day and hour >= current_hour %}
+                    <a href="{% url 'composer:compose' workspace_id=workspace.id %}?account={{ slot.account.id }}&scheduled_date={{ slot.compose_date }}&scheduled_time={{ slot.compose_time }}"
+                       class="calendar-slot-add"
+                       title="Schedule post for {{ slot.account.account_name|default:slot.account.account_handle }} at {{ slot.time_label }}">
+                        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
+                    </a>
+                    {% else %}
+                    <span class="calendar-slot-state">Open</span>
+                    {% endif %}
+                </div>
+                {% endfor %}
+            </div>
             {% endif %}
             {% for pp in hour_posts %}
             <a href="{% url 'composer:compose_edit' workspace_id=workspace.id post_id=pp.post_id %}?account={{ pp.social_account_id }}"

--- a/templates/calendar/partials/week_grid.html
+++ b/templates/calendar/partials/week_grid.html
@@ -21,14 +21,38 @@ Context: week_days, week_slots, workspace.
         <div class="border-r border-stone-200 px-2 py-1 text-right">
             <span class="text-[11px] font-medium text-stone-400 tabular-nums">{{ hour }}:00</span>
         </div>
-        {% for day, slot_posts in day_slots %}
-        <div class="border-r border-stone-100 last:border-r-0 p-1 cal-add-cell {% if slot_posts %}has-posts{% endif %} {% if day == today %}bg-orange-50/30{% endif %}"
+        {% for day, slot_posts, slot_items in day_slots %}
+        <div class="border-r border-stone-100 last:border-r-0 p-1 cal-add-cell {% if slot_posts or slot_items %}has-posts{% endif %} {% if day == today %}bg-orange-50/30{% endif %}"
              @dragover.prevent="allowDrop($event)"
              @drop="dropOnSlot($event, '{{ day|date:'Y-m-d' }}', {{ hour }})">
             {% if day > today or day == today and hour >= current_hour %}
             <a href="{% url 'composer:compose' workspace_id=workspace.id %}?scheduled_date={{ day|date:'Y-m-d' }}&scheduled_time={{ hour }}:00" class="cal-add-btn" title="Create post">
                 <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
             </a>
+            {% endif %}
+            {% if slot_items %}
+            <div class="flex flex-col gap-1 mb-1">
+                {% for slot in slot_items %}
+                <div class="calendar-channel-slot calendar-channel-slot--week {% if slot.is_taken %}is-taken{% else %}is-open{% endif %}">
+                    <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ slot.account.platform }} flex-shrink-0 text-white">
+                        {% include "social_accounts/partials/_platform_icon.html" with platform=slot.account.platform size="3" %}
+                    </span>
+                    <span class="truncate">{{ slot.account.account_name|default:slot.account.account_handle }}</span>
+                    <span class="tabular-nums text-stone-500">{{ slot.time_label }}</span>
+                    {% if slot.is_taken %}
+                    <span class="calendar-slot-state">Taken</span>
+                    {% elif day > today or day == today and hour >= current_hour %}
+                    <a href="{% url 'composer:compose' workspace_id=workspace.id %}?account={{ slot.account.id }}&scheduled_date={{ slot.compose_date }}&scheduled_time={{ slot.compose_time }}"
+                       class="calendar-slot-add"
+                       title="Schedule post for {{ slot.account.account_name|default:slot.account.account_handle }} at {{ slot.time_label }}">
+                        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
+                    </a>
+                    {% else %}
+                    <span class="calendar-slot-state">Open</span>
+                    {% endif %}
+                </div>
+                {% endfor %}
+            </div>
             {% endif %}
             {% for pp in slot_posts %}
             <a href="{% url 'composer:compose_edit' workspace_id=workspace.id post_id=pp.post_id %}?account={{ pp.social_account_id }}"

--- a/templates/calendar/partials/week_grid.html
+++ b/templates/calendar/partials/week_grid.html
@@ -33,15 +33,13 @@ Context: week_days, week_slots, workspace.
             {% if slot_items %}
             <div class="flex flex-col gap-1 mb-1">
                 {% for slot in slot_items %}
-                <div class="calendar-channel-slot calendar-channel-slot--week {% if slot.is_taken %}is-taken{% else %}is-open{% endif %}">
-                    <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ slot.account.platform }} flex-shrink-0 text-white">
+                <div class="calendar-channel-slot calendar-channel-slot--week {% if day < today or day == today and hour < current_hour %}is-past-open{% endif %}">
+                    <span class="calendar-slot-platform-icon">
                         {% include "social_accounts/partials/_platform_icon.html" with platform=slot.account.platform size="3" %}
                     </span>
                     <span class="truncate">{{ slot.account.account_name|default:slot.account.account_handle }}</span>
                     <span class="tabular-nums text-stone-500">{{ slot.time_label }}</span>
-                    {% if slot.is_taken %}
-                    <span class="calendar-slot-state">Taken</span>
-                    {% elif day > today or day == today and hour >= current_hour %}
+                    {% if day > today or day == today and hour >= current_hour %}
                     <a href="{% url 'composer:compose' workspace_id=workspace.id %}?account={{ slot.account.id }}&scheduled_date={{ slot.compose_date }}&scheduled_time={{ slot.compose_time }}"
                        class="calendar-slot-add"
                        title="Schedule post for {{ slot.account.account_name|default:slot.account.account_handle }} at {{ slot.time_label }}">
@@ -74,6 +72,11 @@ Context: week_days, week_slots, workspace.
                 {% endif %}
                 {% endwith %}
                 <span class="truncate">{{ pp.post.title|default:pp.post.caption_snippet|truncatechars:28 }}</span>
+                {% if pp.takes_calendar_slot %}
+                <span class="calendar-post-slot-check" title="Scheduled in a channel slot">
+                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                </span>
+                {% endif %}
             </a>
             {% endfor %}
         </div>


### PR DESCRIPTION
## What does this PR do?

Replaces the queue's compact-index scheduling with a **gap-aware, position-as-index** system across create, edit, and delete flows.

### Core behaviour changes

**`assign_queue_slots`** — stops normalising `QueueEntry.position` to a packed array index. Each entry's `position` is now used directly as an index into `_next_slot_datetimes()`, so intentional gaps between positions are preserved as empty time slots rather than silently closed on every recalculation.

**`add_to_queue`** — two modes:

- *Next available* (`priority=False`): scans positions from 0, fills the earliest unoccupied gap; appends after the last entry only when no gaps exist.
- *Prioritise* (`priority=True`): inserts at position 0. Only shifts existing entries +1 when position 0 is already taken by another post; if position 0 is free (a gap), fills it with no shifting. Existing gaps are preserved through any shift.

In both modes the post's own existing entry is excluded from the "occupied" set (`exclude(post=post)`) so re-queuing an already-queued post correctly re-evaluates its position rather than treating itself as an obstacle.

**`remove_from_queue`** (new) — deletes `QueueEntry` rows for a post on the given channels without calling `assign_queue_slots`, so the freed slot stays as a gap for the next "next available" fill. Called from `save_post` when a queued post is edited and the user switches to a specific scheduled date or "publish now".

**Delete** — cascade deletion already removes `QueueEntry`; `assign_queue_slots` is never triggered, so the freed slot becomes a natural gap. No code change needed.

**`reorder_queue`** — drag-and-drop sets compact positions 0, 1, 2 … explicitly before recalculating, which is the correct and intentional behaviour for manual reordering.

### Data migration

A new migration (`0006_normalise_queue_entry_positions`) shifts legacy queue entries from 1-indexed to 0-indexed per queue. The old `add_to_queue` computed `position = (max_pos or 0) + 1`, placing the first entry at position 1. With position-as-index, a queue starting at 1 would leave slot 0 permanently empty and shift every post one slot later than intended.

---

## Why?

Previously, any queue operation that called `assign_queue_slots` immediately compacted all positions back to 0, 1, 2 … This meant:

- Deleting a post silently pulled every later post one slot earlier.
- "Next available" always appended to the end, even when gaps existed from earlier deletions.
- "Prioritise" always shifted every post regardless of whether slot 0 was free.

Users expected queue gaps to be stable ("I deleted Wednesday's post; the Monday and Friday posts should stay where they are") and for "next available" to fill those gaps before appending.

---

## Transition coverage

| From → To | Behaviour |
|---|---|
| Queued → specific date | `remove_from_queue` frees slot as a gap; no other positions change |
| Queued → publish now | same |
| Specific date → next available | `add_to_queue` finds first gap ≥ position 0 |
| Specific date → prioritise | `add_to_queue(priority=True)`: fill or shift depending on slot 0 state |
| Publish now → next available / prioritise | same as above |
| Next available → prioritise | `exclude(post=post)` re-evaluates correctly; shifts only if slot 0 taken |
| Prioritise → next available | `exclude(post=post)` finds earliest gap; post stays at 0 if nothing is earlier |
| Delete (any scheduling mode) | Cascade removes entry; no recalculation; gap preserved |
| Multi-channel | All queue operations are scoped per-channel; each channel's queue is independent |

---

## How to test

1. Connect a channel and confirm it has posting slots on at least three different days.
2. Create three posts with **Next available** → confirm they land at queue positions 0, 1, 2 with the expected slot datetimes.
3. Delete the middle post (position 1). Confirm the remaining posts stay at positions 0 and 2 (slot datetimes unchanged).
4. Create a fourth post with **Next available** → confirm it fills position 1 (the gap), not position 3.
5. With slot 0 occupied, create a post with **Prioritise** → confirm it lands at position 0, all others shift +1, gaps preserved.
6. With slot 0 **free** (gap), create a post with **Prioritise** → confirm it fills slot 0 with no shifting.
7. Edit a queued post and switch to a **specific date** → confirm the `QueueEntry` is removed, the slot becomes a gap, and the post's `scheduled_at` reflects the chosen date.
8. Edit a queued post and switch to **Publish now** → same as above.
9. Edit a post from **Next available → Prioritise** and vice versa → confirm position updates correctly without disturbing other posts.
10. Run `pytest` and confirm no regressions.

## Checklist

- [x] Tests pass (`pytest`)
- [x] Lint passes (`ruff check .` and `ruff format --check .`)
- [ ] Documentation updated (if applicable)
