### PR TITLE
feat: Adds channel posting slots to the calendar day and week timeline views

### DIFF
--- a/apps/calendar/tests.py
+++ b/apps/calendar/tests.py
@@ -345,10 +345,11 @@ class CalendarChannelSlotViewTests(TestCase):
         context = {"display_timezone": "America/New_York"}
         _day_view_data(self.factory.get("/"), self.workspace, target, context)
 
+        hour_posts = dict((hour, posts) for hour, posts, _slots in context["day_slots"])[9]
         slot_items = dict((hour, slots) for hour, _posts, slots in context["day_slots"])[9]
-        self.assertEqual(len(slot_items), 1)
-        self.assertTrue(slot_items[0]["is_taken"])
-        self.assertEqual(slot_items[0]["time_label"], "09:30")
+        self.assertEqual(slot_items, [])
+        self.assertEqual(len(hour_posts), 1)
+        self.assertTrue(hour_posts[0].takes_calendar_slot)
 
     def test_day_view_channel_filter_limits_slot_badges(self):
         target = date(2026, 6, 15)  # Monday

--- a/apps/calendar/tests.py
+++ b/apps/calendar/tests.py
@@ -4,7 +4,7 @@ import zoneinfo
 from datetime import date, datetime, time
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from django.utils import timezone
 
@@ -12,6 +12,7 @@ from apps.accounts.models import User
 from apps.calendar.models import PostingSlot, Queue, QueueEntry, RecurrenceRule
 from apps.calendar.services import add_to_queue
 from apps.calendar.tasks import generate_recurring_posts
+from apps.calendar.views import _day_view_data
 from apps.composer.models import PlatformPost, Post
 from apps.members.models import OrgMembership, WorkspaceMembership
 from apps.organizations.models import Organization
@@ -304,6 +305,62 @@ class QueueSlotTimezoneTests(TestCase):
         entry = QueueEntry.objects.get(queue=self.queue, post=post)
         local = entry.assigned_slot_datetime.astimezone(zoneinfo.ZoneInfo("Asia/Tokyo"))
         self.assertEqual((local.hour, local.minute), (9, 0))
