### PR TITLE
Expose internal_notes on posts via REST API and MCP tools

### DIFF
--- a/apps/api/routers/posts.py
+++ b/apps/api/routers/posts.py
@@ -81,8 +81,23 @@ def _resolve_account(request: HttpRequest, social_account_id: uuid.UUID) -> Soci
     return SocialAccount.objects.get(id=social_account_id)
 
 
-def _post_to_response(post: Post) -> PostResponse:
-    return PostResponse.from_post(post)
+def _can_view_internal_notes(request: HttpRequest) -> bool:
+    """Whether this caller may see a post's team-only ``internal_notes``.
+
+    The composer hides ``internal_notes`` from the ``client`` / ``viewer``
+    workspace roles ([views.py](apps/composer/views.py): ``can_view_internal_notes``).
+    Those are exactly the builtin roles without ``create_posts`` (see
+    ``BUILTIN_ROLE_PERMISSIONS``), so gating visibility on ``create_posts``
+    reproduces that rule uniformly for both API keys and OAuth members. Reads
+    (`GET /posts/{id}`) aren't otherwise permission-gated, so without this the
+    shared serializer would leak notes to any read-capable client/viewer.
+    """
+    membership = getattr(request, "workspace_membership", None)
+    return bool(membership and membership.effective_permissions.get("create_posts", False))
+
+
+def _post_to_response(request: HttpRequest, post: Post) -> PostResponse:
+    return PostResponse.from_post(post, include_internal_notes=_can_view_internal_notes(request))
 
 
 def _get_workspace_post(request: HttpRequest, post_id: uuid.UUID) -> Post:
@@ -231,12 +246,13 @@ def create(request, payload: CreatePostRequest):
             media_asset_ids=payload.media_asset_ids,
             title=payload.title,
             first_comment=payload.first_comment,
+            internal_notes=payload.internal_notes,
             scheduled_at=payload.scheduled_at,
             author=request.user if not request.user.is_anonymous else None,
             status="scheduled" if payload.action == "schedule" else "draft",
             platform_overrides=platform_overrides,
         )
-        body = _post_to_response(post)
+        body = _post_to_response(request, post)
         status_code = 201
         log_audit_entry(
             request,
@@ -272,7 +288,7 @@ def retrieve(request, post_id: uuid.UUID):
     enforce_http_rate_limits(request, is_write=False)
     post = _get_workspace_post(request, post_id)
     log_audit_entry(request, action="post.read", target_id=post.id, status_code=200)
-    return _post_to_response(post)
+    return _post_to_response(request, post)
 
 
 @router.patch("/{post_id}", response=PostResponse, summary="Update draft fields")
@@ -334,6 +350,9 @@ def update(request, post_id: uuid.UUID, payload: UpdatePostRequest):
         if payload.first_comment is not None:
             post.first_comment = payload.first_comment
             update_fields.append("first_comment")
+        if payload.internal_notes is not None:
+            post.internal_notes = payload.internal_notes
+            update_fields.append("internal_notes")
         if payload.scheduled_at is not None:
             # Re-time any currently-scheduled child. Drafts are unaffected.
             # ``QuerySet.update()`` bypasses ``auto_now``, so we include
@@ -366,7 +385,7 @@ def update(request, post_id: uuid.UUID, payload: UpdatePostRequest):
 
     post.refresh_from_db()
     log_audit_entry(request, action="post.update", target_id=post.id, status_code=200)
-    return _post_to_response(post)
+    return _post_to_response(request, post)
 
 
 @router.post("/{post_id}/schedule", response=PostResponse, summary="Schedule a draft")
@@ -409,7 +428,7 @@ def schedule(request, post_id: uuid.UUID, payload: ScheduleRequest):
 
     post.refresh_from_db()
     log_audit_entry(request, action="post.schedule", target_id=post.id, status_code=200)
-    return _post_to_response(post)
+    return _post_to_response(request, post)
 
 
 @router.post("/{post_id}/cancel", response=PostResponse, summary="Cancel a scheduled post (back to draft)")
@@ -438,4 +457,4 @@ def cancel(request, post_id: uuid.UUID):
 
     post.refresh_from_db()
     log_audit_entry(request, action="post.cancel", target_id=post.id, status_code=200)
-    return _post_to_response(post)
+    return _post_to_response(request, post)

--- a/apps/api/schemas.py
+++ b/apps/api/schemas.py
@@ -165,6 +165,14 @@ class CreatePostRequest(Schema):
             "Bluesky, Google Business; LinkedIn Personal in OIDC mode)."
         ),
     )
