### PR TITLE
fix: keep chip schedule-clear off the publisher's scheduled_at fallback

### DIFF
--- a/apps/composer/services.py
+++ b/apps/composer/services.py
@@ -32,31 +32,30 @@ def sync_post_scheduled_at(post):
       kept appearing as scheduled in the UI.
     * No children, parent already null → no-op.
 
-    A post committed to publishing also drops any draft-stage
-    ``proposed_publish_at``. This is the single chokepoint every scheduling
-    path flows through — ``create_post``, ``transition_platform_post`` (the
-    service used by the REST ``/schedule`` route and the MCP ``schedule_draft``
-    tool), the composer's per-account chip endpoint, and the PATCH re-time —
-    so the suggestion and a committed schedule never coexist. The clear is
-    keyed on child *status*, not ``scheduled_at``, so a status-only transition
-    (the chip menu sets ``scheduled`` without a ``scheduled_at``) still drops
-    it; this mirrors ``_capture_proposed_publish_at``'s guard.
+    A post that gains a committed schedule also drops any draft-stage
+    ``proposed_publish_at``: this is the chokepoint the scheduling paths flow
+    through (``create_post``, ``transition_platform_post`` for the REST
+    ``/schedule`` route and the MCP ``schedule_draft`` tool, and the PATCH
+    re-time which calls this after saving), so the suggestion and a real
+    schedule never coexist. The ``scheduled_at`` aggregate logic is unchanged —
+    the publisher's ``Coalesce(scheduled_at, post__scheduled_at)`` fallback
+    depends on it — so only the proposal clear is added here. The one path that
+    commits a child WITHOUT a ``scheduled_at`` (the composer's per-account chip
+    endpoint) clears the proposal itself rather than routing through here, to
+    avoid disturbing that aggregate.
     """
     times = list(post.platform_posts.exclude(scheduled_at__isnull=True).values_list("scheduled_at", flat=True))
-    update_fields = []
     if not times:
         if post.scheduled_at is not None:
             post.scheduled_at = None
-            update_fields.append("scheduled_at")
-    else:
-        earliest = min(times)
-        if post.scheduled_at != earliest:
-            post.scheduled_at = earliest
-            update_fields.append("scheduled_at")
-    if (
-        post.proposed_publish_at is not None
-        and post.platform_posts.filter(status__in=["scheduled", "publishing", "published"]).exists()
-    ):
+            post.save(update_fields=["scheduled_at", "updated_at"])
+        return
+    earliest = min(times)
+    update_fields = []
+    if post.scheduled_at != earliest:
+        post.scheduled_at = earliest
+        update_fields.append("scheduled_at")
+    if post.proposed_publish_at is not None:
         post.proposed_publish_at = None
         update_fields.append("proposed_publish_at")
     if update_fields:

--- a/apps/composer/tests/test_proposed_publish_at.py
+++ b/apps/composer/tests/test_proposed_publish_at.py
@@ -78,25 +78,6 @@ class ProposedPublishAtServiceTests(TestCase):
         self.assertIsNotNone(post.scheduled_at)
         self.assertIsNone(post.proposed_publish_at)
 
-    def test_sync_clears_proposed_on_status_only_committed_child(self):
-        # The composer chip endpoint commits a child to 'scheduled' WITHOUT a
-        # scheduled_at; the status-keyed clear must still drop the proposal.
-        from apps.composer.services import sync_post_scheduled_at
-
-        post = create_post(
-            workspace=self.ws,
-            social_account=self.sa,
-            caption="hi",
-            status="draft",
-            proposed_publish_at=PROPOSED_LOCAL,
-        )
-        pp = post.platform_posts.get()
-        pp.status = "scheduled"
-        pp.save(update_fields=["status"])
-        sync_post_scheduled_at(post)
-        post.refresh_from_db()
-        self.assertIsNone(post.proposed_publish_at)
-
 
 class ProposedPublishAtSaveTests(TestCase):
     """POST /workspace/<id>/composer/compose/save/ proposed-time handling."""
@@ -300,5 +281,20 @@ class ProposedPublishAtSaveTests(TestCase):
         self.assertEqual(resp.status_code, 200)
         post.refresh_from_db()
         self.assertIsNone(post.proposed_publish_at)
+        # The clear must not disturb the scheduling aggregate the publisher reads.
+        self.assertIsNone(post.scheduled_at)
         pp.refresh_from_db()
         self.assertEqual(pp.status, "scheduled")
+
+    def test_publisher_fallback_still_picks_up_scheduled_post(self):
+        # Regression guard for the publish path: a scheduled child with NULL
+        # scheduled_at must stay "due" via the Post.scheduled_at Coalesce
+        # fallback. The proposal handling must never disturb that aggregate,
+        # else such a post would silently never publish.
+        from apps.publisher.engine import PublishEngine
+
+        past = timezone.now() - timedelta(minutes=5)
+        post = Post.objects.create(workspace=self.ws, author=self.user, caption="x", scheduled_at=past)
+        pp = PlatformPost.objects.create(post=post, social_account=self.sa, status="scheduled", scheduled_at=None)
+        due_ids = {d.id for d in PublishEngine()._get_due_platform_posts()}
+        self.assertIn(pp.id, due_ids)

--- a/apps/composer/views.py
+++ b/apps/composer/views.py
@@ -1005,13 +1005,14 @@ def transition_platform_post(request, workspace_id, post_id, platform_post_id):
     except ValueError as exc:
         return JsonResponse({"error": str(exc)}, status=400)
     pp.save(update_fields=["status", "published_at", "updated_at"])
-    # This view mutates a single child directly (no service call), so reconcile
-    # the parent the same way the service-layer transition does: keep
-    # Post.scheduled_at in sync and drop any now-obsolete proposed_publish_at
-    # when this transition commits the post to publishing.
-    from apps.composer.services import sync_post_scheduled_at
-
-    sync_post_scheduled_at(pp.post)
+    # Committing a child to publishing obsoletes any draft-stage proposal.
+    # Clear it directly rather than via sync_post_scheduled_at: this view sets
+    # ``scheduled`` WITHOUT a ``scheduled_at``, and the publisher relies on the
+    # ``Coalesce(scheduled_at, post__scheduled_at)`` fallback — recomputing the
+    # Post.scheduled_at aggregate here could strand a post that depends on it.
+    if target in ("scheduled", "publishing", "published") and pp.post.proposed_publish_at is not None:
+        pp.post.proposed_publish_at = None
+        pp.post.save(update_fields=["proposed_publish_at", "updated_at"])
     return JsonResponse({"ok": True, "status": pp.status, "platform_post_id": str(pp.id)})
 
 


### PR DESCRIPTION
## What does this PR do?

Follow-up to #81. That PR's squash merge captured the branch only up to the
intermediate Codex fix — the final **publisher-safety revision didn't make it
into `main`**. This lands it.

In the merged code, the composer per-account chip endpoint clears the draft
proposal by calling `sync_post_scheduled_at(pp.post)`. That recomputes the
`Post.scheduled_at` aggregate, which the publisher's due query depends on via
`Coalesce(scheduled_at, post__scheduled_at)` ([engine.py](apps/publisher/engine.py)) — a `PlatformPost` with a NULL
`scheduled_at` falls back to `Post.scheduled_at`. The chip endpoint commits a
child to `scheduled` **without** a `scheduled_at`, so recomputing that
aggregate there could clear `Post.scheduled_at` and strand the post — it would
never publish.

This PR makes the proposal-clear side-effect-free:

- `sync_post_scheduled_at` keeps its original `scheduled_at`-based logic, so
  `Post.scheduled_at` behaves identically to before the feature (the publisher
  is untouched). Only the proposal clear in the has-scheduled-children branch
  remains.
- The chip endpoint clears `proposed_publish_at` **directly** and never touches
  `Post.scheduled_at`, so the publisher's `Coalesce` fallback is undisturbed.

## Why?

`main` currently carries the latent publish-stranding risk described above and
lacks the regression test proving the fallback still works. The proposal still
gets cleared on a chip-schedule — just without the publisher side effect.

## How to test

- `pytest apps/composer apps/publisher` — 29+ passing, including:
  - `test_chip_transition_to_scheduled_clears_proposed` (proposal cleared, `Post.scheduled_at` untouched).
  - `test_publisher_fallback_still_picks_up_scheduled_post` — a scheduled child with a NULL `scheduled_at` is still returned by `PublishEngine._get_due_platform_posts()` via the `Post.scheduled_at` fallback.
- Full sweep incl. `apps/publisher`: 343 passing on the source branch.

## Checklist

- [x] Tests pass (`pytest`)
- [x] Lint passes (`ruff check` and `ruff format --check` on changed files)
- [x] Documentation updated (n/a — behavioral fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)