+
+
+class CalendarChannelSlotViewTests(TestCase):
+    """Day/week calendar data should expose channel posting slots."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.org = Organization.objects.create(name="Calendar Slots Org", default_timezone="America/New_York")
+        self.workspace = Workspace.objects.create(organization=self.org, name="Calendar Slots WS")
+        self.account = SocialAccount.objects.create(
+            workspace=self.workspace,
+            platform="instagram",
+            account_platform_id="ig-calendar-slots",
+            account_name="Instagram",
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+        self.other_account = SocialAccount.objects.create(
+            workspace=self.workspace,
+            platform="linkedin_company",
+            account_platform_id="li-calendar-slots",
+            account_name="LinkedIn",
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+
+    def test_day_view_marks_exact_channel_slot_taken(self):
+        target = date(2026, 6, 15)  # Monday
+        ny = zoneinfo.ZoneInfo("America/New_York")
+        scheduled_at = datetime(2026, 6, 15, 9, 30, tzinfo=ny)
+        PostingSlot.objects.create(social_account=self.account, day_of_week=0, time=time(9, 30))
+        post = Post.objects.create(workspace=self.workspace, caption="scheduled", scheduled_at=scheduled_at)
+        PlatformPost.objects.create(
+            post=post,
+            social_account=self.account,
+            status="scheduled",
+            scheduled_at=scheduled_at,
+        )
+
+        context = {"display_timezone": "America/New_York"}
+        _day_view_data(self.factory.get("/"), self.workspace, target, context)
+
+        slot_items = dict((hour, slots) for hour, _posts, slots in context["day_slots"])[9]
+        self.assertEqual(len(slot_items), 1)
+        self.assertTrue(slot_items[0]["is_taken"])
+        self.assertEqual(slot_items[0]["time_label"], "09:30")
+
+    def test_day_view_channel_filter_limits_slot_badges(self):
+        target = date(2026, 6, 15)  # Monday
+        PostingSlot.objects.create(social_account=self.account, day_of_week=0, time=time(9, 0))
+        PostingSlot.objects.create(social_account=self.other_account, day_of_week=0, time=time(9, 0))
+
+        request = self.factory.get("/", {"channel": str(self.account.id)})
+        context = {"display_timezone": "America/New_York"}
+        _day_view_data(request, self.workspace, target, context)
+
+        slot_items = dict((hour, slots) for hour, _posts, slots in context["day_slots"])[9]
+        self.assertEqual([slot["account"] for slot in slot_items], [self.account])
 
 
 class RecurringPostTimezoneTests(TestCase):

--- a/apps/calendar/tests.py
+++ b/apps/calendar/tests.py
@@ -363,6 +363,41 @@ class CalendarChannelSlotViewTests(TestCase):
         slot_items = dict((hour, slots) for hour, _posts, slots in context["day_slots"])[9]
         self.assertEqual([slot["account"] for slot in slot_items], [self.account])
 
+    def test_day_view_ignores_malformed_channel_filter(self):
+        target = date(2026, 6, 15)  # Monday
+        PostingSlot.objects.create(social_account=self.account, day_of_week=0, time=time(9, 0))
+
+        request = self.factory.get("/", {"channel": "not-a-uuid"})
+        context = {"display_timezone": "America/New_York"}
+        _day_view_data(request, self.workspace, target, context)
+
+        slot_items = dict((hour, slots) for hour, _posts, slots in context["day_slots"])[9]
+        self.assertEqual([slot["account"] for slot in slot_items], [self.account])
+
+    def test_day_view_includes_workspace_slot_from_adjacent_display_date(self):
+        self.workspace.timezone = "America/Los_Angeles"
+        self.workspace.save(update_fields=["timezone"])
+        target = date(2026, 6, 16)  # Tuesday in Tokyo
+        la = zoneinfo.ZoneInfo("America/Los_Angeles")
+        scheduled_at = datetime(2026, 6, 15, 9, 0, tzinfo=la)
+        PostingSlot.objects.create(social_account=self.account, day_of_week=0, time=time(9, 0))
+        post = Post.objects.create(workspace=self.workspace, caption="tokyo-boundary", scheduled_at=scheduled_at)
+        PlatformPost.objects.create(
+            post=post,
+            social_account=self.account,
+            status="scheduled",
+            scheduled_at=scheduled_at,
+        )
+
+        context = {"display_timezone": "Asia/Tokyo"}
+        _day_view_data(self.factory.get("/"), self.workspace, target, context)
+
+        hour_posts = dict((hour, posts) for hour, posts, _slots in context["day_slots"])[1]
+        slot_items = dict((hour, slots) for hour, _posts, slots in context["day_slots"])[1]
+        self.assertEqual(slot_items, [])
+        self.assertEqual(len(hour_posts), 1)
+        self.assertTrue(hour_posts[0].takes_calendar_slot)
+
 
 class RecurringPostTimezoneTests(TestCase):
     """``generate_recurring_posts`` must preserve the source post's *local*

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -2,6 +2,7 @@
 
 import calendar as cal_mod
 import json
+import uuid
 from collections import defaultdict
 from datetime import date, datetime, time, timedelta
 
@@ -96,6 +97,17 @@ def _parse_date(date_str, default=None):
     return default or date.today()
 
 
