### PR TITLE
fix: honor workspace timezone for calendar slot/CTA links and gate slots precisely

### DIFF
--- a/apps/calendar/tests.py
+++ b/apps/calendar/tests.py
@@ -345,8 +345,9 @@ class CalendarChannelSlotViewTests(TestCase):
         context = {"display_timezone": "America/New_York"}
         _day_view_data(self.factory.get("/"), self.workspace, target, context)
 
-        hour_posts = dict((hour, posts) for hour, posts, _slots in context["day_slots"])[9]
-        slot_items = dict((hour, slots) for hour, _posts, slots in context["day_slots"])[9]
+        cells = {cell["hour"]: cell for cell in context["day_slots"]}
+        hour_posts = cells[9]["posts"]
+        slot_items = cells[9]["slots"]
         self.assertEqual(slot_items, [])
         self.assertEqual(len(hour_posts), 1)
         self.assertTrue(hour_posts[0].takes_calendar_slot)
@@ -360,7 +361,8 @@ class CalendarChannelSlotViewTests(TestCase):
         context = {"display_timezone": "America/New_York"}
         _day_view_data(request, self.workspace, target, context)
 
-        slot_items = dict((hour, slots) for hour, _posts, slots in context["day_slots"])[9]
+        cells = {cell["hour"]: cell for cell in context["day_slots"]}
+        slot_items = cells[9]["slots"]
         self.assertEqual([slot["account"] for slot in slot_items], [self.account])
 
     def test_day_view_ignores_malformed_channel_filter(self):
@@ -371,7 +373,8 @@ class CalendarChannelSlotViewTests(TestCase):
         context = {"display_timezone": "America/New_York"}
         _day_view_data(request, self.workspace, target, context)
 
-        slot_items = dict((hour, slots) for hour, _posts, slots in context["day_slots"])[9]
+        cells = {cell["hour"]: cell for cell in context["day_slots"]}
+        slot_items = cells[9]["slots"]
         self.assertEqual([slot["account"] for slot in slot_items], [self.account])
 
     def test_day_view_includes_workspace_slot_from_adjacent_display_date(self):
@@ -392,8 +395,9 @@ class CalendarChannelSlotViewTests(TestCase):
         context = {"display_timezone": "Asia/Tokyo"}
         _day_view_data(self.factory.get("/"), self.workspace, target, context)
 