+    internal_notes: str = Field(
+        "",
+        max_length=10_000,
+        description=(
+            "Private team-only note. Never published to any platform; surfaced only "
+            "to your team via the API and the composer."
+        ),
+    )
     media_asset_ids: list[uuid.UUID] = Field(
         default_factory=list,
         description="MediaAsset IDs already uploaded to the workspace's media library. Position-ordered.",
@@ -200,6 +208,11 @@ class UpdatePostRequest(Schema):
     caption: str | None = Field(None, max_length=10_000)
     title: str | None = Field(None, max_length=255)
     first_comment: str | None = Field(None, max_length=10_000)
+    internal_notes: str | None = Field(
+        None,
+        max_length=10_000,
+        description="Private team-only note. Omit (or send null) to leave it unchanged.",
+    )
     media_asset_ids: list[uuid.UUID] | None = None
     scheduled_at: dt.datetime | None = Field(
         None,
@@ -250,6 +263,7 @@ class PostResponse(Schema):
     title: str
     caption: str
     first_comment: str
+    internal_notes: str
     scheduled_at: dt.datetime | None
     published_at: dt.datetime | None
     status: str  # derived aggregate
@@ -262,12 +276,20 @@ class PostResponse(Schema):
         return _serialize_utc_z(value)
 
     @classmethod
-    def from_post(cls, post: Post) -> PostResponse:
+    def from_post(cls, post: Post, *, include_internal_notes: bool = False) -> PostResponse:
         """Single source of truth for Post → API response shape.
 
         Used by both the REST router and MCP handlers so the two surfaces
         cannot drift. ``post.platform_posts`` should be prefetched with
         ``social_account`` to avoid an N+1.
+
+        ``internal_notes`` is a team-only field. The composer hides it from
+        ``client`` / ``viewer`` workspace roles, so the API/MCP mirror that by
+        redacting it to ``""`` unless ``include_internal_notes`` is set. Call
+        sites derive that flag from the caller's ``create_posts`` permission
+        (see ``_can_view_internal_notes`` in the REST router and MCP handlers).
+        It defaults to ``False`` so a new, unconverted call site fails closed —
+        redacted — rather than leaking notes.
         """
         platform_posts = [
             PlatformPostSummary.from_platform_post(pp) for pp in post.platform_posts.select_related("social_account")
@@ -278,6 +300,7 @@ class PostResponse(Schema):
             title=post.title,
             caption=post.caption,
             first_comment=post.first_comment,
+            internal_notes=post.internal_notes if include_internal_notes else "",
             scheduled_at=post.scheduled_at,
             published_at=post.published_at,
             status=post.status,

--- a/apps/api/tests/test_e2e.py
+++ b/apps/api/tests/test_e2e.py
@@ -363,6 +363,19 @@ class TestPatchRouteHappyPaths:
         assert draft_post.title == "new title"
         assert draft_post.first_comment == "first!"
 
+    def test_internal_notes_update_persists(self, client_with_token, draft_post):
+        r = client_with_token.patch(
+            f"/api/v1/posts/{draft_post.id}",
+            data=json.dumps({"internal_notes": "needs a second pass before publish"}),
+            content_type="application/json",
+        )
+        assert r.status_code == 200, r.content
+        assert r.json()["internal_notes"] == "needs a second pass before publish"
+        draft_post.refresh_from_db()
+        assert draft_post.internal_notes == "needs a second pass before publish"
+        # Untouched fields preserved.
+        assert draft_post.caption == "initial"
+
 
 # ===========================================================================
 # Audit-log action labels

--- a/apps/api/tests/test_routers.py
+++ b/apps/api/tests/test_routers.py
@@ -204,6 +204,27 @@ class TestCreatePost:
         assert Post.objects.count() == 1
         assert PlatformPost.objects.filter(status="draft").count() == 1
 
+    def test_create_draft_with_internal_notes(self, client_with_token, social_account):
+        r = client_with_token.post(
+            "/api/v1/posts/",
+            data=json.dumps(
+                {
+                    "social_account_id": str(social_account.id),
+                    "caption": "Has a private note.",
+                    "internal_notes": "Approved by legal; ship Monday.",
+                    "action": "draft",
+                }
+            ),
+            content_type="application/json",
+        )
+        assert r.status_code == 201, r.content
+        body = r.json()
+        assert body["internal_notes"] == "Approved by legal; ship Monday."
+        # Persisted on the model; the team note never leaks into the public caption.
+        post = Post.objects.get(id=body["id"])
+        assert post.internal_notes == "Approved by legal; ship Monday."
+        assert post.caption == "Has a private note."
+
     def test_create_scheduled_requires_scheduled_at(self, client_with_token, social_account):
         r = client_with_token.post(
             "/api/v1/posts/",
@@ -250,6 +271,49 @@ class TestCreatePost:
         )
         assert r.status_code == 403
         assert "allowlist" in r.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# internal_notes visibility
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestInternalNotesVisibility:
+    """``internal_notes`` is a team-only field. The shared ``PostResponse``
+    serializer must redact it for callers without ``create_posts`` — the API
+    analogue of the composer hiding it from client/viewer roles — even though
+    reads aren't otherwise permission-gated.
+    """
+
+    def _post_with_note(self, workspace, user, social_account, note="eyes only"):
+        post = Post.objects.create(workspace=workspace, author=user, caption="public", internal_notes=note)
+        PlatformPost.objects.create(post=post, social_account=social_account, status="draft")
+        return post
+
+    def test_create_posts_caller_sees_internal_notes(self, client_with_token, workspace, user, social_account):
+        post = self._post_with_note(workspace, user, social_account)
+        r = client_with_token.get(f"/api/v1/posts/{post.id}")
+        assert r.status_code == 200, r.content
+        assert r.json()["internal_notes"] == "eyes only"
+
+    def test_caller_without_create_posts_gets_redacted_notes(self, user, owner_memberships, workspace, social_account):
+        # A key that can read posts (allowlisted) but lacks create_posts — the
+        # API analogue of a client/viewer-role member.
+        readonly = services.issue_api_key(
+            workspace=workspace,
+            social_accounts=[social_account],
+            issued_by=user,
+            name="readonly",
+            permissions=["view_analytics"],  # deliberately omits create_posts
+        )
+        client = _SecureClient(HTTP_AUTHORIZATION=f"Bearer {readonly.plaintext_token}")
+        post = self._post_with_note(workspace, user, social_account)
+        r = client.get(f"/api/v1/posts/{post.id}")
+        assert r.status_code == 200, r.content
+        body = r.json()
+        assert body["internal_notes"] == ""  # redacted
+        assert body["caption"] == "public"  # other fields unaffected
 
 
 # ---------------------------------------------------------------------------

--- a/apps/composer/services.py
+++ b/apps/composer/services.py
@@ -60,6 +60,7 @@ def create_post(
     media_asset_ids: Iterable[Any] | None = None,
     title: str = "",
     first_comment: str = "",
+    internal_notes: str = "",
     scheduled_at: dt.datetime | None = None,
     author=None,
     status: str = "draft",
@@ -157,6 +158,7 @@ def create_post(
             title=title,
             caption=caption,
             first_comment=first_comment,
+            internal_notes=internal_notes,
             scheduled_at=scheduled_at if status == "scheduled" else None,
         )
         # Each override field is independent: ``None`` (or omitted)

--- a/apps/mcp/handlers.py
+++ b/apps/mcp/handlers.py
@@ -103,13 +103,29 @@ def _parse_media_tags(args: dict) -> list:
     return tags
 
 
-def _serialize_post(post: Post) -> dict:
+def _can_view_internal_notes(context: dict[str, Any]) -> bool:
+    """Whether this MCP caller may see a post's team-only ``internal_notes``.
+
+    Mirrors the REST router's check: visibility is gated on ``create_posts``,
+    the permission held by exactly the workspace roles the composer lets view
+    internal notes (i.e. not client/viewer). ``get_post`` isn't permission-
+    gated, so without this an OAuth client/viewer could read team notes.
+    """
+    membership = context.get("membership")
+    return bool(membership and membership.effective_permissions.get("create_posts", False))
+
+
+def _serialize_post(post: Post, context: dict[str, Any]) -> dict:
     """Serialize a Post for an MCP tool response.
 
     Delegates to the same Pydantic schema the REST router returns so
     the two surfaces cannot drift in either field set or wire format.
+    ``internal_notes`` is redacted unless the caller may view it (see
+    ``_can_view_internal_notes``).
     """
-    return PostResponse.from_post(post).model_dump(mode="json")
+    return PostResponse.from_post(post, include_internal_notes=_can_view_internal_notes(context)).model_dump(
+        mode="json"
+    )
 
 
 def _get_post_for_key(api_key, post_id_str: str) -> Post:
@@ -193,13 +209,14 @@ def _create_draft(args: dict, context: dict[str, Any]) -> dict:
             caption=args["caption"],
             title=args.get("title", ""),
             first_comment=args.get("first_comment", ""),
+            internal_notes=args.get("internal_notes", ""),
             media_asset_ids=args.get("media_asset_ids") or [],
             author=api_key.issued_by if api_key.issued_by_id else None,
             status="draft",
         )
     except ValueError as exc:
         raise JsonRpcError(INVALID_PARAMS, str(exc)) from exc
-    return _wrap_text(_serialize_post(post))
+    return _wrap_text(_serialize_post(post, context))
 
 
 register_tool(
@@ -223,6 +240,12 @@ register_tool(
                     "type": "string",
                     "default": "",
                     "description": "Optional comment auto-posted after the main post.",
+                },
+                "internal_notes": {
+                    "type": "string",
+                    "default": "",
+                    "maxLength": 10000,
+                    "description": "Private team-only note. Never published to any platform.",
                 },
                 "media_asset_ids": {
                     "type": "array",
@@ -277,6 +300,7 @@ def _schedule_post(args: dict, context: dict[str, Any]) -> dict:
             caption=args["caption"],
             title=args.get("title", ""),
             first_comment=args.get("first_comment", ""),
+            internal_notes=args.get("internal_notes", ""),
             media_asset_ids=args.get("media_asset_ids") or [],
             scheduled_at=scheduled_at,
             author=api_key.issued_by if api_key.issued_by_id else None,
@@ -284,7 +308,7 @@ def _schedule_post(args: dict, context: dict[str, Any]) -> dict:
         )
     except ValueError as exc:
         raise JsonRpcError(INVALID_PARAMS, str(exc)) from exc
-    return _wrap_text(_serialize_post(post))
+    return _wrap_text(_serialize_post(post, context))
 
 
 register_tool(
@@ -305,6 +329,12 @@ register_tool(
                 },
                 "title": {"type": "string", "default": "", "maxLength": 255},
                 "first_comment": {"type": "string", "default": ""},
+                "internal_notes": {
+                    "type": "string",
+                    "default": "",
+                    "maxLength": 10000,
+                    "description": "Private team-only note. Never published to any platform.",
+                },
                 "media_asset_ids": {
                     "type": "array",
                     "items": {"type": "string", "format": "uuid"},
@@ -329,7 +359,7 @@ def _get_post(args: dict, context: dict[str, Any]) -> dict:
         raise JsonRpcError(INVALID_PARAMS, "post_id is required")
     api_key = context["api_key"]
     post = _get_post_for_key(api_key, args["post_id"])
-    return _wrap_text(_serialize_post(post))
+    return _wrap_text(_serialize_post(post, context))
 
 
 register_tool(
@@ -381,7 +411,7 @@ def _cancel_post(args: dict, context: dict[str, Any]) -> dict:
             except ValueError as exc:
                 raise JsonRpcError(INVALID_PARAMS, str(exc)) from exc
     post.refresh_from_db()
-    return _wrap_text(_serialize_post(post))
+    return _wrap_text(_serialize_post(post, context))
 
 
 register_tool(
@@ -458,7 +488,7 @@ def _schedule_draft(args: dict, context: dict[str, Any]) -> dict:
             except ValueError as exc:
                 raise JsonRpcError(INVALID_PARAMS, str(exc)) from exc
     post.refresh_from_db()
-    return _wrap_text(_serialize_post(post))
+    return _wrap_text(_serialize_post(post, context))
 
 
 register_tool(

--- a/apps/mcp/tests/test_oauth_auth.py
+++ b/apps/mcp/tests/test_oauth_auth.py
@@ -264,3 +264,38 @@ class TestOAuthShimCoversToolSurface:
         assert status == 200
         assert body["error"]["code"] == INVALID_PARAMS
         assert "not found" in body["error"]["message"].lower()
+
+
+@pytest.mark.django_db
+class TestOAuthInternalNotesVisibility:
+    """``internal_notes`` is team-only. ``get_post`` isn't permission-gated, so
+    the shared ``PostResponse`` serializer must redact the field for
+    client/viewer-role OAuth callers (whom the composer also blocks from seeing
+    internal notes) while internal roles keep seeing it.
+    """
+
+    def _post_with_note(self, ws, user, sa, note="board-only context"):
+        from apps.composer.models import PlatformPost, Post
+
+        post = Post.objects.create(workspace=ws, author=user, caption="public", internal_notes=note)
+        PlatformPost.objects.create(post=post, social_account=sa, status="draft")
+        return post
+
+    def test_viewer_get_post_redacts_internal_notes(self):
+        user, ws, sa = _make_user_with_workspace("viewer-notes@example.com", WorkspaceMembership.WorkspaceRole.VIEWER)
+        post = self._post_with_note(ws, user, sa)
+        c = _SecureClient(HTTP_AUTHORIZATION=f"Bearer {_mint_oauth_token(user)}")
+        status, body = _post(c, _rpc("tools/call", {"name": "get_post", "arguments": {"post_id": str(post.id)}}))
+        assert status == 200
+        payload = json.loads(body["result"]["content"][0]["text"])
+        assert payload["internal_notes"] == ""  # redacted for a viewer
+        assert payload["caption"] == "public"  # other fields intact
+
+    def test_owner_get_post_includes_internal_notes(self):
+        user, ws, sa = _make_user_with_workspace("owner-notes@example.com", WorkspaceMembership.WorkspaceRole.OWNER)
+        post = self._post_with_note(ws, user, sa)
+        c = _SecureClient(HTTP_AUTHORIZATION=f"Bearer {_mint_oauth_token(user)}")
+        status, body = _post(c, _rpc("tools/call", {"name": "get_post", "arguments": {"post_id": str(post.id)}}))
+        assert status == 200
+        payload = json.loads(body["result"]["content"][0]["text"])
+        assert payload["internal_notes"] == "board-only context"

--- a/apps/mcp/tests/test_rest_parity.py
+++ b/apps/mcp/tests/test_rest_parity.py
@@ -120,6 +120,7 @@ def scheduled_post(db, user, workspace, social_account):
         title="Parity title",
         caption="Parity caption",
         first_comment="Parity first comment",
+        internal_notes="Parity internal note",
         scheduled_at=when,
     )
     PlatformPost.objects.create(
@@ -178,6 +179,40 @@ class TestRestMcpPostParity:
         assert "created_at" in body
         assert "updated_at" in body
         assert body["platform_posts"][0]["platform_post_id"] == "upstream-abc-123"
+
+    def test_internal_notes_round_trips_through_mcp_create_draft(self, client_with_token, social_account):
+        """internal_notes set via MCP ``create_draft`` must come back on the MCP
+        response *and* match what REST returns for the same post — proving the
+        field threads through the shared ``create_post`` service and
+        ``PostResponse`` rather than a surface-specific code path.
+        """
+        note = "Cleared with the client on the 2pm call."
+        mcp = client_with_token.post(
+            MCP_URL,
+            data=json.dumps(
+                _rpc(
+                    "tools/call",
+                    {
+                        "name": "create_draft",
+                        "arguments": {
+                            "social_account_id": str(social_account.id),
+                            "caption": "draft with a note",
+                            "internal_notes": note,
+                        },
+                    },
+                )
+            ),
+            content_type="application/json",
+        )
+        assert mcp.status_code == 200
+        envelope = mcp.json()
+        assert "error" not in envelope, envelope
+        mcp_body = json.loads(envelope["result"]["content"][0]["text"])
+        assert mcp_body["internal_notes"] == note
+
+        rest = client_with_token.get(f"/api/v1/posts/{mcp_body['id']}")
+        assert rest.status_code == 200, rest.content
+        assert rest.json()["internal_notes"] == note
 
     def test_mcp_scheduled_at_uses_z_suffix_for_utc(self, client_with_token, scheduled_post):
         """Gap 5: MCP used to emit ``+00:00``; both surfaces now emit ``Z``."""


### PR DESCRIPTION
## What does this PR do?

Surfaces the team-only `internal_notes` field on the Agent REST API and the MCP tools, reusing existing endpoints/tools rather than adding new ones. The field already exists on the `Post` model (and is edited in the composer), so **there is no migration**.

- Threads `internal_notes` through the shared `create_post()` service (`apps/composer/services.py`).
- **REST**: settable on `POST /api/v1/posts/` and `PATCH /api/v1/posts/{id}`; returned on `PostResponse`.
- **MCP**: settable on `create_draft` and `schedule_post`; returned by `get_post` (and the other post-returning tools) via the shared serializer.

## Why?

The team wanted to attach internal, team-only notes (never published to any platform) to posts from integrations/agents, not just the web composer.

It also closes a **privacy gap** caught in review: `internal_notes` is serialized through the shared `PostResponse`, which the read paths use, and reads aren't otherwise permission-gated. Visibility is therefore gated on the `create_posts` permission in the serializer (redacted to `""` otherwise) — the exact permission held by the workspace roles the composer lets view internal notes (i.e. not `client`/`viewer`). Without this, a read-capable `client`/`viewer` OAuth caller could read team notes via `GET /posts/{id}` or MCP `get_post`. `from_post()` defaults to redacted so any new call site fails closed.

Writes need no extra gate — `create`/`update` already require `create_posts`.

## How to test

- `pytest apps/api/tests apps/mcp/tests` → **194 passed**, including new internal_notes visibility tests (REST + OAuth), the REST↔MCP parity test, and the OAuth all-tools guard.
- **Manual REST**: `POST /api/v1/posts/` with `internal_notes` set, then `GET /api/v1/posts/{id}` — a `create_posts`-capable key sees the note; a read-only key gets `internal_notes: ""`.
- **Manual MCP**: call `create_draft` with `internal_notes`, then `get_post` — an internal-role caller sees it; a `viewer`-role OAuth caller gets `""`.
- OpenAPI (`/api/v1/docs`) shows `internal_notes` on `CreatePostRequest`, `UpdatePostRequest`, and `PostResponse`.

## Checklist

- [x] Tests pass (`pytest`) — 194 passed across `apps/api` + `apps/mcp`
- [x] Lint passes (`ruff check .` and `ruff format --check .`)
- [x] Documentation updated (if applicable) — N/A; the OpenAPI docs are auto-generated from the schemas, and field-level descriptions are included