+def _get_valid_channel_filter(request):
+    """Return a UUID-safe channel filter value, or blank when malformed."""
+    channel = request.GET.get("channel", "").strip()
+    if not channel:
+        return ""
+    try:
+        return str(uuid.UUID(channel))
+    except (TypeError, ValueError, AttributeError):
+        return ""
+
+
 def _get_filtered_posts(workspace, request):
     """Apply calendar filters from query params."""
     qs = (
@@ -172,7 +184,7 @@ def _get_filtered_platform_posts(workspace, request):
         qs = qs.filter(social_account__platform__in=platforms)
 
     # Channel filter (calendar toolbar sends the selected SocialAccount id).
-    channel = request.GET.get("channel")
+    channel = _get_valid_channel_filter(request)
     if channel:
         qs = qs.filter(social_account_id=channel)
 
@@ -213,8 +225,8 @@ def _get_calendar_slot_occurrences(workspace, request, display_tz, visible_dates
     if not visible_dates:
         return defaultdict(list)
 
-    first_date = min(visible_dates)
-    last_date = max(visible_dates)
+    first_date = min(visible_dates) - timedelta(days=1)
+    last_date = max(visible_dates) + timedelta(days=1)
     occurrence_dates = [first_date + timedelta(days=offset) for offset in range((last_date - first_date).days + 1)]
 
     slots = PostingSlot.objects.filter(
@@ -222,7 +234,7 @@ def _get_calendar_slot_occurrences(workspace, request, display_tz, visible_dates
         social_account__connection_status=SocialAccount.ConnectionStatus.CONNECTED,
         is_active=True,
     )
-    channel = request.GET.get("channel")
+    channel = _get_valid_channel_filter(request)
     if channel:
         slots = slots.filter(social_account_id=channel)
 

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -761,9 +761,7 @@ def _day_view_data(request, workspace, target_date, context):
     hours = list(range(0, 24))
 
     # Build a list of (hour, posts, slots) tuples for easy template iteration
-    day_slots = [
-        (hour, posts_by_hour.get(hour, []), slots_by_hour.get((target_date, hour), [])) for hour in hours
-    ]
+    day_slots = [(hour, posts_by_hour.get(hour, []), slots_by_hour.get((target_date, hour), [])) for hour in hours]
 
     from django.utils import timezone as _tz
 

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -171,6 +171,11 @@ def _get_filtered_platform_posts(workspace, request):
     if platforms:
         qs = qs.filter(social_account__platform__in=platforms)
 
+    # Channel filter (calendar toolbar sends the selected SocialAccount id).
+    channel = request.GET.get("channel")
+    if channel:
+        qs = qs.filter(social_account_id=channel)
+
     # Author filter
     authors = request.GET.getlist("author")
     if authors:
@@ -192,6 +197,76 @@ def _get_filtered_platform_posts(workspace, request):
         qs = qs.filter(tag_q)
 
     return qs
+
+
+def _get_calendar_slot_occurrences(workspace, request, display_tz, visible_dates, platform_posts):
+    """Return PostingSlot occurrences grouped by display date/hour.
+
+    PostingSlot times are defined in the workspace timezone. Convert concrete
+    occurrences into the active display timezone before placing them in the
+    day/week timeline, so timezone changes move slots and posts together.
+    """
+    import zoneinfo
+
+    workspace_tz = zoneinfo.ZoneInfo(workspace.effective_timezone or "UTC")
+    visible_dates = set(visible_dates)
+    if not visible_dates:
+        return defaultdict(list)
+
+    first_date = min(visible_dates)
+    last_date = max(visible_dates)
+    occurrence_dates = [first_date + timedelta(days=offset) for offset in range((last_date - first_date).days + 1)]
+
+    taken_keys = set()
+    for pp in platform_posts:
+        if not pp.effective_at:
+            continue
+        local_dt = pp.effective_at.astimezone(display_tz)
+        if local_dt.date() in visible_dates:
+            taken_keys.add((pp.social_account_id, local_dt.date(), local_dt.hour, local_dt.minute))
+
+    slots = PostingSlot.objects.filter(
+        social_account__workspace=workspace,
+        social_account__connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        is_active=True,
+    )
+    channel = request.GET.get("channel")
+    if channel:
+        slots = slots.filter(social_account_id=channel)
+
+    slots = slots.select_related("social_account").order_by(
+        "time",
+        "social_account__platform",
+        "social_account__account_name",
+    )
+
+    slots_by_hour = defaultdict(list)
+    dates_by_weekday = defaultdict(list)
+    for occurrence_date in occurrence_dates:
+        dates_by_weekday[occurrence_date.weekday()].append(occurrence_date)
+
+    for slot in slots:
+        for occurrence_date in dates_by_weekday.get(slot.day_of_week, []):
+            workspace_dt = datetime.combine(occurrence_date, slot.time, tzinfo=workspace_tz)
+            local_dt = workspace_dt.astimezone(display_tz)
+            if local_dt.date() not in visible_dates:
+                continue
+
+            key = (slot.social_account_id, local_dt.date(), local_dt.hour, local_dt.minute)
+            slots_by_hour[(local_dt.date(), local_dt.hour)].append(
+                {
+                    "account": slot.social_account,
+                    "date": local_dt.date(),
+                    "hour": local_dt.hour,
+                    "minute": local_dt.minute,
+                    "time_label": local_dt.strftime("%H:%M"),
+                    "compose_date": workspace_dt.strftime("%Y-%m-%d"),
+                    "compose_time": workspace_dt.strftime("%H:%M"),
+                    "is_taken": key in taken_keys,
+                }
+            )
+
+    return slots_by_hour
 
 
 def _get_publish_context(workspace, request):
@@ -621,16 +696,17 @@ def _week_view_data(request, workspace, target_date, context):
                 key = (local_dt.date(), local_dt.hour)
                 posts_by_slot[key].append(pp)
 
+    slots_by_hour = _get_calendar_slot_occurrences(workspace, request, display_tz, week_days, platform_posts)
     hours = list(range(0, 24))
 
     # Build a grid structure the template can iterate:
-    # week_slots = [(hour, [(day, posts), ...]), ...]
+    # week_slots = [(hour, [(day, posts, slots), ...]), ...]
     week_slots = []
     for hour in hours:
         day_slots = []
         for day in week_days:
             key = (day, hour)
-            day_slots.append((day, posts_by_slot.get(key, [])))
+            day_slots.append((day, posts_by_slot.get(key, []), slots_by_hour.get(key, [])))
         week_slots.append((hour, day_slots))
 
     from django.utils import timezone as _tz
@@ -681,10 +757,13 @@ def _day_view_data(request, workspace, target_date, context):
             if local_dt.date() == target_date:
                 posts_by_hour[local_dt.hour].append(pp)
 
+    slots_by_hour = _get_calendar_slot_occurrences(workspace, request, display_tz, [target_date], platform_posts)
     hours = list(range(0, 24))
 
-    # Build a list of (hour, posts) tuples for easy template iteration
-    day_slots = [(hour, posts_by_hour.get(hour, [])) for hour in hours]
+    # Build a list of (hour, posts, slots) tuples for easy template iteration
+    day_slots = [
+        (hour, posts_by_hour.get(hour, []), slots_by_hour.get((target_date, hour), [])) for hour in hours
+    ]
 
     from django.utils import timezone as _tz
 

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -217,14 +217,6 @@ def _get_calendar_slot_occurrences(workspace, request, display_tz, visible_dates
     last_date = max(visible_dates)
     occurrence_dates = [first_date + timedelta(days=offset) for offset in range((last_date - first_date).days + 1)]
 
-    taken_keys = set()
-    for pp in platform_posts:
-        if not pp.effective_at:
-            continue
-        local_dt = pp.effective_at.astimezone(display_tz)
-        if local_dt.date() in visible_dates:
-            taken_keys.add((pp.social_account_id, local_dt.date(), local_dt.hour, local_dt.minute))
-
     slots = PostingSlot.objects.filter(
         social_account__workspace=workspace,
         social_account__connection_status=SocialAccount.ConnectionStatus.CONNECTED,
@@ -241,6 +233,8 @@ def _get_calendar_slot_occurrences(workspace, request, display_tz, visible_dates
     )
 
     slots_by_hour = defaultdict(list)
+    slot_keys = set()
+    slot_occurrences = []
     dates_by_weekday = defaultdict(list)
     for occurrence_date in occurrence_dates:
         dates_by_weekday[occurrence_date.weekday()].append(occurrence_date)
@@ -253,18 +247,37 @@ def _get_calendar_slot_occurrences(workspace, request, display_tz, visible_dates
                 continue
 
             key = (slot.social_account_id, local_dt.date(), local_dt.hour, local_dt.minute)
-            slots_by_hour[(local_dt.date(), local_dt.hour)].append(
-                {
-                    "account": slot.social_account,
-                    "date": local_dt.date(),
-                    "hour": local_dt.hour,
-                    "minute": local_dt.minute,
-                    "time_label": local_dt.strftime("%H:%M"),
-                    "compose_date": workspace_dt.strftime("%Y-%m-%d"),
-                    "compose_time": workspace_dt.strftime("%H:%M"),
-                    "is_taken": key in taken_keys,
-                }
+            slot_keys.add(key)
+            slot_occurrences.append(
+                (
+                    key,
+                    {
+                        "account": slot.social_account,
+                        "date": local_dt.date(),
+                        "hour": local_dt.hour,
+                        "minute": local_dt.minute,
+                        "time_label": local_dt.strftime("%H:%M"),
+                        "compose_date": workspace_dt.strftime("%Y-%m-%d"),
+                        "compose_time": workspace_dt.strftime("%H:%M"),
+                    },
+                )
             )
+
+    taken_keys = set()
+    for pp in platform_posts:
+        pp.takes_calendar_slot = False
+        if not pp.effective_at:
+            continue
+        local_dt = pp.effective_at.astimezone(display_tz)
+        key = (pp.social_account_id, local_dt.date(), local_dt.hour, local_dt.minute)
+        if key in slot_keys:
+            pp.takes_calendar_slot = True
+            taken_keys.add(key)
+
+    for key, slot in slot_occurrences:
+        if key in taken_keys:
+            continue
+        slots_by_hour[(slot["date"], slot["hour"])].append(slot)
 
     return slots_by_hour
 
@@ -677,7 +690,7 @@ def _week_view_data(request, workspace, target_date, context):
     week_days = [monday + timedelta(days=i) for i in range(7)]
 
     # Widen query by ±1 day to handle timezone boundary shifts
-    platform_posts = (
+    platform_posts = list(
         _get_filtered_platform_posts(workspace, request)
         .filter(
             effective_at__date__gte=week_days[0] - timedelta(days=1),
@@ -740,7 +753,7 @@ def _day_view_data(request, workspace, target_date, context):
     display_tz = zoneinfo.ZoneInfo(context.get("display_timezone", "UTC"))
 
     # Widen query by ±1 day to handle timezone boundary shifts
-    platform_posts = (
+    platform_posts = list(
         _get_filtered_platform_posts(workspace, request)
         .filter(
             effective_at__date__gte=target_date - timedelta(days=1),

--- a/apps/composer/views.py
+++ b/apps/composer/views.py
@@ -445,9 +445,11 @@ def compose(request, workspace_id, post_id=None):
         .order_by("platform", "account_name")
     )
 
-    # When opening from calendar with a specific account, show only that account
-    if account_filter and post_id:
+    # When opening from calendar with a specific account, show only that account.
+    if account_filter:
         social_accounts = social_accounts.filter(id=account_filter)
+        if not post_id and social_accounts.exists():
+            selected_account_ids = [account_filter]
 
     # Platform character limits for JS
     char_limits = {}

--- a/templates/calendar/calendar.html
+++ b/templates/calendar/calendar.html
@@ -235,6 +235,60 @@
         transform: scale(1.1);
     }
 
+    .calendar-channel-slot {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        max-width: 100%;
+        min-height: 24px;
+        padding: 3px 5px;
+        border-radius: 6px;
+        font-size: 11px;
+        font-weight: 600;
+        border: 1px solid #E7E5E4;
+        background: #FAFAF9;
+        color: #44403C;
+    }
+    .calendar-channel-slot--week {
+        width: 100%;
+        font-size: 10px;
+        gap: 4px;
+    }
+    .calendar-channel-slot.is-open {
+        border-color: #FED7AA;
+        background: #FFF7ED;
+    }
+    .calendar-channel-slot.is-taken {
+        border-color: #BBF7D0;
+        background: #F0FDF4;
+    }
+    .calendar-slot-state {
+        flex-shrink: 0;
+        padding: 1px 5px;
+        border-radius: 9999px;
+        background: rgba(255,255,255,0.72);
+        color: #57534E;
+        font-size: 9px;
+        text-transform: uppercase;
+        letter-spacing: 0;
+    }
+    .calendar-slot-add {
+        flex-shrink: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 18px;
+        height: 18px;
+        border-radius: 9999px;
+        background: #F97316;
+        color: white;
+        box-shadow: 0 1px 4px rgba(249,115,22,0.25);
+    }
+    .calendar-slot-add:hover {
+        background: #EA580C;
+        transform: scale(1.05);
+    }
+
     /* Draggable feedback */
     .post-chip.dragging { opacity: 0.5; transform: rotate(2deg); }
 

--- a/templates/calendar/calendar.html
+++ b/templates/calendar/calendar.html
@@ -245,32 +245,29 @@
         border-radius: 6px;
         font-size: 11px;
         font-weight: 600;
-        border: 1px solid #E7E5E4;
-        background: #FAFAF9;
-        color: #44403C;
+        border: 1px dashed #E7E5E4;
+        background: #FFFFFF;
+        color: #78716C;
     }
     .calendar-channel-slot--week {
         width: 100%;
         font-size: 10px;
         gap: 4px;
     }
-    .calendar-channel-slot.is-open {
-        border-color: #FED7AA;
-        background: #FFF7ED;
+    .calendar-channel-slot.is-past-open {
+        opacity: 0.45;
+        background: #FAFAF9;
     }
-    .calendar-channel-slot.is-taken {
-        border-color: #BBF7D0;
-        background: #F0FDF4;
-    }
-    .calendar-slot-state {
+    .calendar-slot-platform-icon {
         flex-shrink: 0;
-        padding: 1px 5px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 16px;
+        height: 16px;
         border-radius: 9999px;
-        background: rgba(255,255,255,0.72);
-        color: #57534E;
-        font-size: 9px;
-        text-transform: uppercase;
-        letter-spacing: 0;
+        background: #F5F5F4;
+        color: #78716C;
     }
     .calendar-slot-add {
         flex-shrink: 0;
@@ -280,13 +277,24 @@
         width: 18px;
         height: 18px;
         border-radius: 9999px;
-        background: #F97316;
-        color: white;
-        box-shadow: 0 1px 4px rgba(249,115,22,0.25);
+        background: #FFEDD5;
+        color: #C2410C;
     }
     .calendar-slot-add:hover {
-        background: #EA580C;
+        background: #FED7AA;
         transform: scale(1.05);
+    }
+    .calendar-post-slot-check {
+        flex-shrink: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 16px;
+        height: 16px;
+        border-radius: 9999px;
+        background: rgba(255,255,255,0.72);
+        color: #15803D;
+        margin-left: auto;
     }
 
     /* Draggable feedback */

--- a/templates/calendar/partials/day_grid.html
+++ b/templates/calendar/partials/day_grid.html
@@ -24,15 +24,13 @@ Context: day_slots, target_date, workspace.
             {% if slot_items %}
             <div class="flex flex-wrap gap-1.5">
                 {% for slot in slot_items %}
-                <div class="calendar-channel-slot {% if slot.is_taken %}is-taken{% else %}is-open{% endif %}">
-                    <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ slot.account.platform }} flex-shrink-0 text-white">
+                <div class="calendar-channel-slot {% if is_past_day or is_today and hour < current_hour %}is-past-open{% endif %}">
+                    <span class="calendar-slot-platform-icon">
                         {% include "social_accounts/partials/_platform_icon.html" with platform=slot.account.platform size="3" %}
                     </span>
                     <span class="truncate">{{ slot.account.account_name|default:slot.account.account_handle }}</span>
                     <span class="tabular-nums text-stone-500">{{ slot.time_label }}</span>
-                    {% if slot.is_taken %}
-                    <span class="calendar-slot-state">Taken</span>
-                    {% elif not is_past_day and not is_today or not is_past_day and hour >= current_hour %}
+                    {% if not is_past_day and not is_today or not is_past_day and hour >= current_hour %}
                     <a href="{% url 'composer:compose' workspace_id=workspace.id %}?account={{ slot.account.id }}&scheduled_date={{ slot.compose_date }}&scheduled_time={{ slot.compose_time }}"
                        class="calendar-slot-add"
                        title="Schedule post for {{ slot.account.account_name|default:slot.account.account_handle }} at {{ slot.time_label }}">
@@ -65,6 +63,11 @@ Context: day_slots, target_date, workspace.
                 {% endif %}
                 {% endwith %}
                 <span class="truncate">{{ pp.post.title|default:pp.post.caption_snippet|truncatechars:28 }}</span>
+                {% if pp.takes_calendar_slot %}
+                <span class="calendar-post-slot-check" title="Scheduled in a channel slot">
+                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                </span>
+                {% endif %}
             </a>
             {% endfor %}
         </div>

--- a/templates/calendar/partials/day_grid.html
+++ b/templates/calendar/partials/day_grid.html
@@ -4,8 +4,8 @@ Context: day_slots, target_date, workspace.
 {% endcomment %}
 
 <div class="bg-white mx-auto" style="animation: slideUp 200ms cubic-bezier(0.16,1,0.3,1) both; max-height: calc(100vh - 200px); overflow-y: auto;">
-    {% for hour, hour_posts in day_slots %}
-    <div class="flex border-b border-stone-100 min-h-[64px] cal-add-cell {% if hour_posts %}has-posts{% endif %} {% if is_today and hour == current_hour %}bg-orange-50/50{% endif %}"
+{% for hour, hour_posts, slot_items in day_slots %}
+    <div class="flex border-b border-stone-100 min-h-[64px] cal-add-cell {% if hour_posts or slot_items %}has-posts{% endif %} {% if is_today and hour == current_hour %}bg-orange-50/50{% endif %}"
          @dragover.prevent="allowDrop($event)"
          @drop="dropOnSlot($event, '{{ target_date|date:'Y-m-d' }}', {{ hour }})">
         <!-- Time label -->
@@ -14,12 +14,36 @@ Context: day_slots, target_date, workspace.
                 {% if hour < 10 %}0{% endif %}{{ hour }}:00
             </span>
         </div>
-        <!-- Posts in this hour -->
+        <!-- Slots and posts in this hour -->
         <div class="flex-1 p-2 flex flex-col justify-center gap-1">
             {% if not is_past_day and not is_today or not is_past_day and hour >= current_hour %}
             <a href="{% url 'composer:compose' workspace_id=workspace.id %}?scheduled_date={{ target_date|date:'Y-m-d' }}&scheduled_time={{ hour }}:00" class="cal-add-btn cal-add-btn--inline" style="position:static; margin:0 auto;" title="Create post">
                 <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
             </a>
+            {% endif %}
+            {% if slot_items %}
+            <div class="flex flex-wrap gap-1.5">
+                {% for slot in slot_items %}
+                <div class="calendar-channel-slot {% if slot.is_taken %}is-taken{% else %}is-open{% endif %}">
+                    <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ slot.account.platform }} flex-shrink-0 text-white">
+                        {% include "social_accounts/partials/_platform_icon.html" with platform=slot.account.platform size="3" %}
+                    </span>
+                    <span class="truncate">{{ slot.account.account_name|default:slot.account.account_handle }}</span>
+                    <span class="tabular-nums text-stone-500">{{ slot.time_label }}</span>
+                    {% if slot.is_taken %}
+                    <span class="calendar-slot-state">Taken</span>
+                    {% elif not is_past_day and not is_today or not is_past_day and hour >= current_hour %}
+                    <a href="{% url 'composer:compose' workspace_id=workspace.id %}?account={{ slot.account.id }}&scheduled_date={{ slot.compose_date }}&scheduled_time={{ slot.compose_time }}"
+                       class="calendar-slot-add"
+                       title="Schedule post for {{ slot.account.account_name|default:slot.account.account_handle }} at {{ slot.time_label }}">
+                        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
+                    </a>
+                    {% else %}
+                    <span class="calendar-slot-state">Open</span>
+                    {% endif %}
+                </div>
+                {% endfor %}
+            </div>
             {% endif %}
             {% for pp in hour_posts %}
             <a href="{% url 'composer:compose_edit' workspace_id=workspace.id post_id=pp.post_id %}?account={{ pp.social_account_id }}"

--- a/templates/calendar/partials/week_grid.html
+++ b/templates/calendar/partials/week_grid.html
@@ -21,14 +21,38 @@ Context: week_days, week_slots, workspace.
         <div class="border-r border-stone-200 px-2 py-1 text-right">
             <span class="text-[11px] font-medium text-stone-400 tabular-nums">{{ hour }}:00</span>
         </div>
-        {% for day, slot_posts in day_slots %}
-        <div class="border-r border-stone-100 last:border-r-0 p-1 cal-add-cell {% if slot_posts %}has-posts{% endif %} {% if day == today %}bg-orange-50/30{% endif %}"
+        {% for day, slot_posts, slot_items in day_slots %}
+        <div class="border-r border-stone-100 last:border-r-0 p-1 cal-add-cell {% if slot_posts or slot_items %}has-posts{% endif %} {% if day == today %}bg-orange-50/30{% endif %}"
              @dragover.prevent="allowDrop($event)"
              @drop="dropOnSlot($event, '{{ day|date:'Y-m-d' }}', {{ hour }})">
             {% if day > today or day == today and hour >= current_hour %}
             <a href="{% url 'composer:compose' workspace_id=workspace.id %}?scheduled_date={{ day|date:'Y-m-d' }}&scheduled_time={{ hour }}:00" class="cal-add-btn" title="Create post">
                 <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
             </a>
+            {% endif %}
+            {% if slot_items %}
+            <div class="flex flex-col gap-1 mb-1">
+                {% for slot in slot_items %}
+                <div class="calendar-channel-slot calendar-channel-slot--week {% if slot.is_taken %}is-taken{% else %}is-open{% endif %}">
+                    <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ slot.account.platform }} flex-shrink-0 text-white">
+                        {% include "social_accounts/partials/_platform_icon.html" with platform=slot.account.platform size="3" %}
+                    </span>
+                    <span class="truncate">{{ slot.account.account_name|default:slot.account.account_handle }}</span>
+                    <span class="tabular-nums text-stone-500">{{ slot.time_label }}</span>
+                    {% if slot.is_taken %}
+                    <span class="calendar-slot-state">Taken</span>
+                    {% elif day > today or day == today and hour >= current_hour %}
+                    <a href="{% url 'composer:compose' workspace_id=workspace.id %}?account={{ slot.account.id }}&scheduled_date={{ slot.compose_date }}&scheduled_time={{ slot.compose_time }}"
+                       class="calendar-slot-add"
+                       title="Schedule post for {{ slot.account.account_name|default:slot.account.account_handle }} at {{ slot.time_label }}">
+                        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
+                    </a>
+                    {% else %}
+                    <span class="calendar-slot-state">Open</span>
+                    {% endif %}
+                </div>
+                {% endfor %}
+            </div>
             {% endif %}
             {% for pp in slot_posts %}
             <a href="{% url 'composer:compose_edit' workspace_id=workspace.id post_id=pp.post_id %}?account={{ pp.social_account_id }}"

--- a/templates/calendar/partials/week_grid.html
+++ b/templates/calendar/partials/week_grid.html
@@ -33,15 +33,13 @@ Context: week_days, week_slots, workspace.
             {% if slot_items %}
             <div class="flex flex-col gap-1 mb-1">
                 {% for slot in slot_items %}
-                <div class="calendar-channel-slot calendar-channel-slot--week {% if slot.is_taken %}is-taken{% else %}is-open{% endif %}">
-                    <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ slot.account.platform }} flex-shrink-0 text-white">
+                <div class="calendar-channel-slot calendar-channel-slot--week {% if day < today or day == today and hour < current_hour %}is-past-open{% endif %}">
+                    <span class="calendar-slot-platform-icon">
                         {% include "social_accounts/partials/_platform_icon.html" with platform=slot.account.platform size="3" %}
                     </span>
                     <span class="truncate">{{ slot.account.account_name|default:slot.account.account_handle }}</span>
                     <span class="tabular-nums text-stone-500">{{ slot.time_label }}</span>
-                    {% if slot.is_taken %}
-                    <span class="calendar-slot-state">Taken</span>
-                    {% elif day > today or day == today and hour >= current_hour %}
+                    {% if day > today or day == today and hour >= current_hour %}
                     <a href="{% url 'composer:compose' workspace_id=workspace.id %}?account={{ slot.account.id }}&scheduled_date={{ slot.compose_date }}&scheduled_time={{ slot.compose_time }}"
                        class="calendar-slot-add"
                        title="Schedule post for {{ slot.account.account_name|default:slot.account.account_handle }} at {{ slot.time_label }}">
@@ -74,6 +72,11 @@ Context: week_days, week_slots, workspace.
                 {% endif %}
                 {% endwith %}
                 <span class="truncate">{{ pp.post.title|default:pp.post.caption_snippet|truncatechars:28 }}</span>
+                {% if pp.takes_calendar_slot %}
+                <span class="calendar-post-slot-check" title="Scheduled in a channel slot">
+                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                </span>
+                {% endif %}
             </a>
             {% endfor %}
         </div>


### PR DESCRIPTION
## What does this PR do?

Adds channel posting slots to the calendar day and week timeline views.

- Shows active open `PostingSlot` occurrences as compact, lighter channel badges in the matching hour cells.
- Fades past open slots so they are visible but less prominent.
- Hides taken slot badges and adds a checkmark to matching post chips instead.
- Adds an open-slot action that opens the composer with the channel and slot date/time preselected.
- Applies the calendar channel filter to both platform post chips and slot badges.
- Lets the create composer respect `?account=` so slot-created posts start scoped to the intended channel.
- Hides taken slot badges from day/week calendar cells.
- Adds a checkmark badge directly on post chips when the post occupies a channel slot.
- Uses lighter visual styling for open slot badges so they do not compete with actual post chips.
- Fades past open slots so unavailable historical gaps are still visible but less prominent.

## Why?

The publish calendar already showed scheduled posts, but it did not expose the underlying channel schedule in day/week views. This makes gaps and occupied slots visible at a glance, and gives users a direct path to schedule a new post into an available channel slot without changing existing post rendering or drag/drop behavior.

## How to test

- `.venv/bin/python -m pytest apps/calendar/tests.py -q`
- `DJANGO_SETTINGS_MODULE=config.settings.test SECRET_KEY=test-secret-key-not-for-production DATABASE_URL=sqlite:///:memory: .venv/bin/python manage.py check`
- `.venv/bin/python -m ruff check .`
- `.venv/bin/python -m ruff format --check .`

## Checklist

- [x] Tests pass (`pytest`) - focused calendar tests pass; full suite not run locally.
- [x] Lint passes (`ruff check .` and `ruff format --check .`)
- [x] Documentation updated (if applicable) - not applicable; no setup or configuration docs changed.