### PR TITLE
fix: support Facebook multi-photo posts

### DIFF
--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -266,6 +266,9 @@ class FacebookProvider(SocialProvider):
         )
 
     def _publish_photo(self, access_token: str, page_id: str, content: PublishContent) -> PublishResult:
+        if len(content.media_urls) > 1:
+            return self._publish_multi_photo(access_token, page_id, content)
+
         payload: dict = {"url": content.media_urls[0]}
         if content.text:
             payload["message"] = content.text
@@ -280,6 +283,53 @@ class FacebookProvider(SocialProvider):
             platform_post_id=data["id"],
             url=f"https://www.facebook.com/{data.get('post_id', data['id'])}",
             extra=data,
+        )
+
+    def _publish_multi_photo(self, access_token: str, page_id: str, content: PublishContent) -> PublishResult:
+        photo_ids: list[str] = []
+
+        for url in content.media_urls:
+            resp = self._request(
+                "POST",
+                f"{BASE_URL}/{page_id}/photos",
+                access_token=access_token,
+                json={"url": url, "published": False},
+            )
+            data = resp.json()
+            photo_id = data.get("id")
+            if not photo_id:
+                raise PublishError(
+                    "Failed to stage Facebook photo for multi-photo post",
+                    platform=self.platform_name,
+                    raw_response=data,
+                )
+            photo_ids.append(photo_id)
+
+        payload: dict = {
+            "attached_media": [{"media_fbid": photo_id} for photo_id in photo_ids],
+        }
+        if content.text:
+            payload["message"] = content.text
+
+        resp = self._request(
+            "POST",
+            f"{BASE_URL}/{page_id}/feed",
+            access_token=access_token,
+            json=payload,
+        )
+        data = resp.json()
+        post_id = data.get("id")
+        if not post_id:
+            raise PublishError(
+                "Failed to publish Facebook multi-photo post",
+                platform=self.platform_name,
+                raw_response=data,
+            )
+
+        return PublishResult(
+            platform_post_id=post_id,
+            url=f"https://www.facebook.com/{post_id}",
+            extra={**data, "photo_ids": photo_ids},
         )
 
     def _publish_video(self, access_token: str, page_id: str, content: PublishContent) -> PublishResult:

--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -279,9 +279,10 @@ class FacebookProvider(SocialProvider):
             json=payload,
         )
         data = resp.json()
+        post_id = data.get("post_id", data["id"])
         return PublishResult(
-            platform_post_id=data["id"],
-            url=f"https://www.facebook.com/{data.get('post_id', data['id'])}",
+            platform_post_id=post_id,
+            url=f"https://www.facebook.com/{post_id}",
             extra=data,
         )
 

--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -279,10 +279,9 @@ class FacebookProvider(SocialProvider):
             json=payload,
         )
         data = resp.json()
-        post_id = data.get("post_id", data["id"])
         return PublishResult(
-            platform_post_id=post_id,
-            url=f"https://www.facebook.com/{post_id}",
+            platform_post_id=data["id"],
+            url=f"https://www.facebook.com/{data.get('post_id', data['id'])}",
             extra=data,
         )
 

--- a/tests/providers/test_facebook.py
+++ b/tests/providers/test_facebook.py
@@ -57,27 +57,6 @@ def test_publish_multi_photo_post_stages_photos_then_publishes_feed_post():
     )
 
 
-def test_publish_single_photo_uses_feed_post_id_when_available():
-    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
-    provider._request = MagicMock(
-        return_value=MagicMock(json=MagicMock(return_value={"id": "photo-1", "post_id": "page-1_post-1"}))
-    )
-
-    result = provider.publish_post(
-        "page-token",
-        PublishContent(
-            text="Caption for the photo",
-            media_urls=["https://cdn.example.com/one.jpg"],
-            post_type=PostType.IMAGE,
-            extra={"page_id": "page-1"},
-        ),
-    )
-
-    assert result.platform_post_id == "page-1_post-1"
-    assert result.url == "https://www.facebook.com/page-1_post-1"
-    assert result.extra["id"] == "photo-1"
-
-
 def test_publish_multi_photo_post_requires_staged_photo_ids():
     provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
     provider._request = MagicMock(return_value=MagicMock(json=MagicMock(return_value={"success": True})))

--- a/tests/providers/test_facebook.py
+++ b/tests/providers/test_facebook.py
@@ -57,6 +57,27 @@ def test_publish_multi_photo_post_stages_photos_then_publishes_feed_post():
     )
 
 
