### PR TITLE
fix: target Facebook first comments to feed posts

### DIFF
--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -276,9 +276,10 @@ class FacebookProvider(SocialProvider):
             json=payload,
         )
         data = resp.json()
+        post_id = data.get("post_id", data["id"])
         return PublishResult(
-            platform_post_id=data["id"],
-            url=f"https://www.facebook.com/{data.get('post_id', data['id'])}",
+            platform_post_id=post_id,
+            url=f"https://www.facebook.com/{post_id}",
             extra=data,
         )
 

--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -72,6 +72,7 @@ class FacebookProvider(SocialProvider):
         scopes = [
             "business_management",
             "pages_show_list",
+            "pages_manage_engagement",
             "pages_manage_posts",
             "pages_read_engagement",
             "pages_read_user_content",

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -149,3 +149,7 @@ class TestProviderMetadata:
     def test_facebook_auth_type_is_oauth2(self):
         p = get_provider("facebook")
         assert p.auth_type == AuthType.OAUTH2
+
+    def test_facebook_scopes_include_comment_permission(self):
+        p = get_provider("facebook")
+        assert "pages_manage_engagement" in p.required_scopes

--- a/tests/providers/test_facebook.py
+++ b/tests/providers/test_facebook.py
@@ -1,0 +1,25 @@
+from unittest.mock import MagicMock
+
+from providers.facebook import FacebookProvider
+from providers.types import PostType, PublishContent
+
+
+def test_publish_single_photo_uses_feed_post_id_when_available():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        return_value=MagicMock(json=MagicMock(return_value={"id": "photo-1", "post_id": "page-1_post-1"}))
+    )
+
+    result = provider.publish_post(
+        "page-token",
+        PublishContent(
+            text="Caption for the photo",
+            media_urls=["https://cdn.example.com/one.jpg"],
+            post_type=PostType.IMAGE,
+            extra={"page_id": "page-1"},
+        ),
+    )
+
+    assert result.platform_post_id == "page-1_post-1"
+    assert result.url == "https://www.facebook.com/page-1_post-1"
+    assert result.extra["id"] == "photo-1"


### PR DESCRIPTION
## What Changed

- Facebook single-photo publishing now stores Meta's feed `post_id` when it is returned, instead of storing the photo object id.
- Facebook OAuth now requests `pages_manage_engagement`, which is required for Page comment/engagement actions.
- Added focused regression coverage for the single-photo response shape and required Facebook comment permission scope.

## Why

The delayed first-comment worker posts to `/{platform_post_id}/comments`. For Facebook single-photo uploads, Meta can return both a photo object `id` and a visible feed `post_id`. Storing the photo object id could make the first comment target the wrong object.

A separate production failure showed Facebook returning `(#200) You do not have sufficient permissions to perform this action` when posting a first comment. Publishing the main post can work with `pages_manage_posts`, but commenting as the Page also needs the engagement permission on the issued token.

## Impact

Newly published Facebook single-photo posts should have first comments posted against the visible feed post when Meta returns `post_id`. Facebook accounts must reconnect after deployment so Meta issues tokens with `pages_manage_engagement`; existing tokens will not gain the new permission automatically.

## Validation

- `.venv/bin/python -m pytest tests/providers/test_facebook.py tests/providers/test_base.py::TestProviderMetadata::test_facebook_scopes_include_comment_permission -vv --tb=short`