### PR TITLE
fix(facebook): harden multi-photo publishing

### DIFF
--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -299,8 +299,7 @@ class FacebookProvider(SocialProvider):
         # orphaned unpublished photos behind for an obviously invalid request.
         if len(urls) > FACEBOOK_MAX_ATTACHED_MEDIA:
             raise PublishError(
-                f"Facebook multi-photo posts support at most {FACEBOOK_MAX_ATTACHED_MEDIA} photos "
-                f"(got {len(urls)})",
+                f"Facebook multi-photo posts support at most {FACEBOOK_MAX_ATTACHED_MEDIA} photos (got {len(urls)})",
                 platform=self.platform_name,
             )
         if any(self._is_video_url(url) for url in urls):

--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from urllib.parse import urlencode
+from urllib.parse import urlencode, urlparse
 
 from .base import SocialProvider
 from .exceptions import APIError, OAuthError, PublishError
@@ -29,6 +29,13 @@ logger = logging.getLogger(__name__)
 BASE_URL = "https://graph.facebook.com/v21.0"
 OAUTH_URL = "https://www.facebook.com/v21.0/dialog/oauth"
 TOKEN_URL = f"{BASE_URL}/oauth/access_token"
+
+# Facebook caps the ``attached_media`` array on a single feed post. Larger sets
+# must use the album-creation flow, which this provider does not implement.
+FACEBOOK_MAX_ATTACHED_MEDIA = 10
+# Extension heuristic for spotting video URLs, mirroring the per-item checks in
+# the Instagram / Threads carousel providers.
+VIDEO_URL_SUFFIXES = (".mp4", ".mov")
 
 
 class FacebookProvider(SocialProvider):
@@ -286,51 +293,91 @@ class FacebookProvider(SocialProvider):
         )
 
     def _publish_multi_photo(self, access_token: str, page_id: str, content: PublishContent) -> PublishResult:
-        photo_ids: list[str] = []
+        urls = content.media_urls
 
-        for url in content.media_urls:
-            resp = self._request(
-                "POST",
-                f"{BASE_URL}/{page_id}/photos",
-                access_token=access_token,
-                json={"url": url, "published": False},
+        # Pre-staging guards: fail before any network call so we never leave
+        # orphaned unpublished photos behind for an obviously invalid request.
+        if len(urls) > FACEBOOK_MAX_ATTACHED_MEDIA:
+            raise PublishError(
+                f"Facebook multi-photo posts support at most {FACEBOOK_MAX_ATTACHED_MEDIA} photos "
+                f"(got {len(urls)})",
+                platform=self.platform_name,
             )
-            data = resp.json()
-            photo_id = data.get("id")
-            if not photo_id:
+        if any(self._is_video_url(url) for url in urls):
+            raise PublishError(
+                "Facebook multi-photo posts support images only; post videos separately",
+                platform=self.platform_name,
+            )
+
+        photo_ids: list[str] = []
+        try:
+            for url in urls:
+                data = self._request(
+                    "POST",
+                    f"{BASE_URL}/{page_id}/photos",
+                    access_token=access_token,
+                    json={"url": url, "published": False},
+                ).json()
+                photo_id = data.get("id")
+                if not photo_id:
+                    raise PublishError(
+                        "Failed to stage Facebook photo for multi-photo post",
+                        platform=self.platform_name,
+                        raw_response=data,
+                    )
+                photo_ids.append(photo_id)
+
+            payload: dict = {
+                "attached_media": [{"media_fbid": photo_id} for photo_id in photo_ids],
+            }
+            if content.text:
+                payload["message"] = content.text
+
+            data = self._request(
+                "POST",
+                f"{BASE_URL}/{page_id}/feed",
+                access_token=access_token,
+                json=payload,
+            ).json()
+            post_id = data.get("id")
+            if not post_id:
                 raise PublishError(
-                    "Failed to stage Facebook photo for multi-photo post",
+                    "Failed to publish Facebook multi-photo post",
                     platform=self.platform_name,
                     raw_response=data,
                 )
-            photo_ids.append(photo_id)
-
-        payload: dict = {
-            "attached_media": [{"media_fbid": photo_id} for photo_id in photo_ids],
-        }
-        if content.text:
-            payload["message"] = content.text
-
-        resp = self._request(
-            "POST",
-            f"{BASE_URL}/{page_id}/feed",
-            access_token=access_token,
-            json=payload,
-        )
-        data = resp.json()
-        post_id = data.get("id")
-        if not post_id:
-            raise PublishError(
-                "Failed to publish Facebook multi-photo post",
-                platform=self.platform_name,
-                raw_response=data,
-            )
+        except Exception:
+            # Best-effort: remove any photos already staged as unpublished so a
+            # partial failure (or a retry by the publisher) doesn't accumulate
+            # orphaned media on the page.
+            self._delete_staged_photos(access_token, photo_ids)
+            raise
 
         return PublishResult(
             platform_post_id=post_id,
             url=f"https://www.facebook.com/{post_id}",
             extra={**data, "photo_ids": photo_ids},
         )
+
+    @staticmethod
+    def _is_video_url(url: str) -> bool:
+        """Heuristically detect a video URL by file extension.
+
+        Uses the URL path only so presigned query strings (R2/S3) don't defeat
+        the check.
+        """
+        return urlparse(url).path.lower().endswith(VIDEO_URL_SUFFIXES)
+
+    def _delete_staged_photos(self, access_token: str, photo_ids: list[str]) -> None:
+        """Best-effort cleanup of unpublished photos staged for a multi-photo post.
+
+        Swallows errors so cleanup never masks the original publish failure.
+        """
+        for photo_id in photo_ids:
+            try:
+                self._request("DELETE", f"{BASE_URL}/{photo_id}", access_token=access_token)
+            except Exception:
+                logger.warning("Failed to clean up staged Facebook photo %s", photo_id)
 
     def _publish_video(self, access_token: str, page_id: str, content: PublishContent) -> PublishResult:
         payload: dict = {"file_url": content.media_urls[0]}

--- a/tests/providers/test_facebook.py
+++ b/tests/providers/test_facebook.py
@@ -100,9 +100,7 @@ def test_publish_single_photo_uses_photos_edge_without_staging():
     """A single image must publish directly via /photos (no unpublished staging, no attached_media)."""
     provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
     provider._request = MagicMock(
-        return_value=MagicMock(
-            json=MagicMock(return_value={"id": "photo-1", "post_id": "page-1_post-1"})
-        )
+        return_value=MagicMock(json=MagicMock(return_value={"id": "photo-1", "post_id": "page-1_post-1"}))
     )
 
     result = provider.publish_post(
@@ -218,6 +216,4 @@ def test_publish_multi_photo_cleans_up_after_partial_staging_failure():
             ),
         )
 