-        hour_posts = dict((hour, posts) for hour, posts, _slots in context["day_slots"])[1]
-        slot_items = dict((hour, slots) for hour, _posts, slots in context["day_slots"])[1]
+        cells = {cell["hour"]: cell for cell in context["day_slots"]}
+        hour_posts = cells[1]["posts"]
+        slot_items = cells[1]["slots"]
         self.assertEqual(slot_items, [])
         self.assertEqual(len(hour_posts), 1)
         self.assertTrue(hour_posts[0].takes_calendar_slot)

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -220,7 +220,10 @@ def _get_calendar_slot_occurrences(workspace, request, display_tz, visible_dates
     """
     import zoneinfo
 
+    from django.utils import timezone
+
     workspace_tz = zoneinfo.ZoneInfo(workspace.effective_timezone or "UTC")
+    now = timezone.now()
     visible_dates = set(visible_dates)
     if not visible_dates:
         return defaultdict(list)
@@ -271,6 +274,11 @@ def _get_calendar_slot_occurrences(workspace, request, display_tz, visible_dates
                         "time_label": local_dt.strftime("%H:%M"),
                         "compose_date": workspace_dt.strftime("%Y-%m-%d"),
                         "compose_time": workspace_dt.strftime("%H:%M"),
+                        # Precise per-occurrence gate: a slot earlier in the
+                        # current hour is already past, so the template must show
+                        # "Open" (faded) rather than an actionable "+" that the
+                        # composer would then reject as a past schedule time.
+                        "is_past": workspace_dt <= now,
                     },
                 )
             )
@@ -292,6 +300,21 @@ def _get_calendar_slot_occurrences(workspace, request, display_tz, visible_dates
         slots_by_hour[(slot["date"], slot["hour"])].append(slot)
 
     return slots_by_hour
+
+
+def _cell_compose_params(display_date, hour, display_tz, workspace_tz):
+    """Workspace-tz wall-clock (date, time) strings for a display-tz grid cell.
+
+    The composer reads ``?scheduled_date``/``?scheduled_time`` in the *workspace*
+    timezone (see ``apps.composer.views.save_post``), so a calendar "+" must hand
+    it the workspace-tz wall time of the instant the cell represents. Passing the
+    raw display-tz hour would schedule at the wrong moment whenever the active
+    display timezone differs from the workspace timezone. (Channel-slot "+" links
+    already do this via the slot's ``compose_date``/``compose_time``.)
+    """
+    cell_dt = datetime.combine(display_date, time(hour), tzinfo=display_tz)
+    workspace_dt = cell_dt.astimezone(workspace_tz)
+    return workspace_dt.strftime("%Y-%m-%d"), workspace_dt.strftime("%H:%M")
 
 
 def _get_publish_context(workspace, request):
@@ -748,14 +771,26 @@ def _week_view_data(request, workspace, target_date, context):
     hours = list(range(0, 24))
 
     # Build a grid structure the template can iterate:
-    # week_slots = [(hour, [(day, posts, slots), ...]), ...]
+    # week_slots = [(hour, [cell, ...]), ...] where each cell is a dict with
+    # day/posts/slots plus the workspace-tz compose_date/compose_time used by the
+    # "Create post" CTA (so it schedules correctly under a non-workspace display tz).
+    workspace_tz = zoneinfo.ZoneInfo(workspace.effective_timezone or "UTC")
     week_slots = []
     for hour in hours:
-        day_slots = []
+        day_cells = []
         for day in week_days:
             key = (day, hour)
-            day_slots.append((day, posts_by_slot.get(key, []), slots_by_hour.get(key, [])))
-        week_slots.append((hour, day_slots))
+            compose_date, compose_time = _cell_compose_params(day, hour, display_tz, workspace_tz)
+            day_cells.append(
+                {
+                    "day": day,
+                    "posts": posts_by_slot.get(key, []),
+                    "slots": slots_by_hour.get(key, []),
+                    "compose_date": compose_date,
+                    "compose_time": compose_time,
+                }
+            )
+        week_slots.append((hour, day_cells))
 
     from django.utils import timezone as _tz
 
@@ -808,8 +843,22 @@ def _day_view_data(request, workspace, target_date, context):
     slots_by_hour = _get_calendar_slot_occurrences(workspace, request, display_tz, [target_date], platform_posts)
     hours = list(range(0, 24))
 
-    # Build a list of (hour, posts, slots) tuples for easy template iteration
-    day_slots = [(hour, posts_by_hour.get(hour, []), slots_by_hour.get((target_date, hour), [])) for hour in hours]
+    # One cell per hour. ``compose_date``/``compose_time`` are the workspace-tz
+    # wall time of the cell so the "Create post" CTA schedules at the right
+    # instant even when the display timezone differs from the workspace one.
+    workspace_tz = zoneinfo.ZoneInfo(workspace.effective_timezone or "UTC")
+    day_slots = []
+    for hour in hours:
+        compose_date, compose_time = _cell_compose_params(target_date, hour, display_tz, workspace_tz)
+        day_slots.append(
+            {
+                "hour": hour,
+                "posts": posts_by_hour.get(hour, []),
+                "slots": slots_by_hour.get((target_date, hour), []),
+                "compose_date": compose_date,
+                "compose_time": compose_time,
+            }
+        )
 
     from django.utils import timezone as _tz
 

--- a/templates/calendar/calendar.html
+++ b/templates/calendar/calendar.html
@@ -363,7 +363,7 @@ function calendarApp() {
             event.dataTransfer.dropEffect = 'move';
         },
 
-        dropOnSlot(event, dateStr, hour) {
+        dropOnSlot(event, dateStr, timeStr) {
             event.preventDefault();
             const platformPostId = this.draggedPlatformPostId;
             if (!platformPostId) return;
@@ -384,7 +384,11 @@ function calendarApp() {
             }
             this.draggedPlatformPostId = null;
 
-            const newDatetime = dateStr + 'T' + String(hour).padStart(2, '0') + ':00:00';
+            // dateStr/timeStr are the target cell's workspace-tz wall date/time
+            // (see _cell_compose_params); reschedule_post interprets the naive
+            // value in the workspace timezone, so the drop lands on the right
+            // instant even when the calendar display timezone differs from it.
+            const newDatetime = dateStr + 'T' + timeStr + ':00';
 
             const csrfToken =
                 (document.querySelector('[name=csrfmiddlewaretoken]') || {}).value ||

--- a/templates/calendar/partials/day_grid.html
+++ b/templates/calendar/partials/day_grid.html
@@ -7,7 +7,7 @@ Context: day_slots, target_date, workspace.
 {% for cell in day_slots %}
     <div class="flex border-b border-stone-100 min-h-[64px] cal-add-cell {% if cell.posts or cell.slots %}has-posts{% endif %} {% if is_today and cell.hour == current_hour %}bg-orange-50/50{% endif %}"
          @dragover.prevent="allowDrop($event)"
-         @drop="dropOnSlot($event, '{{ target_date|date:'Y-m-d' }}', {{ cell.hour }})">
+         @drop="dropOnSlot($event, '{{ cell.compose_date }}', '{{ cell.compose_time }}')">
         <!-- Time label -->
         <div class="w-20 flex-shrink-0 border-r border-stone-200 px-3 py-2 text-right">
             <span class="text-xs font-medium tabular-nums {% if is_today and cell.hour == current_hour %}text-orange-600 font-semibold{% else %}text-stone-400{% endif %}">

--- a/templates/calendar/partials/day_grid.html
+++ b/templates/calendar/partials/day_grid.html
@@ -4,33 +4,33 @@ Context: day_slots, target_date, workspace.
 {% endcomment %}
 
 <div class="bg-white mx-auto" style="animation: slideUp 200ms cubic-bezier(0.16,1,0.3,1) both; max-height: calc(100vh - 200px); overflow-y: auto;">
-{% for hour, hour_posts, slot_items in day_slots %}
-    <div class="flex border-b border-stone-100 min-h-[64px] cal-add-cell {% if hour_posts or slot_items %}has-posts{% endif %} {% if is_today and hour == current_hour %}bg-orange-50/50{% endif %}"
+{% for cell in day_slots %}
+    <div class="flex border-b border-stone-100 min-h-[64px] cal-add-cell {% if cell.posts or cell.slots %}has-posts{% endif %} {% if is_today and cell.hour == current_hour %}bg-orange-50/50{% endif %}"
          @dragover.prevent="allowDrop($event)"
-         @drop="dropOnSlot($event, '{{ target_date|date:'Y-m-d' }}', {{ hour }})">
+         @drop="dropOnSlot($event, '{{ target_date|date:'Y-m-d' }}', {{ cell.hour }})">
         <!-- Time label -->
         <div class="w-20 flex-shrink-0 border-r border-stone-200 px-3 py-2 text-right">
-            <span class="text-xs font-medium tabular-nums {% if is_today and hour == current_hour %}text-orange-600 font-semibold{% else %}text-stone-400{% endif %}">
-                {% if hour < 10 %}0{% endif %}{{ hour }}:00
+            <span class="text-xs font-medium tabular-nums {% if is_today and cell.hour == current_hour %}text-orange-600 font-semibold{% else %}text-stone-400{% endif %}">
+                {% if cell.hour < 10 %}0{% endif %}{{ cell.hour }}:00
             </span>
         </div>
         <!-- Slots and posts in this hour -->
         <div class="flex-1 p-2 flex flex-col justify-center gap-1">
-            {% if not is_past_day and not is_today or not is_past_day and hour >= current_hour %}
-            <a href="{% url 'composer:compose' workspace_id=workspace.id %}?scheduled_date={{ target_date|date:'Y-m-d' }}&scheduled_time={{ hour }}:00" class="cal-add-btn cal-add-btn--inline" style="position:static; margin:0 auto;" title="Create post">
+            {% if not is_past_day and not is_today or not is_past_day and cell.hour >= current_hour %}
+            <a href="{% url 'composer:compose' workspace_id=workspace.id %}?scheduled_date={{ cell.compose_date }}&scheduled_time={{ cell.compose_time }}" class="cal-add-btn cal-add-btn--inline" style="position:static; margin:0 auto;" title="Create post">
                 <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
             </a>
             {% endif %}
-            {% if slot_items %}
+            {% if cell.slots %}
             <div class="flex flex-wrap gap-1.5">
-                {% for slot in slot_items %}
-                <div class="calendar-channel-slot {% if is_past_day or is_today and hour < current_hour %}is-past-open{% endif %}">
+                {% for slot in cell.slots %}
+                <div class="calendar-channel-slot {% if slot.is_past %}is-past-open{% endif %}">
                     <span class="calendar-slot-platform-icon">
                         {% include "social_accounts/partials/_platform_icon.html" with platform=slot.account.platform size="3" %}
                     </span>
                     <span class="truncate">{{ slot.account.account_name|default:slot.account.account_handle }}</span>
                     <span class="tabular-nums text-stone-500">{{ slot.time_label }}</span>
-                    {% if not is_past_day and not is_today or not is_past_day and hour >= current_hour %}
+                    {% if not slot.is_past %}
                     <a href="{% url 'composer:compose' workspace_id=workspace.id %}?account={{ slot.account.id }}&scheduled_date={{ slot.compose_date }}&scheduled_time={{ slot.compose_time }}"
                        class="calendar-slot-add"
                        title="Schedule post for {{ slot.account.account_name|default:slot.account.account_handle }} at {{ slot.time_label }}">
@@ -43,7 +43,7 @@ Context: day_slots, target_date, workspace.
                 {% endfor %}
             </div>
             {% endif %}
-            {% for pp in hour_posts %}
+            {% for pp in cell.posts %}
             <a href="{% url 'composer:compose_edit' workspace_id=workspace.id post_id=pp.post_id %}?account={{ pp.social_account_id }}"
                class="post-chip status-{{ pp.status }}"
                {% if pp.status == "draft" or pp.status == "approved" or pp.status == "scheduled" %}draggable="true"

--- a/templates/calendar/partials/month_grid.html
+++ b/templates/calendar/partials/month_grid.html
@@ -21,7 +21,7 @@ Enhanced with: holidays, custom events, category colors, recurring badges.
         {% for day in week %}
         <div class="cal-day cal-add-cell {% if day.posts %}has-posts{% endif %} {% if day.is_today %}today{% elif day.is_past %}past{% endif %} {% if not day.is_current_month %}other-month{% endif %}"
              @dragover.prevent="allowDrop($event)"
-             @drop="dropOnSlot($event, '{{ day.date|date:'Y-m-d' }}', 9)">
+             @drop="dropOnSlot($event, '{{ day.date|date:'Y-m-d' }}', '09:00')">
             {% if not day.is_past %}
             <a href="{% url 'composer:compose' workspace_id=workspace.id %}?scheduled_date={{ day.date|date:'Y-m-d' }}" class="cal-add-btn" title="Create post">
                 <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>

--- a/templates/calendar/partials/week_grid.html
+++ b/templates/calendar/partials/week_grid.html
@@ -24,7 +24,7 @@ Context: week_days, week_slots, workspace.
         {% for cell in day_cells %}
         <div class="border-r border-stone-100 last:border-r-0 p-1 cal-add-cell {% if cell.posts or cell.slots %}has-posts{% endif %} {% if cell.day == today %}bg-orange-50/30{% endif %}"
              @dragover.prevent="allowDrop($event)"
-             @drop="dropOnSlot($event, '{{ cell.day|date:'Y-m-d' }}', {{ hour }})">
+             @drop="dropOnSlot($event, '{{ cell.compose_date }}', '{{ cell.compose_time }}')">
             {% if cell.day > today or cell.day == today and hour >= current_hour %}
             <a href="{% url 'composer:compose' workspace_id=workspace.id %}?scheduled_date={{ cell.compose_date }}&scheduled_time={{ cell.compose_time }}" class="cal-add-btn" title="Create post">
                 <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>

--- a/templates/calendar/partials/week_grid.html
+++ b/templates/calendar/partials/week_grid.html
@@ -16,30 +16,30 @@ Context: week_days, week_slots, workspace.
     </div>
 
     <!-- Hour rows -->
-    {% for hour, day_slots in week_slots %}
+    {% for hour, day_cells in week_slots %}
     <div class="grid grid-cols-[72px_repeat(7,minmax(0,1fr))] border-b border-stone-100 min-h-[56px]">
         <div class="border-r border-stone-200 px-2 py-1 text-right">
             <span class="text-[11px] font-medium text-stone-400 tabular-nums">{{ hour }}:00</span>
         </div>
-        {% for day, slot_posts, slot_items in day_slots %}
-        <div class="border-r border-stone-100 last:border-r-0 p-1 cal-add-cell {% if slot_posts or slot_items %}has-posts{% endif %} {% if day == today %}bg-orange-50/30{% endif %}"
+        {% for cell in day_cells %}
+        <div class="border-r border-stone-100 last:border-r-0 p-1 cal-add-cell {% if cell.posts or cell.slots %}has-posts{% endif %} {% if cell.day == today %}bg-orange-50/30{% endif %}"
              @dragover.prevent="allowDrop($event)"
-             @drop="dropOnSlot($event, '{{ day|date:'Y-m-d' }}', {{ hour }})">
-            {% if day > today or day == today and hour >= current_hour %}
-            <a href="{% url 'composer:compose' workspace_id=workspace.id %}?scheduled_date={{ day|date:'Y-m-d' }}&scheduled_time={{ hour }}:00" class="cal-add-btn" title="Create post">
+             @drop="dropOnSlot($event, '{{ cell.day|date:'Y-m-d' }}', {{ hour }})">
+            {% if cell.day > today or cell.day == today and hour >= current_hour %}
+            <a href="{% url 'composer:compose' workspace_id=workspace.id %}?scheduled_date={{ cell.compose_date }}&scheduled_time={{ cell.compose_time }}" class="cal-add-btn" title="Create post">
                 <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
             </a>
             {% endif %}
-            {% if slot_items %}
+            {% if cell.slots %}
             <div class="flex flex-col gap-1 mb-1">
-                {% for slot in slot_items %}
-                <div class="calendar-channel-slot calendar-channel-slot--week {% if day < today or day == today and hour < current_hour %}is-past-open{% endif %}">
+                {% for slot in cell.slots %}
+                <div class="calendar-channel-slot calendar-channel-slot--week {% if slot.is_past %}is-past-open{% endif %}">
                     <span class="calendar-slot-platform-icon">
                         {% include "social_accounts/partials/_platform_icon.html" with platform=slot.account.platform size="3" %}
                     </span>
                     <span class="truncate">{{ slot.account.account_name|default:slot.account.account_handle }}</span>
                     <span class="tabular-nums text-stone-500">{{ slot.time_label }}</span>
-                    {% if day > today or day == today and hour >= current_hour %}
+                    {% if not slot.is_past %}
                     <a href="{% url 'composer:compose' workspace_id=workspace.id %}?account={{ slot.account.id }}&scheduled_date={{ slot.compose_date }}&scheduled_time={{ slot.compose_time }}"
                        class="calendar-slot-add"
                        title="Schedule post for {{ slot.account.account_name|default:slot.account.account_handle }} at {{ slot.time_label }}">
@@ -52,7 +52,7 @@ Context: week_days, week_slots, workspace.
                 {% endfor %}
             </div>
             {% endif %}
-            {% for pp in slot_posts %}
+            {% for pp in cell.posts %}
             <a href="{% url 'composer:compose_edit' workspace_id=workspace.id post_id=pp.post_id %}?account={{ pp.social_account_id }}"
                class="post-chip status-{{ pp.status }}"
                {% if pp.status == "draft" or pp.status == "approved" or pp.status == "scheduled" %}draggable="true"


### PR DESCRIPTION
## What

Follow-up correctness fixes for the channel posting slots added in #80.

### 1. Calendar "+" CTAs now schedule at the correct instant under any display timezone
The generic hourly "Create post" buttons in the day/week grids encoded the **display-tz** hour, but the composer interprets `scheduled_time` in the **workspace** timezone (`apps/composer/views.py` `save_post`). So when the calendar's display timezone differed from the workspace timezone, the plain "+" scheduled at the wrong moment (off by the tz offset). They now emit the workspace-tz wall time of the cell via a new `_cell_compose_params()` helper — matching what the channel-slot "+" links already did.

### 2. Channel-slot badges gate on a precise per-slot `is_past`
Slot "+"/"Open" state was gated by hour granularity (`hour >= current_hour`), so a slot earlier in the current hour (e.g. 14:00 at 14:30) still showed an actionable "+" that the composer then rejected as a past time. Each slot occurrence now carries `is_past` (slot instant vs `now`), and the day/week templates gate the fade + "+"/"Open" on it (which also removes the convoluted per-slot conditional).

## Verification
- `ruff check` / `ruff format --check`: pass
- `pytest apps/calendar/tests.py`: 21 passed
- Manual (workspace tz = Europe/Berlin):
  - With display = America/New_York, the generic "+" at the 15:00 NY cell links to `21:00` Berlin (and 18:00 NY → `00:00` Berlin next day) — previously it passed the raw `15:00`.
  - Once past 20:00 Berlin, the 20:00 slot correctly shows faded "Open" instead of an actionable "+".

Note: the generic-"+" timezone bug predates #80 — that PR's slot "+" already did the workspace-tz conversion correctly, which is what surfaced the inconsistency in the older generic button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
