### PR TITLE
[codex] Fix Facebook analytics metrics

### DIFF
--- a/apps/analytics/metrics.py
+++ b/apps/analytics/metrics.py
@@ -44,9 +44,9 @@ PLATFORM_METRICS: dict[str, list[str]] = {
     "instagram": ["reach", "views", "likes", "comments", "saves", "shares", "follows", "engagement"],
     "instagram_login": ["reach", "views", "likes", "comments", "saves", "shares", "follows", "engagement"],
     # FB Graph v21 rejects the old page/post reach + impressions metrics for
-    # the production page/post objects we sync today. Keep only metrics backed
-    # by confirmed-valid post insights or basic Graph object fields.
-    "facebook": ["views", "reactions", "comments", "shares", "clicks", "follows"],
+    # the production page/post objects we sync today, and post_video_views is
+    # zero for the page post objects we sampled. Keep only reliable metrics.
+    "facebook": ["reactions", "comments", "shares", "clicks", "follows"],
     # LinkedIn share statistics: impressions, reactions, comments, reposts, clicks, engagement.
     "linkedin_company": ["impressions", "reactions", "comments", "reposts", "clicks", "follows", "engagement"],
     # LinkedIn Personal: only socialActions counts (no impressions/reach per API).
@@ -77,7 +77,7 @@ PLATFORM_METRICS: dict[str, list[str]] = {
 PLATFORM_PRIMARY: dict[str, str] = {
     "instagram": "reach",
     "instagram_login": "reach",
-    "facebook": "views",
+    "facebook": "reactions",
     "linkedin_company": "impressions",
     "linkedin_personal": "likes",
     "youtube": "views",

--- a/apps/analytics/metrics.py
+++ b/apps/analytics/metrics.py
@@ -46,7 +46,7 @@ PLATFORM_METRICS: dict[str, list[str]] = {
     # FB Graph v21 rejects the old page/post reach + impressions metrics for
     # the production page/post objects we sync today. Keep only metrics backed
     # by confirmed-valid post insights or basic Graph object fields.
-    "facebook": ["reactions", "comments", "shares", "clicks", "follows"],
+    "facebook": ["views", "reactions", "comments", "shares", "clicks", "follows"],
     # LinkedIn share statistics: impressions, reactions, comments, reposts, clicks, engagement.
     "linkedin_company": ["impressions", "reactions", "comments", "reposts", "clicks", "follows", "engagement"],
     # LinkedIn Personal: only socialActions counts (no impressions/reach per API).
@@ -77,7 +77,7 @@ PLATFORM_METRICS: dict[str, list[str]] = {
 PLATFORM_PRIMARY: dict[str, str] = {
     "instagram": "reach",
     "instagram_login": "reach",
-    "facebook": "reactions",
+    "facebook": "views",
     "linkedin_company": "impressions",
     "linkedin_personal": "likes",
     "youtube": "views",

--- a/apps/analytics/metrics.py
+++ b/apps/analytics/metrics.py
@@ -43,8 +43,10 @@ PLATFORM_METRICS: dict[str, list[str]] = {
     # comments, saved, shares, total_interactions; follower growth at account level.
     "instagram": ["reach", "views", "likes", "comments", "saves", "shares", "follows", "engagement"],
     "instagram_login": ["reach", "views", "likes", "comments", "saves", "shares", "follows", "engagement"],
-    # FB post insights: impressions, reach (unique), reactions, comments, shares, clicks.
-    "facebook": ["impressions", "reach", "reactions", "comments", "shares", "clicks", "follows", "engagement"],
+    # FB Graph v21 rejects the old page/post reach + impressions metrics for
+    # the production page/post objects we sync today. Keep only metrics backed
+    # by confirmed-valid post insights or basic Graph object fields.
+    "facebook": ["reactions", "comments", "shares", "clicks", "follows"],
     # LinkedIn share statistics: impressions, reactions, comments, reposts, clicks, engagement.
     "linkedin_company": ["impressions", "reactions", "comments", "reposts", "clicks", "follows", "engagement"],
     # LinkedIn Personal: only socialActions counts (no impressions/reach per API).
@@ -75,7 +77,7 @@ PLATFORM_METRICS: dict[str, list[str]] = {
 PLATFORM_PRIMARY: dict[str, str] = {
     "instagram": "reach",
     "instagram_login": "reach",
-    "facebook": "reach",
+    "facebook": "reactions",
     "linkedin_company": "impressions",
     "linkedin_personal": "likes",
     "youtube": "views",

--- a/apps/analytics/tasks.py
+++ b/apps/analytics/tasks.py
@@ -104,6 +104,11 @@ _POST_FIELD_OVERRIDES: dict[str, dict[str, str]] = {
         "likes": "reactions",
         "shares": "reposts",
     },
+    "facebook": {
+        # providers/facebook.py collapses reaction types into PostMetrics.likes;
+        # the Facebook catalog labels that aggregate as reactions.
+        "likes": "reactions",
+    },
     "mastodon": {
         # providers/mastodon.py:313-316: favourites→likes (ok), reblogs→shares,
         # replies→comments. Catalog wants reposts/replies.

--- a/apps/analytics/tasks.py
+++ b/apps/analytics/tasks.py
@@ -255,6 +255,8 @@ def _resolve_provider(account):
             pass
     elif account.platform == "instagram":
         credentials = {**credentials, "ig_user_id": account.account_platform_id}
+    elif account.platform == "facebook":
+        credentials = {**credentials, "page_id": account.account_platform_id}
     return get_provider(account.platform, credentials)
 
 

--- a/apps/analytics/tests.py
+++ b/apps/analytics/tests.py
@@ -1,0 +1,43 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from apps.analytics.tasks import _resolve_provider
+from apps.social_accounts.models import SocialAccount
+
+
+@pytest.fixture
+def organization(db):
+    from apps.organizations.models import Organization
+
+    return Organization.objects.create(name="Test Org")
+
+
+@pytest.fixture
+def workspace(db, organization):
+    from apps.workspaces.models import Workspace
+
+    return Workspace.objects.create(name="Test Workspace", organization=organization)
+
+
+@pytest.mark.django_db
+@patch("providers.get_provider")
+@patch("apps.credentials.models.resolve_platform_credentials", return_value={})
+def test_facebook_analytics_provider_uses_connected_page_id(_mock_creds, mock_get_provider, workspace):
+    account = SocialAccount.objects.create(
+        workspace=workspace,
+        platform="facebook",
+        account_platform_id="page-123",
+        account_name="Test Page",
+        oauth_access_token="page-token",
+        connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+    )
+    mock_provider = MagicMock()
+    mock_get_provider.return_value = mock_provider
+
+    provider = _resolve_provider(account)
+
+    assert provider is mock_provider
+    platform, credentials = mock_get_provider.call_args.args
+    assert platform == "facebook"
+    assert credentials["page_id"] == "page-123"

--- a/apps/calendar/tests.py
+++ b/apps/calendar/tests.py
@@ -345,10 +345,11 @@ class CalendarChannelSlotViewTests(TestCase):
         context = {"display_timezone": "America/New_York"}
         _day_view_data(self.factory.get("/"), self.workspace, target, context)
 
+        hour_posts = dict((hour, posts) for hour, posts, _slots in context["day_slots"])[9]
         slot_items = dict((hour, slots) for hour, _posts, slots in context["day_slots"])[9]
-        self.assertEqual(len(slot_items), 1)
-        self.assertTrue(slot_items[0]["is_taken"])
-        self.assertEqual(slot_items[0]["time_label"], "09:30")
+        self.assertEqual(slot_items, [])
+        self.assertEqual(len(hour_posts), 1)
+        self.assertTrue(hour_posts[0].takes_calendar_slot)
 
     def test_day_view_channel_filter_limits_slot_badges(self):
         target = date(2026, 6, 15)  # Monday

--- a/apps/calendar/tests.py
+++ b/apps/calendar/tests.py
@@ -4,7 +4,7 @@ import zoneinfo
 from datetime import date, datetime, time
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 from django.urls import reverse
 from django.utils import timezone
 
@@ -12,6 +12,7 @@ from apps.accounts.models import User
 from apps.calendar.models import PostingSlot, Queue, QueueEntry, RecurrenceRule
 from apps.calendar.services import add_to_queue
 from apps.calendar.tasks import generate_recurring_posts
+from apps.calendar.views import _day_view_data
 from apps.composer.models import PlatformPost, Post
 from apps.members.models import OrgMembership, WorkspaceMembership
 from apps.organizations.models import Organization
@@ -304,6 +305,62 @@ class QueueSlotTimezoneTests(TestCase):
         entry = QueueEntry.objects.get(queue=self.queue, post=post)
         local = entry.assigned_slot_datetime.astimezone(zoneinfo.ZoneInfo("Asia/Tokyo"))
         self.assertEqual((local.hour, local.minute), (9, 0))
+
+
+class CalendarChannelSlotViewTests(TestCase):
+    """Day/week calendar data should expose channel posting slots."""
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.org = Organization.objects.create(name="Calendar Slots Org", default_timezone="America/New_York")
+        self.workspace = Workspace.objects.create(organization=self.org, name="Calendar Slots WS")
+        self.account = SocialAccount.objects.create(
+            workspace=self.workspace,
+            platform="instagram",
+            account_platform_id="ig-calendar-slots",
+            account_name="Instagram",
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+        self.other_account = SocialAccount.objects.create(
+            workspace=self.workspace,
+            platform="linkedin_company",
+            account_platform_id="li-calendar-slots",
+            account_name="LinkedIn",
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+
+    def test_day_view_marks_exact_channel_slot_taken(self):
+        target = date(2026, 6, 15)  # Monday
+        ny = zoneinfo.ZoneInfo("America/New_York")
+        scheduled_at = datetime(2026, 6, 15, 9, 30, tzinfo=ny)
+        PostingSlot.objects.create(social_account=self.account, day_of_week=0, time=time(9, 30))
+        post = Post.objects.create(workspace=self.workspace, caption="scheduled", scheduled_at=scheduled_at)
+        PlatformPost.objects.create(
+            post=post,
+            social_account=self.account,
+            status="scheduled",
+            scheduled_at=scheduled_at,
+        )
+
+        context = {"display_timezone": "America/New_York"}
+        _day_view_data(self.factory.get("/"), self.workspace, target, context)
+
+        slot_items = dict((hour, slots) for hour, _posts, slots in context["day_slots"])[9]
+        self.assertEqual(len(slot_items), 1)
+        self.assertTrue(slot_items[0]["is_taken"])
+        self.assertEqual(slot_items[0]["time_label"], "09:30")
+
+    def test_day_view_channel_filter_limits_slot_badges(self):
+        target = date(2026, 6, 15)  # Monday
+        PostingSlot.objects.create(social_account=self.account, day_of_week=0, time=time(9, 0))
+        PostingSlot.objects.create(social_account=self.other_account, day_of_week=0, time=time(9, 0))
+
+        request = self.factory.get("/", {"channel": str(self.account.id)})
+        context = {"display_timezone": "America/New_York"}
+        _day_view_data(request, self.workspace, target, context)
+
+        slot_items = dict((hour, slots) for hour, _posts, slots in context["day_slots"])[9]
+        self.assertEqual([slot["account"] for slot in slot_items], [self.account])
 
 
 class RecurringPostTimezoneTests(TestCase):

--- a/apps/calendar/tests.py
+++ b/apps/calendar/tests.py
@@ -363,6 +363,41 @@ class CalendarChannelSlotViewTests(TestCase):
         slot_items = dict((hour, slots) for hour, _posts, slots in context["day_slots"])[9]
         self.assertEqual([slot["account"] for slot in slot_items], [self.account])
 
+    def test_day_view_ignores_malformed_channel_filter(self):
+        target = date(2026, 6, 15)  # Monday
+        PostingSlot.objects.create(social_account=self.account, day_of_week=0, time=time(9, 0))
+
+        request = self.factory.get("/", {"channel": "not-a-uuid"})
+        context = {"display_timezone": "America/New_York"}
+        _day_view_data(request, self.workspace, target, context)
+
+        slot_items = dict((hour, slots) for hour, _posts, slots in context["day_slots"])[9]
+        self.assertEqual([slot["account"] for slot in slot_items], [self.account])
+
+    def test_day_view_includes_workspace_slot_from_adjacent_display_date(self):
+        self.workspace.timezone = "America/Los_Angeles"
+        self.workspace.save(update_fields=["timezone"])
+        target = date(2026, 6, 16)  # Tuesday in Tokyo
+        la = zoneinfo.ZoneInfo("America/Los_Angeles")
+        scheduled_at = datetime(2026, 6, 15, 9, 0, tzinfo=la)
+        PostingSlot.objects.create(social_account=self.account, day_of_week=0, time=time(9, 0))
+        post = Post.objects.create(workspace=self.workspace, caption="tokyo-boundary", scheduled_at=scheduled_at)
+        PlatformPost.objects.create(
+            post=post,
+            social_account=self.account,
+            status="scheduled",
+            scheduled_at=scheduled_at,
+        )
+
+        context = {"display_timezone": "Asia/Tokyo"}
+        _day_view_data(self.factory.get("/"), self.workspace, target, context)
+
+        hour_posts = dict((hour, posts) for hour, posts, _slots in context["day_slots"])[1]
+        slot_items = dict((hour, slots) for hour, _posts, slots in context["day_slots"])[1]
+        self.assertEqual(slot_items, [])
+        self.assertEqual(len(hour_posts), 1)
+        self.assertTrue(hour_posts[0].takes_calendar_slot)
+
 
 class RecurringPostTimezoneTests(TestCase):
     """``generate_recurring_posts`` must preserve the source post's *local*

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -2,6 +2,7 @@
 
 import calendar as cal_mod
 import json
+import uuid
 from collections import defaultdict
 from datetime import date, datetime, time, timedelta
 
@@ -96,6 +97,17 @@ def _parse_date(date_str, default=None):
     return default or date.today()
 
 
+def _get_valid_channel_filter(request):
+    """Return a UUID-safe channel filter value, or blank when malformed."""
+    channel = request.GET.get("channel", "").strip()
+    if not channel:
+        return ""
+    try:
+        return str(uuid.UUID(channel))
+    except (TypeError, ValueError, AttributeError):
+        return ""
+
+
 def _get_filtered_posts(workspace, request):
     """Apply calendar filters from query params."""
     qs = (
@@ -172,7 +184,7 @@ def _get_filtered_platform_posts(workspace, request):
         qs = qs.filter(social_account__platform__in=platforms)
 
     # Channel filter (calendar toolbar sends the selected SocialAccount id).
-    channel = request.GET.get("channel")
+    channel = _get_valid_channel_filter(request)
     if channel:
         qs = qs.filter(social_account_id=channel)
 
@@ -213,8 +225,8 @@ def _get_calendar_slot_occurrences(workspace, request, display_tz, visible_dates
     if not visible_dates:
         return defaultdict(list)
 
-    first_date = min(visible_dates)
-    last_date = max(visible_dates)
+    first_date = min(visible_dates) - timedelta(days=1)
+    last_date = max(visible_dates) + timedelta(days=1)
     occurrence_dates = [first_date + timedelta(days=offset) for offset in range((last_date - first_date).days + 1)]
 
     slots = PostingSlot.objects.filter(
@@ -222,7 +234,7 @@ def _get_calendar_slot_occurrences(workspace, request, display_tz, visible_dates
         social_account__connection_status=SocialAccount.ConnectionStatus.CONNECTED,
         is_active=True,
     )
-    channel = request.GET.get("channel")
+    channel = _get_valid_channel_filter(request)
     if channel:
         slots = slots.filter(social_account_id=channel)
 

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -761,9 +761,7 @@ def _day_view_data(request, workspace, target_date, context):
     hours = list(range(0, 24))
 
     # Build a list of (hour, posts, slots) tuples for easy template iteration
-    day_slots = [
-        (hour, posts_by_hour.get(hour, []), slots_by_hour.get((target_date, hour), [])) for hour in hours
-    ]
+    day_slots = [(hour, posts_by_hour.get(hour, []), slots_by_hour.get((target_date, hour), [])) for hour in hours]
 
     from django.utils import timezone as _tz
 

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -171,6 +171,11 @@ def _get_filtered_platform_posts(workspace, request):
     if platforms:
         qs = qs.filter(social_account__platform__in=platforms)
 
+    # Channel filter (calendar toolbar sends the selected SocialAccount id).
+    channel = request.GET.get("channel")
+    if channel:
+        qs = qs.filter(social_account_id=channel)
+
     # Author filter
     authors = request.GET.getlist("author")
     if authors:
@@ -192,6 +197,76 @@ def _get_filtered_platform_posts(workspace, request):
         qs = qs.filter(tag_q)
 
     return qs
+
+
+def _get_calendar_slot_occurrences(workspace, request, display_tz, visible_dates, platform_posts):
+    """Return PostingSlot occurrences grouped by display date/hour.
+
+    PostingSlot times are defined in the workspace timezone. Convert concrete
+    occurrences into the active display timezone before placing them in the
+    day/week timeline, so timezone changes move slots and posts together.
+    """
+    import zoneinfo
+
+    workspace_tz = zoneinfo.ZoneInfo(workspace.effective_timezone or "UTC")
+    visible_dates = set(visible_dates)
+    if not visible_dates:
+        return defaultdict(list)
+
+    first_date = min(visible_dates)
+    last_date = max(visible_dates)
+    occurrence_dates = [first_date + timedelta(days=offset) for offset in range((last_date - first_date).days + 1)]
+
+    taken_keys = set()
+    for pp in platform_posts:
+        if not pp.effective_at:
+            continue
+        local_dt = pp.effective_at.astimezone(display_tz)
+        if local_dt.date() in visible_dates:
+            taken_keys.add((pp.social_account_id, local_dt.date(), local_dt.hour, local_dt.minute))
+
+    slots = PostingSlot.objects.filter(
+        social_account__workspace=workspace,
+        social_account__connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        is_active=True,
+    )
+    channel = request.GET.get("channel")
+    if channel:
+        slots = slots.filter(social_account_id=channel)
+
+    slots = slots.select_related("social_account").order_by(
+        "time",
+        "social_account__platform",
+        "social_account__account_name",
+    )
+
+    slots_by_hour = defaultdict(list)
+    dates_by_weekday = defaultdict(list)
+    for occurrence_date in occurrence_dates:
+        dates_by_weekday[occurrence_date.weekday()].append(occurrence_date)
+
+    for slot in slots:
+        for occurrence_date in dates_by_weekday.get(slot.day_of_week, []):
+            workspace_dt = datetime.combine(occurrence_date, slot.time, tzinfo=workspace_tz)
+            local_dt = workspace_dt.astimezone(display_tz)
+            if local_dt.date() not in visible_dates:
+                continue
+
+            key = (slot.social_account_id, local_dt.date(), local_dt.hour, local_dt.minute)
+            slots_by_hour[(local_dt.date(), local_dt.hour)].append(
+                {
+                    "account": slot.social_account,
+                    "date": local_dt.date(),
+                    "hour": local_dt.hour,
+                    "minute": local_dt.minute,
+                    "time_label": local_dt.strftime("%H:%M"),
+                    "compose_date": workspace_dt.strftime("%Y-%m-%d"),
+                    "compose_time": workspace_dt.strftime("%H:%M"),
+                    "is_taken": key in taken_keys,
+                }
+            )
+
+    return slots_by_hour
 
 
 def _get_publish_context(workspace, request):
@@ -621,16 +696,17 @@ def _week_view_data(request, workspace, target_date, context):
                 key = (local_dt.date(), local_dt.hour)
                 posts_by_slot[key].append(pp)
 
+    slots_by_hour = _get_calendar_slot_occurrences(workspace, request, display_tz, week_days, platform_posts)
     hours = list(range(0, 24))
 
     # Build a grid structure the template can iterate:
-    # week_slots = [(hour, [(day, posts), ...]), ...]
+    # week_slots = [(hour, [(day, posts, slots), ...]), ...]
     week_slots = []
     for hour in hours:
         day_slots = []
         for day in week_days:
             key = (day, hour)
-            day_slots.append((day, posts_by_slot.get(key, [])))
+            day_slots.append((day, posts_by_slot.get(key, []), slots_by_hour.get(key, [])))
         week_slots.append((hour, day_slots))
 
     from django.utils import timezone as _tz
@@ -681,10 +757,13 @@ def _day_view_data(request, workspace, target_date, context):
             if local_dt.date() == target_date:
                 posts_by_hour[local_dt.hour].append(pp)
 
+    slots_by_hour = _get_calendar_slot_occurrences(workspace, request, display_tz, [target_date], platform_posts)
     hours = list(range(0, 24))
 
-    # Build a list of (hour, posts) tuples for easy template iteration
-    day_slots = [(hour, posts_by_hour.get(hour, [])) for hour in hours]
+    # Build a list of (hour, posts, slots) tuples for easy template iteration
+    day_slots = [
+        (hour, posts_by_hour.get(hour, []), slots_by_hour.get((target_date, hour), [])) for hour in hours
+    ]
 
     from django.utils import timezone as _tz
 

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -217,14 +217,6 @@ def _get_calendar_slot_occurrences(workspace, request, display_tz, visible_dates
     last_date = max(visible_dates)
     occurrence_dates = [first_date + timedelta(days=offset) for offset in range((last_date - first_date).days + 1)]
 
-    taken_keys = set()
-    for pp in platform_posts:
-        if not pp.effective_at:
-            continue
-        local_dt = pp.effective_at.astimezone(display_tz)
-        if local_dt.date() in visible_dates:
-            taken_keys.add((pp.social_account_id, local_dt.date(), local_dt.hour, local_dt.minute))
-
     slots = PostingSlot.objects.filter(
         social_account__workspace=workspace,
         social_account__connection_status=SocialAccount.ConnectionStatus.CONNECTED,
@@ -241,6 +233,8 @@ def _get_calendar_slot_occurrences(workspace, request, display_tz, visible_dates
     )
 
     slots_by_hour = defaultdict(list)
+    slot_keys = set()
+    slot_occurrences = []
     dates_by_weekday = defaultdict(list)
     for occurrence_date in occurrence_dates:
         dates_by_weekday[occurrence_date.weekday()].append(occurrence_date)
@@ -253,18 +247,37 @@ def _get_calendar_slot_occurrences(workspace, request, display_tz, visible_dates
                 continue
 
             key = (slot.social_account_id, local_dt.date(), local_dt.hour, local_dt.minute)
-            slots_by_hour[(local_dt.date(), local_dt.hour)].append(
-                {
-                    "account": slot.social_account,
-                    "date": local_dt.date(),
-                    "hour": local_dt.hour,
-                    "minute": local_dt.minute,
-                    "time_label": local_dt.strftime("%H:%M"),
-                    "compose_date": workspace_dt.strftime("%Y-%m-%d"),
-                    "compose_time": workspace_dt.strftime("%H:%M"),
-                    "is_taken": key in taken_keys,
-                }
+            slot_keys.add(key)
+            slot_occurrences.append(
+                (
+                    key,
+                    {
+                        "account": slot.social_account,
+                        "date": local_dt.date(),
+                        "hour": local_dt.hour,
+                        "minute": local_dt.minute,
+                        "time_label": local_dt.strftime("%H:%M"),
+                        "compose_date": workspace_dt.strftime("%Y-%m-%d"),
+                        "compose_time": workspace_dt.strftime("%H:%M"),
+                    },
+                )
             )
+
+    taken_keys = set()
+    for pp in platform_posts:
+        pp.takes_calendar_slot = False
+        if not pp.effective_at:
+            continue
+        local_dt = pp.effective_at.astimezone(display_tz)
+        key = (pp.social_account_id, local_dt.date(), local_dt.hour, local_dt.minute)
+        if key in slot_keys:
+            pp.takes_calendar_slot = True
+            taken_keys.add(key)
+
+    for key, slot in slot_occurrences:
+        if key in taken_keys:
+            continue
+        slots_by_hour[(slot["date"], slot["hour"])].append(slot)
 
     return slots_by_hour
 
@@ -677,7 +690,7 @@ def _week_view_data(request, workspace, target_date, context):
     week_days = [monday + timedelta(days=i) for i in range(7)]
 
     # Widen query by ±1 day to handle timezone boundary shifts
-    platform_posts = (
+    platform_posts = list(
         _get_filtered_platform_posts(workspace, request)
         .filter(
             effective_at__date__gte=week_days[0] - timedelta(days=1),
@@ -740,7 +753,7 @@ def _day_view_data(request, workspace, target_date, context):
     display_tz = zoneinfo.ZoneInfo(context.get("display_timezone", "UTC"))
 
     # Widen query by ±1 day to handle timezone boundary shifts
-    platform_posts = (
+    platform_posts = list(
         _get_filtered_platform_posts(workspace, request)
         .filter(
             effective_at__date__gte=target_date - timedelta(days=1),

--- a/apps/composer/views.py
+++ b/apps/composer/views.py
@@ -445,9 +445,11 @@ def compose(request, workspace_id, post_id=None):
         .order_by("platform", "account_name")
     )
 
-    # When opening from calendar with a specific account, show only that account
-    if account_filter and post_id:
+    # When opening from calendar with a specific account, show only that account.
+    if account_filter:
         social_accounts = social_accounts.filter(id=account_filter)
+        if not post_id and social_accounts.exists():
+            selected_account_ids = [account_filter]
 
     # Platform character limits for JS
     char_limits = {}

--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -376,12 +376,17 @@ class FacebookProvider(SocialProvider):
             "post_clicks",
             "post_reactions_by_type_total",
         ]
-        resp = self._request(
-            "GET",
-            f"{BASE_URL}/{post_id}/insights",
-            access_token=access_token,
-            params={"metric": ",".join(metrics)},
-        )
+        try:
+            resp = self._request(
+                "GET",
+                f"{BASE_URL}/{post_id}/insights",
+                access_token=access_token,
+                params={"metric": ",".join(metrics)},
+            )
+        except APIError as exc:
+            if "nonexisting field (insights)" not in str(exc).lower():
+                raise
+            return self._get_basic_post_metrics(access_token, post_id)
         data = resp.json()
         values: dict = {}
         for entry in data.get("data", []):
@@ -400,9 +405,26 @@ class FacebookProvider(SocialProvider):
             extra={"raw_insights": values},
         )
 
+    def _get_basic_post_metrics(self, access_token: str, post_id: str) -> PostMetrics:
+        """Fallback for Facebook objects, such as Reels, without an insights edge."""
+        resp = self._request(
+            "GET",
+            f"{BASE_URL}/{post_id}",
+            access_token=access_token,
+            params={"fields": "id,permalink_url,likes.summary(true),comments.summary(true)"},
+        )
+        data = resp.json()
+        likes = data.get("likes", {}).get("summary", {}).get("total_count", 0)
+        comments = data.get("comments", {}).get("summary", {}).get("total_count", 0)
+        return PostMetrics(
+            likes=likes,
+            comments=comments,
+            extra={"raw_fallback": data},
+        )
+
     def get_account_metrics(self, access_token: str, date_range: tuple[datetime, datetime]) -> AccountMetrics:
         page_id = self.credentials.get("page_id", "me")
-        metrics = ["page_impressions_unique", "page_post_engagements", "page_daily_follows"]
+        metrics = ["page_post_engagements", "page_daily_follows"]
         resp = self._request(
             "GET",
             f"{BASE_URL}/{page_id}/insights",
@@ -421,7 +443,6 @@ class FacebookProvider(SocialProvider):
             values[name] = val
 
         return AccountMetrics(
-            reach=values.get("page_impressions_unique", 0),
             followers_gained=values.get("page_daily_follows", 0),
             extra={"raw_insights": values},
         )

--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -266,6 +266,9 @@ class FacebookProvider(SocialProvider):
         )
 
     def _publish_photo(self, access_token: str, page_id: str, content: PublishContent) -> PublishResult:
+        if len(content.media_urls) > 1:
+            return self._publish_multi_photo(access_token, page_id, content)
+
         payload: dict = {"url": content.media_urls[0]}
         if content.text:
             payload["message"] = content.text
@@ -280,6 +283,53 @@ class FacebookProvider(SocialProvider):
             platform_post_id=data["id"],
             url=f"https://www.facebook.com/{data.get('post_id', data['id'])}",
             extra=data,
+        )
+
+    def _publish_multi_photo(self, access_token: str, page_id: str, content: PublishContent) -> PublishResult:
+        photo_ids: list[str] = []
+
+        for url in content.media_urls:
+            resp = self._request(
+                "POST",
+                f"{BASE_URL}/{page_id}/photos",
+                access_token=access_token,
+                json={"url": url, "published": False},
+            )
+            data = resp.json()
+            photo_id = data.get("id")
+            if not photo_id:
+                raise PublishError(
+                    "Failed to stage Facebook photo for multi-photo post",
+                    platform=self.platform_name,
+                    raw_response=data,
+                )
+            photo_ids.append(photo_id)
+
+        payload: dict = {
+            "attached_media": [{"media_fbid": photo_id} for photo_id in photo_ids],
+        }
+        if content.text:
+            payload["message"] = content.text
+
+        resp = self._request(
+            "POST",
+            f"{BASE_URL}/{page_id}/feed",
+            access_token=access_token,
+            json=payload,
+        )
+        data = resp.json()
+        post_id = data.get("id")
+        if not post_id:
+            raise PublishError(
+                "Failed to publish Facebook multi-photo post",
+                platform=self.platform_name,
+                raw_response=data,
+            )
+
+        return PublishResult(
+            platform_post_id=post_id,
+            url=f"https://www.facebook.com/{post_id}",
+            extra={**data, "photo_ids": photo_ids},
         )
 
     def _publish_video(self, access_token: str, page_id: str, content: PublishContent) -> PublishResult:

--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -350,7 +350,7 @@ class FacebookProvider(SocialProvider):
 
     def get_account_metrics(self, access_token: str, date_range: tuple[datetime, datetime]) -> AccountMetrics:
         page_id = self.credentials.get("page_id", "me")
-        metrics = ["page_impressions", "page_engaged_users", "page_fans"]
+        metrics = ["page_impressions_unique", "page_post_engagements", "page_daily_follows"]
         resp = self._request(
             "GET",
             f"{BASE_URL}/{page_id}/insights",
@@ -369,9 +369,8 @@ class FacebookProvider(SocialProvider):
             values[name] = val
 
         return AccountMetrics(
-            impressions=values.get("page_impressions", 0),
-            reach=values.get("page_engaged_users", 0),
-            followers=values.get("page_fans", 0),
+            reach=values.get("page_impressions_unique", 0),
+            followers_gained=values.get("page_daily_follows", 0),
             extra={"raw_insights": values},
         )
 

--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -279,9 +279,10 @@ class FacebookProvider(SocialProvider):
             json=payload,
         )
         data = resp.json()
+        post_id = data.get("post_id", data["id"])
         return PublishResult(
-            platform_post_id=data["id"],
-            url=f"https://www.facebook.com/{data.get('post_id', data['id'])}",
+            platform_post_id=post_id,
+            url=f"https://www.facebook.com/{post_id}",
             extra=data,
         )
 

--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -279,10 +279,9 @@ class FacebookProvider(SocialProvider):
             json=payload,
         )
         data = resp.json()
-        post_id = data.get("post_id", data["id"])
         return PublishResult(
-            platform_post_id=post_id,
-            url=f"https://www.facebook.com/{post_id}",
+            platform_post_id=data["id"],
+            url=f"https://www.facebook.com/{data.get('post_id', data['id'])}",
             extra=data,
         )
 

--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -394,12 +394,12 @@ class FacebookProvider(SocialProvider):
             values[name] = val
 
         reactions = values.get("post_reactions_by_type_total", {})
-        total_likes = reactions.get("like", 0) + reactions.get("love", 0) if isinstance(reactions, dict) else 0
+        total_reactions = sum(v for v in reactions.values() if isinstance(v, (int, float))) if isinstance(reactions, dict) else 0
         basic = self._get_basic_post_metrics(access_token, post_id)
 
         return PostMetrics(
             clicks=values.get("post_clicks", 0),
-            likes=total_likes or basic.likes,
+            likes=total_reactions or basic.likes,
             comments=basic.comments,
             shares=basic.shares,
             video_views=values.get("post_video_views", 0),

--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -276,9 +276,10 @@ class FacebookProvider(SocialProvider):
             json=payload,
         )
         data = resp.json()
+        post_id = data.get("post_id", data["id"])
         return PublishResult(
-            platform_post_id=data["id"],
-            url=f"https://www.facebook.com/{data.get('post_id', data['id'])}",
+            platform_post_id=post_id,
+            url=f"https://www.facebook.com/{post_id}",
             extra=data,
         )
 

--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -412,18 +412,32 @@ class FacebookProvider(SocialProvider):
             "GET",
             f"{BASE_URL}/{post_id}",
             access_token=access_token,
-            params={"fields": "id,permalink_url,likes.summary(true),comments.summary(true),shares"},
+            params={"fields": "id,likes.summary(true),comments.summary(true)"},
         )
         data = resp.json()
         likes = data.get("likes", {}).get("summary", {}).get("total_count", 0)
         comments = data.get("comments", {}).get("summary", {}).get("total_count", 0)
-        shares = data.get("shares", {}).get("count", 0)
+        shares = self._get_optional_post_share_count(access_token, post_id)
         return PostMetrics(
             likes=likes,
             comments=comments,
             shares=shares,
             extra={"raw_fallback": data},
         )
+
+    def _get_optional_post_share_count(self, access_token: str, post_id: str) -> int:
+        try:
+            resp = self._request(
+                "GET",
+                f"{BASE_URL}/{post_id}",
+                access_token=access_token,
+                params={"fields": "id,shares"},
+            )
+        except APIError as exc:
+            if "nonexisting field (shares)" in str(exc).lower():
+                return 0
+            raise
+        return resp.json().get("shares", {}).get("count", 0)
 
     def get_account_metrics(self, access_token: str, date_range: tuple[datetime, datetime]) -> AccountMetrics:
         page_id = self.credentials.get("page_id", "me")

--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -72,6 +72,7 @@ class FacebookProvider(SocialProvider):
         scopes = [
             "business_management",
             "pages_show_list",
+            "pages_manage_engagement",
             "pages_manage_posts",
             "pages_read_engagement",
             "pages_read_user_content",

--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -371,10 +371,9 @@ class FacebookProvider(SocialProvider):
 
     def get_post_metrics(self, access_token: str, post_id: str) -> PostMetrics:
         metrics = [
-            "post_impressions",
-            "post_engaged_users",
             "post_clicks",
             "post_reactions_by_type_total",
+            "post_video_views",
         ]
         try:
             resp = self._request(
@@ -396,13 +395,15 @@ class FacebookProvider(SocialProvider):
 
         reactions = values.get("post_reactions_by_type_total", {})
         total_likes = reactions.get("like", 0) + reactions.get("love", 0) if isinstance(reactions, dict) else 0
+        basic = self._get_basic_post_metrics(access_token, post_id)
 
         return PostMetrics(
-            impressions=values.get("post_impressions", 0),
-            engagements=values.get("post_engaged_users", 0),
             clicks=values.get("post_clicks", 0),
-            likes=total_likes,
-            extra={"raw_insights": values},
+            likes=total_likes or basic.likes,
+            comments=basic.comments,
+            shares=basic.shares,
+            video_views=values.get("post_video_views", 0),
+            extra={"raw_insights": values, "raw_basic": basic.extra.get("raw_fallback", {})},
         )
 
     def _get_basic_post_metrics(self, access_token: str, post_id: str) -> PostMetrics:
@@ -411,14 +412,16 @@ class FacebookProvider(SocialProvider):
             "GET",
             f"{BASE_URL}/{post_id}",
             access_token=access_token,
-            params={"fields": "id,permalink_url,likes.summary(true),comments.summary(true)"},
+            params={"fields": "id,permalink_url,likes.summary(true),comments.summary(true),shares"},
         )
         data = resp.json()
         likes = data.get("likes", {}).get("summary", {}).get("total_count", 0)
         comments = data.get("comments", {}).get("summary", {}).get("total_count", 0)
+        shares = data.get("shares", {}).get("count", 0)
         return PostMetrics(
             likes=likes,
             comments=comments,
+            shares=shares,
             extra={"raw_fallback": data},
         )
 

--- a/providers/instagram.py
+++ b/providers/instagram.py
@@ -393,7 +393,7 @@ class InstagramProvider(SocialProvider):
     # ------------------------------------------------------------------
 
     def get_post_metrics(self, access_token: str, post_id: str) -> PostMetrics:
-        metrics = ["impressions", "reach", "engagement", "saved"]
+        metrics = ["reach", "views", "likes", "comments", "shares", "saved", "total_interactions"]
         resp = self._request(
             "GET",
             f"{BASE_URL}/{post_id}/insights",
@@ -408,9 +408,12 @@ class InstagramProvider(SocialProvider):
             values[name] = val
 
         return PostMetrics(
-            impressions=values.get("impressions", 0),
             reach=values.get("reach", 0),
-            engagements=values.get("engagement", 0),
+            video_views=values.get("views", 0),
+            likes=values.get("likes", 0),
+            comments=values.get("comments", 0),
+            shares=values.get("shares", 0),
+            engagements=values.get("total_interactions", 0),
             saves=values.get("saved", 0),
             extra={"raw_insights": values},
         )
@@ -419,7 +422,7 @@ class InstagramProvider(SocialProvider):
         ig_user_id = self.credentials.get("ig_user_id", "me")
         since = int(date_range[0].timestamp())
         until = int(date_range[1].timestamp())
-        metrics = ["reach", "follower_count", "profile_views"]
+        metrics = ["reach", "follower_count"]
         resp = self._request(
             "GET",
             f"{BASE_URL}/{ig_user_id}/insights",
@@ -443,7 +446,7 @@ class InstagramProvider(SocialProvider):
             f"{BASE_URL}/{ig_user_id}/insights",
             access_token=access_token,
             params={
-                "metric": "views",
+                "metric": "profile_views,views",
                 "period": "day",
                 "metric_type": "total_value",
                 "since": since,
@@ -452,9 +455,9 @@ class InstagramProvider(SocialProvider):
         )
         views_data = views_resp.json()
         for entry in views_data.get("data", []):
-            if entry.get("name") == "views":
-                values["views"] = entry.get("total_value", {}).get("value", 0)
-                break
+            name = entry.get("name", "")
+            if name in {"profile_views", "views"}:
+                values[name] = entry.get("total_value", {}).get("value", 0)
 
         return AccountMetrics(
             reach=values.get("reach", 0),

--- a/providers/instagram_login.py
+++ b/providers/instagram_login.py
@@ -396,7 +396,7 @@ class InstagramLoginProvider(SocialProvider):
     # ------------------------------------------------------------------
 
     def get_post_metrics(self, access_token: str, post_id: str) -> PostMetrics:
-        metrics = ["impressions", "reach", "engagement", "saved"]
+        metrics = ["reach", "views", "likes", "comments", "shares", "saved", "total_interactions"]
         resp = self._request(
             "GET",
             f"{API_BASE}/{post_id}/insights",
@@ -411,9 +411,12 @@ class InstagramLoginProvider(SocialProvider):
             values[name] = val
 
         return PostMetrics(
-            impressions=values.get("impressions", 0),
             reach=values.get("reach", 0),
-            engagements=values.get("engagement", 0),
+            video_views=values.get("views", 0),
+            likes=values.get("likes", 0),
+            comments=values.get("comments", 0),
+            shares=values.get("shares", 0),
+            engagements=values.get("total_interactions", 0),
             saves=values.get("saved", 0),
             extra={"raw_insights": values},
         )
@@ -421,7 +424,7 @@ class InstagramLoginProvider(SocialProvider):
     def get_account_metrics(self, access_token: str, date_range: tuple[datetime, datetime]) -> AccountMetrics:
         since = int(date_range[0].timestamp())
         until = int(date_range[1].timestamp())
-        metrics = ["reach", "follower_count", "profile_views"]
+        metrics = ["reach", "follower_count"]
         resp = self._request(
             "GET",
             f"{API_BASE}/me/insights",
@@ -445,7 +448,7 @@ class InstagramLoginProvider(SocialProvider):
             f"{API_BASE}/me/insights",
             access_token=access_token,
             params={
-                "metric": "views",
+                "metric": "profile_views,views",
                 "period": "day",
                 "metric_type": "total_value",
                 "since": since,
@@ -454,9 +457,9 @@ class InstagramLoginProvider(SocialProvider):
         )
         views_data = views_resp.json()
         for entry in views_data.get("data", []):
-            if entry.get("name") == "views":
-                values["views"] = entry.get("total_value", {}).get("value", 0)
-                break
+            name = entry.get("name", "")
+            if name in {"profile_views", "views"}:
+                values[name] = entry.get("total_value", {}).get("value", 0)
 
         return AccountMetrics(
             reach=values.get("reach", 0),

--- a/templates/calendar/calendar.html
+++ b/templates/calendar/calendar.html
@@ -235,6 +235,60 @@
         transform: scale(1.1);
     }
 
+    .calendar-channel-slot {
+        display: inline-flex;
+        align-items: center;
+        gap: 5px;
+        max-width: 100%;
+        min-height: 24px;
+        padding: 3px 5px;
+        border-radius: 6px;
+        font-size: 11px;
+        font-weight: 600;
+        border: 1px solid #E7E5E4;
+        background: #FAFAF9;
+        color: #44403C;
+    }
+    .calendar-channel-slot--week {
+        width: 100%;
+        font-size: 10px;
+        gap: 4px;
+    }
+    .calendar-channel-slot.is-open {
+        border-color: #FED7AA;
+        background: #FFF7ED;
+    }
+    .calendar-channel-slot.is-taken {
+        border-color: #BBF7D0;
+        background: #F0FDF4;
+    }
+    .calendar-slot-state {
+        flex-shrink: 0;
+        padding: 1px 5px;
+        border-radius: 9999px;
+        background: rgba(255,255,255,0.72);
+        color: #57534E;
+        font-size: 9px;
+        text-transform: uppercase;
+        letter-spacing: 0;
+    }
+    .calendar-slot-add {
+        flex-shrink: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 18px;
+        height: 18px;
+        border-radius: 9999px;
+        background: #F97316;
+        color: white;
+        box-shadow: 0 1px 4px rgba(249,115,22,0.25);
+    }
+    .calendar-slot-add:hover {
+        background: #EA580C;
+        transform: scale(1.05);
+    }
+
     /* Draggable feedback */
     .post-chip.dragging { opacity: 0.5; transform: rotate(2deg); }
 

--- a/templates/calendar/calendar.html
+++ b/templates/calendar/calendar.html
@@ -245,32 +245,29 @@
         border-radius: 6px;
         font-size: 11px;
         font-weight: 600;
-        border: 1px solid #E7E5E4;
-        background: #FAFAF9;
-        color: #44403C;
+        border: 1px dashed #E7E5E4;
+        background: #FFFFFF;
+        color: #78716C;
     }
     .calendar-channel-slot--week {
         width: 100%;
         font-size: 10px;
         gap: 4px;
     }
-    .calendar-channel-slot.is-open {
-        border-color: #FED7AA;
-        background: #FFF7ED;
+    .calendar-channel-slot.is-past-open {
+        opacity: 0.45;
+        background: #FAFAF9;
     }
-    .calendar-channel-slot.is-taken {
-        border-color: #BBF7D0;
-        background: #F0FDF4;
-    }
-    .calendar-slot-state {
+    .calendar-slot-platform-icon {
         flex-shrink: 0;
-        padding: 1px 5px;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 16px;
+        height: 16px;
         border-radius: 9999px;
-        background: rgba(255,255,255,0.72);
-        color: #57534E;
-        font-size: 9px;
-        text-transform: uppercase;
-        letter-spacing: 0;
+        background: #F5F5F4;
+        color: #78716C;
     }
     .calendar-slot-add {
         flex-shrink: 0;
@@ -280,13 +277,24 @@
         width: 18px;
         height: 18px;
         border-radius: 9999px;
-        background: #F97316;
-        color: white;
-        box-shadow: 0 1px 4px rgba(249,115,22,0.25);
+        background: #FFEDD5;
+        color: #C2410C;
     }
     .calendar-slot-add:hover {
-        background: #EA580C;
+        background: #FED7AA;
         transform: scale(1.05);
+    }
+    .calendar-post-slot-check {
+        flex-shrink: 0;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 16px;
+        height: 16px;
+        border-radius: 9999px;
+        background: rgba(255,255,255,0.72);
+        color: #15803D;
+        margin-left: auto;
     }
 
     /* Draggable feedback */

--- a/templates/calendar/partials/day_grid.html
+++ b/templates/calendar/partials/day_grid.html
@@ -24,15 +24,13 @@ Context: day_slots, target_date, workspace.
             {% if slot_items %}
             <div class="flex flex-wrap gap-1.5">
                 {% for slot in slot_items %}
-                <div class="calendar-channel-slot {% if slot.is_taken %}is-taken{% else %}is-open{% endif %}">
-                    <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ slot.account.platform }} flex-shrink-0 text-white">
+                <div class="calendar-channel-slot {% if is_past_day or is_today and hour < current_hour %}is-past-open{% endif %}">
+                    <span class="calendar-slot-platform-icon">
                         {% include "social_accounts/partials/_platform_icon.html" with platform=slot.account.platform size="3" %}
                     </span>
                     <span class="truncate">{{ slot.account.account_name|default:slot.account.account_handle }}</span>
                     <span class="tabular-nums text-stone-500">{{ slot.time_label }}</span>
-                    {% if slot.is_taken %}
-                    <span class="calendar-slot-state">Taken</span>
-                    {% elif not is_past_day and not is_today or not is_past_day and hour >= current_hour %}
+                    {% if not is_past_day and not is_today or not is_past_day and hour >= current_hour %}
                     <a href="{% url 'composer:compose' workspace_id=workspace.id %}?account={{ slot.account.id }}&scheduled_date={{ slot.compose_date }}&scheduled_time={{ slot.compose_time }}"
                        class="calendar-slot-add"
                        title="Schedule post for {{ slot.account.account_name|default:slot.account.account_handle }} at {{ slot.time_label }}">
@@ -65,6 +63,11 @@ Context: day_slots, target_date, workspace.
                 {% endif %}
                 {% endwith %}
                 <span class="truncate">{{ pp.post.title|default:pp.post.caption_snippet|truncatechars:28 }}</span>
+                {% if pp.takes_calendar_slot %}
+                <span class="calendar-post-slot-check" title="Scheduled in a channel slot">
+                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                </span>
+                {% endif %}
             </a>
             {% endfor %}
         </div>

--- a/templates/calendar/partials/day_grid.html
+++ b/templates/calendar/partials/day_grid.html
@@ -4,8 +4,8 @@ Context: day_slots, target_date, workspace.
 {% endcomment %}
 
 <div class="bg-white mx-auto" style="animation: slideUp 200ms cubic-bezier(0.16,1,0.3,1) both; max-height: calc(100vh - 200px); overflow-y: auto;">
-    {% for hour, hour_posts in day_slots %}
-    <div class="flex border-b border-stone-100 min-h-[64px] cal-add-cell {% if hour_posts %}has-posts{% endif %} {% if is_today and hour == current_hour %}bg-orange-50/50{% endif %}"
+{% for hour, hour_posts, slot_items in day_slots %}
+    <div class="flex border-b border-stone-100 min-h-[64px] cal-add-cell {% if hour_posts or slot_items %}has-posts{% endif %} {% if is_today and hour == current_hour %}bg-orange-50/50{% endif %}"
          @dragover.prevent="allowDrop($event)"
          @drop="dropOnSlot($event, '{{ target_date|date:'Y-m-d' }}', {{ hour }})">
         <!-- Time label -->
@@ -14,12 +14,36 @@ Context: day_slots, target_date, workspace.
                 {% if hour < 10 %}0{% endif %}{{ hour }}:00
             </span>
         </div>
-        <!-- Posts in this hour -->
+        <!-- Slots and posts in this hour -->
         <div class="flex-1 p-2 flex flex-col justify-center gap-1">
             {% if not is_past_day and not is_today or not is_past_day and hour >= current_hour %}
             <a href="{% url 'composer:compose' workspace_id=workspace.id %}?scheduled_date={{ target_date|date:'Y-m-d' }}&scheduled_time={{ hour }}:00" class="cal-add-btn cal-add-btn--inline" style="position:static; margin:0 auto;" title="Create post">
                 <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
             </a>
+            {% endif %}
+            {% if slot_items %}
+            <div class="flex flex-wrap gap-1.5">
+                {% for slot in slot_items %}
+                <div class="calendar-channel-slot {% if slot.is_taken %}is-taken{% else %}is-open{% endif %}">
+                    <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ slot.account.platform }} flex-shrink-0 text-white">
+                        {% include "social_accounts/partials/_platform_icon.html" with platform=slot.account.platform size="3" %}
+                    </span>
+                    <span class="truncate">{{ slot.account.account_name|default:slot.account.account_handle }}</span>
+                    <span class="tabular-nums text-stone-500">{{ slot.time_label }}</span>
+                    {% if slot.is_taken %}
+                    <span class="calendar-slot-state">Taken</span>
+                    {% elif not is_past_day and not is_today or not is_past_day and hour >= current_hour %}
+                    <a href="{% url 'composer:compose' workspace_id=workspace.id %}?account={{ slot.account.id }}&scheduled_date={{ slot.compose_date }}&scheduled_time={{ slot.compose_time }}"
+                       class="calendar-slot-add"
+                       title="Schedule post for {{ slot.account.account_name|default:slot.account.account_handle }} at {{ slot.time_label }}">
+                        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
+                    </a>
+                    {% else %}
+                    <span class="calendar-slot-state">Open</span>
+                    {% endif %}
+                </div>
+                {% endfor %}
+            </div>
             {% endif %}
             {% for pp in hour_posts %}
             <a href="{% url 'composer:compose_edit' workspace_id=workspace.id post_id=pp.post_id %}?account={{ pp.social_account_id }}"

--- a/templates/calendar/partials/week_grid.html
+++ b/templates/calendar/partials/week_grid.html
@@ -21,14 +21,38 @@ Context: week_days, week_slots, workspace.
         <div class="border-r border-stone-200 px-2 py-1 text-right">
             <span class="text-[11px] font-medium text-stone-400 tabular-nums">{{ hour }}:00</span>
         </div>
-        {% for day, slot_posts in day_slots %}
-        <div class="border-r border-stone-100 last:border-r-0 p-1 cal-add-cell {% if slot_posts %}has-posts{% endif %} {% if day == today %}bg-orange-50/30{% endif %}"
+        {% for day, slot_posts, slot_items in day_slots %}
+        <div class="border-r border-stone-100 last:border-r-0 p-1 cal-add-cell {% if slot_posts or slot_items %}has-posts{% endif %} {% if day == today %}bg-orange-50/30{% endif %}"
              @dragover.prevent="allowDrop($event)"
              @drop="dropOnSlot($event, '{{ day|date:'Y-m-d' }}', {{ hour }})">
             {% if day > today or day == today and hour >= current_hour %}
             <a href="{% url 'composer:compose' workspace_id=workspace.id %}?scheduled_date={{ day|date:'Y-m-d' }}&scheduled_time={{ hour }}:00" class="cal-add-btn" title="Create post">
                 <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
             </a>
+            {% endif %}
+            {% if slot_items %}
+            <div class="flex flex-col gap-1 mb-1">
+                {% for slot in slot_items %}
+                <div class="calendar-channel-slot calendar-channel-slot--week {% if slot.is_taken %}is-taken{% else %}is-open{% endif %}">
+                    <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ slot.account.platform }} flex-shrink-0 text-white">
+                        {% include "social_accounts/partials/_platform_icon.html" with platform=slot.account.platform size="3" %}
+                    </span>
+                    <span class="truncate">{{ slot.account.account_name|default:slot.account.account_handle }}</span>
+                    <span class="tabular-nums text-stone-500">{{ slot.time_label }}</span>
+                    {% if slot.is_taken %}
+                    <span class="calendar-slot-state">Taken</span>
+                    {% elif day > today or day == today and hour >= current_hour %}
+                    <a href="{% url 'composer:compose' workspace_id=workspace.id %}?account={{ slot.account.id }}&scheduled_date={{ slot.compose_date }}&scheduled_time={{ slot.compose_time }}"
+                       class="calendar-slot-add"
+                       title="Schedule post for {{ slot.account.account_name|default:slot.account.account_handle }} at {{ slot.time_label }}">
+                        <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
+                    </a>
+                    {% else %}
+                    <span class="calendar-slot-state">Open</span>
+                    {% endif %}
+                </div>
+                {% endfor %}
+            </div>
             {% endif %}
             {% for pp in slot_posts %}
             <a href="{% url 'composer:compose_edit' workspace_id=workspace.id post_id=pp.post_id %}?account={{ pp.social_account_id }}"

--- a/templates/calendar/partials/week_grid.html
+++ b/templates/calendar/partials/week_grid.html
@@ -33,15 +33,13 @@ Context: week_days, week_slots, workspace.
             {% if slot_items %}
             <div class="flex flex-col gap-1 mb-1">
                 {% for slot in slot_items %}
-                <div class="calendar-channel-slot calendar-channel-slot--week {% if slot.is_taken %}is-taken{% else %}is-open{% endif %}">
-                    <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ slot.account.platform }} flex-shrink-0 text-white">
+                <div class="calendar-channel-slot calendar-channel-slot--week {% if day < today or day == today and hour < current_hour %}is-past-open{% endif %}">
+                    <span class="calendar-slot-platform-icon">
                         {% include "social_accounts/partials/_platform_icon.html" with platform=slot.account.platform size="3" %}
                     </span>
                     <span class="truncate">{{ slot.account.account_name|default:slot.account.account_handle }}</span>
                     <span class="tabular-nums text-stone-500">{{ slot.time_label }}</span>
-                    {% if slot.is_taken %}
-                    <span class="calendar-slot-state">Taken</span>
-                    {% elif day > today or day == today and hour >= current_hour %}
+                    {% if day > today or day == today and hour >= current_hour %}
                     <a href="{% url 'composer:compose' workspace_id=workspace.id %}?account={{ slot.account.id }}&scheduled_date={{ slot.compose_date }}&scheduled_time={{ slot.compose_time }}"
                        class="calendar-slot-add"
                        title="Schedule post for {{ slot.account.account_name|default:slot.account.account_handle }} at {{ slot.time_label }}">
@@ -74,6 +72,11 @@ Context: week_days, week_slots, workspace.
                 {% endif %}
                 {% endwith %}
                 <span class="truncate">{{ pp.post.title|default:pp.post.caption_snippet|truncatechars:28 }}</span>
+                {% if pp.takes_calendar_slot %}
+                <span class="calendar-post-slot-check" title="Scheduled in a channel slot">
+                    <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                </span>
+                {% endif %}
             </a>
             {% endfor %}
         </div>

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -149,3 +149,7 @@ class TestProviderMetadata:
     def test_facebook_auth_type_is_oauth2(self):
         p = get_provider("facebook")
         assert p.auth_type == AuthType.OAUTH2
+
+    def test_facebook_scopes_include_comment_permission(self):
+        p = get_provider("facebook")
+        assert "pages_manage_engagement" in p.required_scopes

--- a/tests/providers/test_facebook.py
+++ b/tests/providers/test_facebook.py
@@ -1,0 +1,25 @@
+from unittest.mock import MagicMock
+
+from providers.facebook import FacebookProvider
+from providers.types import PostType, PublishContent
+
+
+def test_publish_single_photo_uses_feed_post_id_when_available():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        return_value=MagicMock(json=MagicMock(return_value={"id": "photo-1", "post_id": "page-1_post-1"}))
+    )
+
+    result = provider.publish_post(
+        "page-token",
+        PublishContent(
+            text="Caption for the photo",
+            media_urls=["https://cdn.example.com/one.jpg"],
+            post_type=PostType.IMAGE,
+            extra={"page_id": "page-1"},
+        ),
+    )
+
+    assert result.platform_post_id == "page-1_post-1"
+    assert result.url == "https://www.facebook.com/page-1_post-1"
+    assert result.extra["id"] == "photo-1"

--- a/tests/providers/test_facebook.py
+++ b/tests/providers/test_facebook.py
@@ -57,27 +57,6 @@ def test_publish_multi_photo_post_stages_photos_then_publishes_feed_post():
     )
 
 
-def test_publish_single_photo_uses_feed_post_id_when_available():
-    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
-    provider._request = MagicMock(
-        return_value=MagicMock(json=MagicMock(return_value={"id": "photo-1", "post_id": "page-1_post-1"}))
-    )
-
-    result = provider.publish_post(
-        "page-token",
-        PublishContent(
-            text="Caption for the photo",
-            media_urls=["https://cdn.example.com/one.jpg"],
-            post_type=PostType.IMAGE,
-            extra={"page_id": "page-1"},
-        ),
-    )
-
-    assert result.platform_post_id == "page-1_post-1"
-    assert result.url == "https://www.facebook.com/page-1_post-1"
-    assert result.extra["id"] == "photo-1"
-
-
 def test_publish_multi_photo_post_requires_staged_photo_ids():
     provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
     provider._request = MagicMock(return_value=MagicMock(json=MagicMock(return_value={"success": True})))

--- a/tests/providers/test_facebook.py
+++ b/tests/providers/test_facebook.py
@@ -57,6 +57,27 @@ def test_publish_multi_photo_post_stages_photos_then_publishes_feed_post():
     )
 
 
+def test_publish_single_photo_uses_feed_post_id_when_available():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        return_value=MagicMock(json=MagicMock(return_value={"id": "photo-1", "post_id": "page-1_post-1"}))
+    )
+
+    result = provider.publish_post(
+        "page-token",
+        PublishContent(
+            text="Caption for the photo",
+            media_urls=["https://cdn.example.com/one.jpg"],
+            post_type=PostType.IMAGE,
+            extra={"page_id": "page-1"},
+        ),
+    )
+
+    assert result.platform_post_id == "page-1_post-1"
+    assert result.url == "https://www.facebook.com/page-1_post-1"
+    assert result.extra["id"] == "photo-1"
+
+
 def test_publish_multi_photo_post_requires_staged_photo_ids():
     provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
     provider._request = MagicMock(return_value=MagicMock(json=MagicMock(return_value={"success": True})))

--- a/tests/providers/test_facebook.py
+++ b/tests/providers/test_facebook.py
@@ -1,0 +1,93 @@
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from providers.exceptions import PublishError
+from providers.facebook import FacebookProvider
+from providers.types import PostType, PublishContent
+
+
+def test_publish_multi_photo_post_stages_photos_then_publishes_feed_post():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        side_effect=[
+            MagicMock(json=MagicMock(return_value={"id": "photo-1"})),
+            MagicMock(json=MagicMock(return_value={"id": "photo-2"})),
+            MagicMock(json=MagicMock(return_value={"id": "page-1_post-1"})),
+        ]
+    )
+
+    result = provider.publish_post(
+        "page-token",
+        PublishContent(
+            text="Caption for the album",
+            media_urls=["https://cdn.example.com/one.jpg", "https://cdn.example.com/two.jpg"],
+            post_type=PostType.IMAGE,
+            extra={"page_id": "page-1"},
+        ),
+    )
+
+    assert result.platform_post_id == "page-1_post-1"
+    assert result.url == "https://www.facebook.com/page-1_post-1"
+    assert result.extra["photo_ids"] == ["photo-1", "photo-2"]
+    provider._request.assert_has_calls(
+        [
+            call(
+                "POST",
+                "https://graph.facebook.com/v21.0/page-1/photos",
+                access_token="page-token",
+                json={"url": "https://cdn.example.com/one.jpg", "published": False},
+            ),
+            call(
+                "POST",
+                "https://graph.facebook.com/v21.0/page-1/photos",
+                access_token="page-token",
+                json={"url": "https://cdn.example.com/two.jpg", "published": False},
+            ),
+            call(
+                "POST",
+                "https://graph.facebook.com/v21.0/page-1/feed",
+                access_token="page-token",
+                json={
+                    "attached_media": [{"media_fbid": "photo-1"}, {"media_fbid": "photo-2"}],
+                    "message": "Caption for the album",
+                },
+            ),
+        ]
+    )
+
+
+def test_publish_multi_photo_post_requires_staged_photo_ids():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(return_value=MagicMock(json=MagicMock(return_value={"success": True})))
+
+    with pytest.raises(PublishError, match="Failed to stage Facebook photo"):
+        provider.publish_post(
+            "page-token",
+            PublishContent(
+                media_urls=["https://cdn.example.com/one.jpg", "https://cdn.example.com/two.jpg"],
+                post_type=PostType.IMAGE,
+                extra={"page_id": "page-1"},
+            ),
+        )
+
+
+def test_publish_multi_photo_post_requires_feed_post_id():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        side_effect=[
+            MagicMock(json=MagicMock(return_value={"id": "photo-1"})),
+            MagicMock(json=MagicMock(return_value={"id": "photo-2"})),
+            MagicMock(json=MagicMock(return_value={"success": True})),
+        ]
+    )
+
+    with pytest.raises(PublishError, match="Failed to publish Facebook multi-photo post"):
+        provider.publish_post(
+            "page-token",
+            PublishContent(
+                media_urls=["https://cdn.example.com/one.jpg", "https://cdn.example.com/two.jpg"],
+                post_type=PostType.IMAGE,
+                extra={"page_id": "page-1"},
+            ),
+        )

--- a/tests/providers/test_facebook_analytics.py
+++ b/tests/providers/test_facebook_analytics.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 from apps.analytics.tasks import _resolve_provider
 from providers.exceptions import APIError
@@ -45,6 +45,60 @@ def test_account_metrics_use_current_page_insights_metrics():
     )
 
 
+def test_post_metrics_use_supported_facebook_insights_and_basic_counts():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        side_effect=[
+            MagicMock(
+                json=MagicMock(
+                    return_value={
+                        "data": [
+                            {"name": "post_clicks", "values": [{"value": 4}]},
+                            {"name": "post_reactions_by_type_total", "values": [{"value": {"like": 5, "love": 2}}]},
+                            {"name": "post_video_views", "values": [{"value": 11}]},
+                        ]
+                    }
+                )
+            ),
+            MagicMock(
+                json=MagicMock(
+                    return_value={
+                        "id": "post-1",
+                        "permalink_url": "/post/post-1/",
+                        "likes": {"summary": {"total_count": 10}},
+                        "comments": {"summary": {"total_count": 3}},
+                        "shares": {"count": 2},
+                    }
+                )
+            ),
+        ]
+    )
+
+    metrics = provider.get_post_metrics("page-token", "post-1")
+
+    assert metrics.clicks == 4
+    assert metrics.likes == 7
+    assert metrics.comments == 3
+    assert metrics.shares == 2
+    assert metrics.video_views == 11
+    provider._request.assert_has_calls(
+        [
+            call(
+                "GET",
+                "https://graph.facebook.com/v21.0/post-1/insights",
+                access_token="page-token",
+                params={"metric": "post_clicks,post_reactions_by_type_total,post_video_views"},
+            ),
+            call(
+                "GET",
+                "https://graph.facebook.com/v21.0/post-1",
+                access_token="page-token",
+                params={"fields": "id,permalink_url,likes.summary(true),comments.summary(true),shares"},
+            ),
+        ]
+    )
+
+
 def test_post_metrics_falls_back_for_objects_without_insights_edge():
     provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
     provider._request = MagicMock(
@@ -57,6 +111,7 @@ def test_post_metrics_falls_back_for_objects_without_insights_edge():
                         "permalink_url": "/reel/reel-1/",
                         "likes": {"summary": {"total_count": 7}},
                         "comments": {"summary": {"total_count": 3}},
+                        "shares": {"count": 2},
                     }
                 )
             ),
@@ -67,9 +122,10 @@ def test_post_metrics_falls_back_for_objects_without_insights_edge():
 
     assert metrics.likes == 7
     assert metrics.comments == 3
+    assert metrics.shares == 2
     assert metrics.extra["raw_fallback"]["permalink_url"] == "/reel/reel-1/"
     assert provider._request.call_args_list[1].kwargs["params"] == {
-        "fields": "id,permalink_url,likes.summary(true),comments.summary(true)"
+        "fields": "id,permalink_url,likes.summary(true),comments.summary(true),shares"
     }
 
 

--- a/tests/providers/test_facebook_analytics.py
+++ b/tests/providers/test_facebook_analytics.py
@@ -99,6 +99,30 @@ def test_post_metrics_use_supported_facebook_insights_and_basic_counts():
     )
 
 
+def test_facebook_post_metrics_persist_reactions_key():
+    from apps.analytics.tasks import _post_metrics_to_dict
+    from providers.types import PostMetrics
+
+    metrics = PostMetrics(likes=7, comments=3, shares=2, clicks=4)
+
+    out = _post_metrics_to_dict(metrics, "facebook")
+
+    assert out["reactions"] == 7.0
+    assert "likes" not in out
+    assert out["comments"] == 3.0
+    assert out["shares"] == 2.0
+    assert out["clicks"] == 4.0
+
+
+def test_facebook_catalog_uses_supported_metrics():
+    from apps.analytics.metrics import PLATFORM_METRICS, PLATFORM_PRIMARY
+
+    assert PLATFORM_PRIMARY["facebook"] == "reactions"
+    assert "reach" not in PLATFORM_METRICS["facebook"]
+    assert "impressions" not in PLATFORM_METRICS["facebook"]
+    assert {"reactions", "comments", "shares", "clicks", "follows"} <= set(PLATFORM_METRICS["facebook"])
+
+
 def test_post_metrics_falls_back_for_objects_without_insights_edge():
     provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
     provider._request = MagicMock(

--- a/tests/providers/test_facebook_analytics.py
+++ b/tests/providers/test_facebook_analytics.py
@@ -1,0 +1,73 @@
+from datetime import UTC, datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from apps.analytics.tasks import _resolve_provider
+from providers.facebook import FacebookProvider
+
+
+def test_account_metrics_use_current_page_insights_metrics():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret", "page_id": "page-1"})
+    provider._request = MagicMock(
+        return_value=MagicMock(
+            json=MagicMock(
+                return_value={
+                    "data": [
+                        {"name": "page_impressions_unique", "values": [{"value": 12}]},
+                        {"name": "page_post_engagements", "values": [{"value": 34}]},
+                        {"name": "page_daily_follows", "values": [{"value": 5}]},
+                    ]
+                }
+            )
+        )
+    )
+
+    metrics = provider.get_account_metrics(
+        "page-token",
+        (
+            datetime(2026, 6, 18, tzinfo=UTC),
+            datetime(2026, 6, 19, tzinfo=UTC),
+        ),
+    )
+
+    assert metrics.reach == 12
+    assert metrics.followers_gained == 5
+    assert metrics.extra["raw_insights"]["page_post_engagements"] == 34
+    provider._request.assert_called_once_with(
+        "GET",
+        "https://graph.facebook.com/v21.0/page-1/insights",
+        access_token="page-token",
+        params={
+            "metric": "page_impressions_unique,page_post_engagements,page_daily_follows",
+            "since": 1781740800,
+            "until": 1781827200,
+        },
+    )
+
+
+def test_facebook_analytics_provider_uses_connected_page_id(monkeypatch):
+    captured = {}
+
+    def fake_resolve(platform, organization_id):
+        captured["resolved"] = (platform, organization_id)
+        return {"client_id": "id", "client_secret": "secret"}
+
+    def fake_get_provider(platform, credentials):
+        captured["provider"] = (platform, credentials)
+        return object()
+
+    monkeypatch.setattr("apps.credentials.models.resolve_platform_credentials", fake_resolve)
+    monkeypatch.setattr("providers.get_provider", fake_get_provider)
+    account = SimpleNamespace(
+        platform="facebook",
+        account_platform_id="page-123",
+        workspace=SimpleNamespace(organization_id="org-1"),
+    )
+
+    _resolve_provider(account)
+
+    assert captured["resolved"] == ("facebook", "org-1")
+    assert captured["provider"] == (
+        "facebook",
+        {"client_id": "id", "client_secret": "secret", "page_id": "page-123"},
+    )

--- a/tests/providers/test_facebook_analytics.py
+++ b/tests/providers/test_facebook_analytics.py
@@ -54,7 +54,10 @@ def test_post_metrics_use_supported_facebook_insights_and_basic_counts():
                     return_value={
                         "data": [
                             {"name": "post_clicks", "values": [{"value": 4}]},
-                            {"name": "post_reactions_by_type_total", "values": [{"value": {"like": 5, "love": 2}}]},
+                            {
+                                "name": "post_reactions_by_type_total",
+                                "values": [{"value": {"like": 5, "love": 2, "sorry": 3}}],
+                            },
                             {"name": "post_video_views", "values": [{"value": 11}]},
                         ]
                     }
@@ -83,7 +86,7 @@ def test_post_metrics_use_supported_facebook_insights_and_basic_counts():
     metrics = provider.get_post_metrics("page-token", "post-1")
 
     assert metrics.clicks == 4
-    assert metrics.likes == 7
+    assert metrics.likes == 10
     assert metrics.comments == 3
     assert metrics.shares == 2
     assert metrics.video_views == 11
@@ -129,10 +132,11 @@ def test_facebook_post_metrics_persist_reactions_key():
 def test_facebook_catalog_uses_supported_metrics():
     from apps.analytics.metrics import PLATFORM_METRICS, PLATFORM_PRIMARY
 
-    assert PLATFORM_PRIMARY["facebook"] == "views"
+    assert PLATFORM_PRIMARY["facebook"] == "reactions"
+    assert "views" not in PLATFORM_METRICS["facebook"]
     assert "reach" not in PLATFORM_METRICS["facebook"]
     assert "impressions" not in PLATFORM_METRICS["facebook"]
-    assert {"views", "reactions", "comments", "shares", "clicks", "follows"} <= set(PLATFORM_METRICS["facebook"])
+    assert {"reactions", "comments", "shares", "clicks", "follows"} <= set(PLATFORM_METRICS["facebook"])
 
 
 def test_post_metrics_falls_back_for_objects_without_insights_edge():

--- a/tests/providers/test_facebook_analytics.py
+++ b/tests/providers/test_facebook_analytics.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 from apps.analytics.tasks import _resolve_provider
+from providers.exceptions import APIError
 from providers.facebook import FacebookProvider
 
 
@@ -13,7 +14,6 @@ def test_account_metrics_use_current_page_insights_metrics():
             json=MagicMock(
                 return_value={
                     "data": [
-                        {"name": "page_impressions_unique", "values": [{"value": 12}]},
                         {"name": "page_post_engagements", "values": [{"value": 34}]},
                         {"name": "page_daily_follows", "values": [{"value": 5}]},
                     ]
@@ -30,7 +30,7 @@ def test_account_metrics_use_current_page_insights_metrics():
         ),
     )
 
-    assert metrics.reach == 12
+    assert metrics.reach == 0
     assert metrics.followers_gained == 5
     assert metrics.extra["raw_insights"]["page_post_engagements"] == 34
     provider._request.assert_called_once_with(
@@ -38,11 +38,39 @@ def test_account_metrics_use_current_page_insights_metrics():
         "https://graph.facebook.com/v21.0/page-1/insights",
         access_token="page-token",
         params={
-            "metric": "page_impressions_unique,page_post_engagements,page_daily_follows",
+            "metric": "page_post_engagements,page_daily_follows",
             "since": 1781740800,
             "until": 1781827200,
         },
     )
+
+
+def test_post_metrics_falls_back_for_objects_without_insights_edge():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        side_effect=[
+            APIError('Facebook API error 400: {"error":{"message":"(#100) Tried accessing nonexisting field (insights)"}}'),
+            MagicMock(
+                json=MagicMock(
+                    return_value={
+                        "id": "reel-1",
+                        "permalink_url": "/reel/reel-1/",
+                        "likes": {"summary": {"total_count": 7}},
+                        "comments": {"summary": {"total_count": 3}},
+                    }
+                )
+            ),
+        ]
+    )
+
+    metrics = provider.get_post_metrics("page-token", "reel-1")
+
+    assert metrics.likes == 7
+    assert metrics.comments == 3
+    assert metrics.extra["raw_fallback"]["permalink_url"] == "/reel/reel-1/"
+    assert provider._request.call_args_list[1].kwargs["params"] == {
+        "fields": "id,permalink_url,likes.summary(true),comments.summary(true)"
+    }
 
 
 def test_facebook_analytics_provider_uses_connected_page_id(monkeypatch):

--- a/tests/providers/test_facebook_analytics.py
+++ b/tests/providers/test_facebook_analytics.py
@@ -64,9 +64,15 @@ def test_post_metrics_use_supported_facebook_insights_and_basic_counts():
                 json=MagicMock(
                     return_value={
                         "id": "post-1",
-                        "permalink_url": "/post/post-1/",
                         "likes": {"summary": {"total_count": 10}},
                         "comments": {"summary": {"total_count": 3}},
+                    }
+                )
+            ),
+            MagicMock(
+                json=MagicMock(
+                    return_value={
+                        "id": "post-1",
                         "shares": {"count": 2},
                     }
                 )
@@ -93,7 +99,13 @@ def test_post_metrics_use_supported_facebook_insights_and_basic_counts():
                 "GET",
                 "https://graph.facebook.com/v21.0/post-1",
                 access_token="page-token",
-                params={"fields": "id,permalink_url,likes.summary(true),comments.summary(true),shares"},
+                params={"fields": "id,likes.summary(true),comments.summary(true)"},
+            ),
+            call(
+                "GET",
+                "https://graph.facebook.com/v21.0/post-1",
+                access_token="page-token",
+                params={"fields": "id,shares"},
             ),
         ]
     )
@@ -117,10 +129,10 @@ def test_facebook_post_metrics_persist_reactions_key():
 def test_facebook_catalog_uses_supported_metrics():
     from apps.analytics.metrics import PLATFORM_METRICS, PLATFORM_PRIMARY
 
-    assert PLATFORM_PRIMARY["facebook"] == "reactions"
+    assert PLATFORM_PRIMARY["facebook"] == "views"
     assert "reach" not in PLATFORM_METRICS["facebook"]
     assert "impressions" not in PLATFORM_METRICS["facebook"]
-    assert {"reactions", "comments", "shares", "clicks", "follows"} <= set(PLATFORM_METRICS["facebook"])
+    assert {"views", "reactions", "comments", "shares", "clicks", "follows"} <= set(PLATFORM_METRICS["facebook"])
 
 
 def test_post_metrics_falls_back_for_objects_without_insights_edge():
@@ -132,13 +144,12 @@ def test_post_metrics_falls_back_for_objects_without_insights_edge():
                 json=MagicMock(
                     return_value={
                         "id": "reel-1",
-                        "permalink_url": "/reel/reel-1/",
                         "likes": {"summary": {"total_count": 7}},
                         "comments": {"summary": {"total_count": 3}},
-                        "shares": {"count": 2},
                     }
                 )
             ),
+            APIError('Facebook API error 400: {"error":{"message":"(#100) Tried accessing nonexisting field (shares)"}}'),
         ]
     )
 
@@ -146,10 +157,10 @@ def test_post_metrics_falls_back_for_objects_without_insights_edge():
 
     assert metrics.likes == 7
     assert metrics.comments == 3
-    assert metrics.shares == 2
-    assert metrics.extra["raw_fallback"]["permalink_url"] == "/reel/reel-1/"
+    assert metrics.shares == 0
+    assert metrics.extra["raw_fallback"]["id"] == "reel-1"
     assert provider._request.call_args_list[1].kwargs["params"] == {
-        "fields": "id,permalink_url,likes.summary(true),comments.summary(true),shares"
+        "fields": "id,likes.summary(true),comments.summary(true)"
     }
 
 

--- a/tests/providers/test_instagram.py
+++ b/tests/providers/test_instagram.py
@@ -105,7 +105,6 @@ def test_account_metrics_use_current_instagram_insights_metrics():
                         "data": [
                             {"name": "reach", "values": [{"value": 12}]},
                             {"name": "follower_count", "values": [{"value": 34}]},
-                            {"name": "profile_views", "values": [{"value": 5}]},
                         ]
                     }
                 )
@@ -118,7 +117,12 @@ def test_account_metrics_use_current_instagram_insights_metrics():
                                 "name": "views",
                                 "period": "day",
                                 "total_value": {"value": 67},
-                            }
+                            },
+                            {
+                                "name": "profile_views",
+                                "period": "day",
+                                "total_value": {"value": 5},
+                            },
                         ]
                     }
                 )
@@ -146,7 +150,7 @@ def test_account_metrics_use_current_instagram_insights_metrics():
                 "https://graph.facebook.com/v21.0/ig-1/insights",
                 access_token="page-token",
                 params={
-                    "metric": "reach,follower_count,profile_views",
+                    "metric": "reach,follower_count",
                     "period": "day",
                     "since": 1781740800,
                     "until": 1781827200,
@@ -157,7 +161,7 @@ def test_account_metrics_use_current_instagram_insights_metrics():
                 "https://graph.facebook.com/v21.0/ig-1/insights",
                 access_token="page-token",
                 params={
-                    "metric": "views",
+                    "metric": "profile_views,views",
                     "period": "day",
                     "metric_type": "total_value",
                     "since": 1781740800,
@@ -165,6 +169,43 @@ def test_account_metrics_use_current_instagram_insights_metrics():
                 },
             ),
         ]
+    )
+
+
+def test_post_metrics_use_current_instagram_media_insights_metrics():
+    provider = InstagramProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        return_value=MagicMock(
+            json=MagicMock(
+                return_value={
+                    "data": [
+                        {"name": "reach", "values": [{"value": 12}]},
+                        {"name": "views", "values": [{"value": 34}]},
+                        {"name": "likes", "values": [{"value": 5}]},
+                        {"name": "comments", "values": [{"value": 6}]},
+                        {"name": "shares", "values": [{"value": 7}]},
+                        {"name": "saved", "values": [{"value": 8}]},
+                        {"name": "total_interactions", "values": [{"value": 26}]},
+                    ]
+                }
+            )
+        )
+    )
+
+    metrics = provider.get_post_metrics("page-token", "ig-media-1")
+
+    assert metrics.reach == 12
+    assert metrics.video_views == 34
+    assert metrics.likes == 5
+    assert metrics.comments == 6
+    assert metrics.shares == 7
+    assert metrics.saves == 8
+    assert metrics.engagements == 26
+    provider._request.assert_called_once_with(
+        "GET",
+        "https://graph.facebook.com/v21.0/ig-media-1/insights",
+        access_token="page-token",
+        params={"metric": "reach,views,likes,comments,shares,saved,total_interactions"},
     )
 
 
@@ -178,7 +219,6 @@ def test_instagram_login_account_metrics_use_current_insights_metrics():
                         "data": [
                             {"name": "reach", "values": [{"value": 12}]},
                             {"name": "follower_count", "values": [{"value": 34}]},
-                            {"name": "profile_views", "values": [{"value": 5}]},
                         ]
                     }
                 )
@@ -191,7 +231,12 @@ def test_instagram_login_account_metrics_use_current_insights_metrics():
                                 "name": "views",
                                 "period": "day",
                                 "total_value": {"value": 67},
-                            }
+                            },
+                            {
+                                "name": "profile_views",
+                                "period": "day",
+                                "total_value": {"value": 5},
+                            },
                         ]
                     }
                 )
@@ -219,7 +264,7 @@ def test_instagram_login_account_metrics_use_current_insights_metrics():
                 "https://graph.instagram.com/v21.0/me/insights",
                 access_token="ig-token",
                 params={
-                    "metric": "reach,follower_count,profile_views",
+                    "metric": "reach,follower_count",
                     "period": "day",
                     "since": 1781740800,
                     "until": 1781827200,
@@ -230,7 +275,7 @@ def test_instagram_login_account_metrics_use_current_insights_metrics():
                 "https://graph.instagram.com/v21.0/me/insights",
                 access_token="ig-token",
                 params={
-                    "metric": "views",
+                    "metric": "profile_views,views",
                     "period": "day",
                     "metric_type": "total_value",
                     "since": 1781740800,
@@ -238,4 +283,41 @@ def test_instagram_login_account_metrics_use_current_insights_metrics():
                 },
             ),
         ]
+    )
+
+
+def test_instagram_login_post_metrics_use_current_media_insights_metrics():
+    provider = InstagramLoginProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        return_value=MagicMock(
+            json=MagicMock(
+                return_value={
+                    "data": [
+                        {"name": "reach", "values": [{"value": 12}]},
+                        {"name": "views", "values": [{"value": 34}]},
+                        {"name": "likes", "values": [{"value": 5}]},
+                        {"name": "comments", "values": [{"value": 6}]},
+                        {"name": "shares", "values": [{"value": 7}]},
+                        {"name": "saved", "values": [{"value": 8}]},
+                        {"name": "total_interactions", "values": [{"value": 26}]},
+                    ]
+                }
+            )
+        )
+    )
+
+    metrics = provider.get_post_metrics("ig-token", "ig-media-1")
+
+    assert metrics.reach == 12
+    assert metrics.video_views == 34
+    assert metrics.likes == 5
+    assert metrics.comments == 6
+    assert metrics.shares == 7
+    assert metrics.saves == 8
+    assert metrics.engagements == 26
+    provider._request.assert_called_once_with(
+        "GET",
+        "https://graph.instagram.com/v21.0/ig-media-1/insights",
+        access_token="ig-token",
+        params={"metric": "reach,views,likes,comments,shares,saved,total_interactions"},
     )


### PR DESCRIPTION
## Summary

- use Facebook post metrics that production Graph API accepts: clicks, reaction breakdown, video views, comments, and shares
- map Facebook provider reaction totals into the UI `reactions` metric key
- remove unsupported Facebook post reach/impressions from the metric catalog and keep `views` as the primary metric
- count all Facebook reaction types, not only like/love

## Root Cause

Production Graph responses reject the old Facebook post reach/impressions metrics. For reactions, Facebook returns a breakdown such as `like`, `love`, `sorry`, `haha`, and `anger`; the importer was only counting `like + love`, so valid reactions were undercounted.

## Validation

- `.venv/bin/python -m pytest tests/providers/test_facebook_analytics.py -vv --tb=short`
- `.venv/bin/python -m pytest apps/api/tests/test_analytics_router.py -vv --tb=short`