-    provider._request.assert_any_call(
-        "DELETE", "https://graph.facebook.com/v21.0/photo-1", access_token="page-token"
-    )
+    provider._request.assert_any_call("DELETE", "https://graph.facebook.com/v21.0/photo-1", access_token="page-token")

--- a/tests/providers/test_facebook.py
+++ b/tests/providers/test_facebook.py
@@ -79,6 +79,9 @@ def test_publish_multi_photo_post_requires_feed_post_id():
             MagicMock(json=MagicMock(return_value={"id": "photo-1"})),
             MagicMock(json=MagicMock(return_value={"id": "photo-2"})),
             MagicMock(json=MagicMock(return_value={"success": True})),
+            # best-effort cleanup of the two staged photos after the feed call fails
+            MagicMock(json=MagicMock(return_value={})),
+            MagicMock(json=MagicMock(return_value={})),
         ]
     )
 
@@ -91,3 +94,130 @@ def test_publish_multi_photo_post_requires_feed_post_id():
                 extra={"page_id": "page-1"},
             ),
         )
+
+
+def test_publish_single_photo_uses_photos_edge_without_staging():
+    """A single image must publish directly via /photos (no unpublished staging, no attached_media)."""
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        return_value=MagicMock(
+            json=MagicMock(return_value={"id": "photo-1", "post_id": "page-1_post-1"})
+        )
+    )
+
+    result = provider.publish_post(
+        "page-token",
+        PublishContent(
+            text="Single image caption",
+            media_urls=["https://cdn.example.com/one.jpg"],
+            post_type=PostType.IMAGE,
+            extra={"page_id": "page-1"},
+        ),
+    )
+
+    assert result.platform_post_id == "photo-1"
+    assert result.url == "https://www.facebook.com/page-1_post-1"
+    provider._request.assert_called_once_with(
+        "POST",
+        "https://graph.facebook.com/v21.0/page-1/photos",
+        access_token="page-token",
+        json={"url": "https://cdn.example.com/one.jpg", "message": "Single image caption"},
+    )
+    sent = provider._request.call_args.kwargs["json"]
+    assert "published" not in sent
+    assert "attached_media" not in sent
+
+
+def test_is_video_url_ignores_query_string():
+    """Presigned URLs carry query strings; the check must look at the path only."""
+    assert FacebookProvider._is_video_url("https://cdn.example.com/clip.mp4?X-Amz-Sig=abc&x=1") is True
+    assert FacebookProvider._is_video_url("https://cdn.example.com/clip.MOV") is True
+    assert FacebookProvider._is_video_url("https://cdn.example.com/pic.jpg?X-Amz-Sig=abc") is False
+
+
+def test_publish_multi_photo_rejects_video_media():
+    """Mixed image+video must fail with a clear error before any photo is staged."""
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock()
+
+    with pytest.raises(PublishError, match="images only"):
+        provider.publish_post(
+            "page-token",
+            PublishContent(
+                media_urls=["https://cdn.example.com/one.jpg", "https://cdn.example.com/clip.mp4"],
+                post_type=PostType.IMAGE,
+                extra={"page_id": "page-1"},
+            ),
+        )
+    provider._request.assert_not_called()
+
+
+def test_publish_multi_photo_rejects_too_many_photos():
+    """Over Facebook's attached_media cap must fail before any photo is staged."""
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock()
+
+    urls = [f"https://cdn.example.com/{i}.jpg" for i in range(11)]
+    with pytest.raises(PublishError, match="at most 10 photos"):
+        provider.publish_post(
+            "page-token",
+            PublishContent(media_urls=urls, post_type=PostType.IMAGE, extra={"page_id": "page-1"}),
+        )
+    provider._request.assert_not_called()
+
+
+def test_publish_multi_photo_cleans_up_staged_photos_on_feed_failure():
+    """If the feed post fails, every already-staged photo is deleted (best effort)."""
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        side_effect=[
+            MagicMock(json=MagicMock(return_value={"id": "photo-1"})),
+            MagicMock(json=MagicMock(return_value={"id": "photo-2"})),
+            MagicMock(json=MagicMock(return_value={"success": True})),  # feed: no id
+            MagicMock(json=MagicMock(return_value={})),  # delete photo-1
+            MagicMock(json=MagicMock(return_value={})),  # delete photo-2
+        ]
+    )
+
+    with pytest.raises(PublishError, match="Failed to publish Facebook multi-photo post"):
+        provider.publish_post(
+            "page-token",
+            PublishContent(
+                media_urls=["https://cdn.example.com/one.jpg", "https://cdn.example.com/two.jpg"],
+                post_type=PostType.IMAGE,
+                extra={"page_id": "page-1"},
+            ),
+        )
+
+    provider._request.assert_has_calls(
+        [
+            call("DELETE", "https://graph.facebook.com/v21.0/photo-1", access_token="page-token"),
+            call("DELETE", "https://graph.facebook.com/v21.0/photo-2", access_token="page-token"),
+        ]
+    )
+
+
+def test_publish_multi_photo_cleans_up_after_partial_staging_failure():
+    """If staging the second photo fails, the first (already staged) photo is deleted."""
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        side_effect=[
+            MagicMock(json=MagicMock(return_value={"id": "photo-1"})),
+            MagicMock(json=MagicMock(return_value={"success": True})),  # stage 2: no id
+            MagicMock(json=MagicMock(return_value={})),  # delete photo-1
+        ]
+    )
+
+    with pytest.raises(PublishError, match="Failed to stage Facebook photo"):
+        provider.publish_post(
+            "page-token",
+            PublishContent(
+                media_urls=["https://cdn.example.com/one.jpg", "https://cdn.example.com/two.jpg"],
+                post_type=PostType.IMAGE,
+                extra={"page_id": "page-1"},
+            ),
+        )
+
+    provider._request.assert_any_call(
+        "DELETE", "https://graph.facebook.com/v21.0/photo-1", access_token="page-token"
+    )