+def test_publish_single_photo_uses_feed_post_id_when_available():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        return_value=MagicMock(json=MagicMock(return_value={"id": "photo-1", "post_id": "page-1_post-1"}))
+    )
+
+    result = provider.publish_post(
+        "page-token",
+        PublishContent(
+            text="Caption for the photo",
+            media_urls=["https://cdn.example.com/one.jpg"],
+            post_type=PostType.IMAGE,
+            extra={"page_id": "page-1"},
+        ),
+    )
+
+    assert result.platform_post_id == "page-1_post-1"
+    assert result.url == "https://www.facebook.com/page-1_post-1"
+    assert result.extra["id"] == "photo-1"
+
+
 def test_publish_multi_photo_post_requires_staged_photo_ids():
     provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
     provider._request = MagicMock(return_value=MagicMock(json=MagicMock(return_value={"success": True})))

--- a/tests/providers/test_facebook.py
+++ b/tests/providers/test_facebook.py
@@ -1,0 +1,93 @@
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from providers.exceptions import PublishError
+from providers.facebook import FacebookProvider
+from providers.types import PostType, PublishContent
+
+
+def test_publish_multi_photo_post_stages_photos_then_publishes_feed_post():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        side_effect=[
+            MagicMock(json=MagicMock(return_value={"id": "photo-1"})),
+            MagicMock(json=MagicMock(return_value={"id": "photo-2"})),
+            MagicMock(json=MagicMock(return_value={"id": "page-1_post-1"})),
+        ]
+    )
+
+    result = provider.publish_post(
+        "page-token",
+        PublishContent(
+            text="Caption for the album",
+            media_urls=["https://cdn.example.com/one.jpg", "https://cdn.example.com/two.jpg"],
+            post_type=PostType.IMAGE,
+            extra={"page_id": "page-1"},
+        ),
+    )
+
+    assert result.platform_post_id == "page-1_post-1"
+    assert result.url == "https://www.facebook.com/page-1_post-1"
+    assert result.extra["photo_ids"] == ["photo-1", "photo-2"]
+    provider._request.assert_has_calls(
+        [
+            call(
+                "POST",
+                "https://graph.facebook.com/v21.0/page-1/photos",
+                access_token="page-token",
+                json={"url": "https://cdn.example.com/one.jpg", "published": False},
+            ),
+            call(
+                "POST",
+                "https://graph.facebook.com/v21.0/page-1/photos",
+                access_token="page-token",
+                json={"url": "https://cdn.example.com/two.jpg", "published": False},
+            ),
+            call(
+                "POST",
+                "https://graph.facebook.com/v21.0/page-1/feed",
+                access_token="page-token",
+                json={
+                    "attached_media": [{"media_fbid": "photo-1"}, {"media_fbid": "photo-2"}],
+                    "message": "Caption for the album",
+                },
+            ),
+        ]
+    )
+
+
+def test_publish_multi_photo_post_requires_staged_photo_ids():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(return_value=MagicMock(json=MagicMock(return_value={"success": True})))
+
+    with pytest.raises(PublishError, match="Failed to stage Facebook photo"):
+        provider.publish_post(
+            "page-token",
+            PublishContent(
+                media_urls=["https://cdn.example.com/one.jpg", "https://cdn.example.com/two.jpg"],
+                post_type=PostType.IMAGE,
+                extra={"page_id": "page-1"},
+            ),
+        )
+
+
+def test_publish_multi_photo_post_requires_feed_post_id():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        side_effect=[
+            MagicMock(json=MagicMock(return_value={"id": "photo-1"})),
+            MagicMock(json=MagicMock(return_value={"id": "photo-2"})),
+            MagicMock(json=MagicMock(return_value={"success": True})),
+        ]
+    )
+
+    with pytest.raises(PublishError, match="Failed to publish Facebook multi-photo post"):
+        provider.publish_post(
+            "page-token",
+            PublishContent(
+                media_urls=["https://cdn.example.com/one.jpg", "https://cdn.example.com/two.jpg"],
+                post_type=PostType.IMAGE,
+                extra={"page_id": "page-1"},
+            ),
+        )


### PR DESCRIPTION
## What Changed

Adds Facebook Page multi-photo publishing support.

When a Facebook image post contains multiple media URLs, the provider now stages each photo as unpublished, then creates a single feed post with `attached_media`. The published feed post id is returned so follow-up platform operations target the actual Facebook feed post for multi-photo publishes.

## Why

Facebook was using the single-photo `/photos` publish path for all image posts. That path only used `media_urls[0]`, so posts with multiple pictures worked as Instagram carousels but Facebook only published the first image.

## Impact

Users can now publish multiple pictures with a caption to Facebook Pages. Existing single-photo, video, text, and link publishing paths are unchanged.

## Validation

- `.venv/bin/python -m pytest tests/providers/test_facebook.py -vv --tb=short`