### PR TITLE
fix: request Facebook first-comment publishing permission

### DIFF
--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -79,6 +79,7 @@ class FacebookProvider(SocialProvider):
         scopes = [
             "business_management",
             "pages_show_list",
+            "pages_manage_engagement",
             "pages_manage_posts",
             "pages_read_engagement",
             "pages_read_user_content",

--- a/tests/providers/test_base.py
+++ b/tests/providers/test_base.py
@@ -149,3 +149,7 @@ class TestProviderMetadata:
     def test_facebook_auth_type_is_oauth2(self):
         p = get_provider("facebook")
         assert p.auth_type == AuthType.OAUTH2
+
+    def test_facebook_scopes_include_comment_permission(self):
+        p = get_provider("facebook")
+        assert "pages_manage_engagement" in p.required_scopes


### PR DESCRIPTION
## Summary

Adds the Facebook `pages_manage_engagement` OAuth scope so connected Facebook Pages can publish first comments after posting.

## Why

Facebook requires `pages_manage_engagement` for comment creation and engagement actions. Without this scope, first-comment publishing can fail even when regular page posting succeeds.

## Changes

- Adds `pages_manage_engagement` to Facebook provider required scopes
- Adds test coverage to ensure the comment permission remains included

## Validation

- Added provider scope test