### PR DESCRIPTION
## What Changed

Follow-up hardening to #83 (Facebook multi-photo publishing). The merged implementation is correct for the happy path; this makes `_publish_multi_photo` defensive about edge cases the original PR didn't cover.

- **Mixed-media guard** — reject a multi-photo post that contains a video URL *before* staging anything, with a clear error. Facebook's `/photos` edge can't stage video, so previously a post with `[image, video]` (which resolves to `PostType.IMAGE`) failed mid-flight with a cryptic Graph error and left orphaned photos. Detection mirrors the per-item extension checks already used in the Instagram / Threads carousel providers, but matches on the URL **path** so presigned R2/S3 query strings don't defeat it.
- **Photo-count guard** — reject more than `FACEBOOK_MAX_ATTACHED_MEDIA` (10, Facebook's per-feed-post `attached_media` cap) before any network call.
- **Orphan cleanup** — best-effort delete of any already-staged unpublished photos if staging or the `/feed` call fails. Without this, a partial failure (or a publisher retry) accumulates dangling `published:false` media on the Page. Cleanup swallows its own errors so it never masks the original publish failure.

Both guards run before any photo is staged, so an invalid request creates zero orphans.

## Why

Reviewing #83 surfaced three robustness gaps. The core mechanism (stage unpublished → `/feed` with `attached_media`, return the feed post id) was verified correct and is unchanged; this only adds input validation and failure cleanup.

## Tests

- Added a single-photo **regression** test (single image must still publish directly via `/photos`, with no `published:false` staging and no `attached_media`).
- Added tests for each new path: mixed-media rejection, count rejection, cleanup-on-feed-failure, cleanup-on-partial-staging-failure, and `_is_video_url` query-string handling.
- `.venv/bin/python -m pytest tests/providers -q` → **151 passed**; `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)