### PR TITLE
[codex] fix Meta analytics metric mappings

### DIFF
--- a/apps/analytics/metrics.py
+++ b/apps/analytics/metrics.py
@@ -20,13 +20,20 @@ METRICS: dict[str, dict[str, str]] = {
     "shares": {"label": "Shares", "kind": "count"},
     "reposts": {"label": "Reposts", "kind": "count"},
     "saves": {"label": "Saves", "kind": "count"},
+    "interactions": {"label": "Interactions", "kind": "count"},
     "clicks": {"label": "Link clicks", "kind": "count"},
     "outbound": {"label": "Outbound clicks", "kind": "count"},
     "profile_visits": {"label": "Profile visits", "kind": "count"},
+    "profile_activity": {"label": "Profile activity", "kind": "count"},
     "follows": {"label": "New follows", "kind": "count"},
+    "post_follows": {"label": "Follows", "kind": "count"},
     "followers": {"label": "Followers", "kind": "count"},
     "subscribers": {"label": "Subscribers", "kind": "count"},
     "watch_time": {"label": "Watch time", "kind": "minutes"},
+    "avg_watch_time": {"label": "Avg watch time", "kind": "minutes"},
+    "skip_rate": {"label": "Skip rate", "kind": "percent"},
+    "facebook_views": {"label": "Facebook views", "kind": "count"},
+    "crossposted_views": {"label": "Crossposted views", "kind": "count"},
     "avg_view_pct": {"label": "Avg view %", "kind": "percent"},
     "engagement": {"label": "Engagement rate", "kind": "percent"},
 }
@@ -39,12 +46,54 @@ ACCOUNT_ONLY: set[str] = {"follows", "followers", "subscribers"}
 # Which metrics each platform's API reports (after the scope upgrades in the
 # plan are in place). Verified against each platform's published insights API.
 PLATFORM_METRICS: dict[str, list[str]] = {
-    # IG media insights: reach, views (replaced impressions Apr-2025), likes,
-    # comments, saved, shares, total_interactions; follower growth at account level.
-    "instagram": ["reach", "views", "likes", "comments", "saves", "shares", "follows", "engagement"],
-    "instagram_login": ["reach", "views", "likes", "comments", "saves", "shares", "follows", "engagement"],
-    # FB post insights: impressions, reach (unique), reactions, comments, shares, clicks.
-    "facebook": ["impressions", "reach", "reactions", "comments", "shares", "clicks", "follows", "engagement"],
+    # IG media insights: impressions/engagement were removed from the current
+    # media metric set. Use views + total_interactions and the newer Reels /
+    # crosspost metrics when the media type exposes them.
+    "instagram": [
+        "reach",
+        "views",
+        "facebook_views",
+        "crossposted_views",
+        "watch_time",
+        "avg_watch_time",
+        "skip_rate",
+        "likes",
+        "comments",
+        "saves",
+        "shares",
+        "reposts",
+        "interactions",
+        "clicks",
+        "profile_visits",
+        "profile_activity",
+        "post_follows",
+        "follows",
+        "engagement",
+    ],
+    "instagram_login": [
+        "reach",
+        "views",
+        "facebook_views",
+        "crossposted_views",
+        "watch_time",
+        "avg_watch_time",
+        "skip_rate",
+        "likes",
+        "comments",
+        "saves",
+        "shares",
+        "reposts",
+        "interactions",
+        "clicks",
+        "profile_visits",
+        "profile_activity",
+        "post_follows",
+        "follows",
+        "engagement",
+    ],
+    # FB post analytics now come from object summary fields because /insights
+    # is unavailable for some published object types and legacy metrics drift.
+    "facebook": ["impressions", "reach", "reactions", "comments", "shares", "follows", "engagement"],
     # LinkedIn share statistics: impressions, reactions, comments, reposts, clicks, engagement.
     "linkedin_company": ["impressions", "reactions", "comments", "reposts", "clicks", "follows", "engagement"],
     # LinkedIn Personal: only socialActions counts (no impressions/reach per API).
@@ -114,6 +163,7 @@ ENGAGEMENT_PARTS: list[str] = [
     "saves",
     "clicks",
     "outbound",
+    "post_follows",
 ]
 
 # Candidate denominators in priority order (first match wins). If none of

--- a/apps/analytics/tasks.py
+++ b/apps/analytics/tasks.py
@@ -122,6 +122,12 @@ _POST_FIELD_OVERRIDES: dict[str, dict[str, str]] = {
 # ``_GENERIC_POST_EXTRA_KEYS`` below; per-platform overrides handle the
 # vocabulary that providers actually use.
 _POST_EXTRA_OVERRIDES: dict[str, dict[str, str]] = {
+    "instagram": {
+        "follows": "post_follows",
+    },
+    "instagram_login": {
+        "follows": "post_follows",
+    },
     "pinterest": {
         # providers/pinterest.py:328 stores Pinterest's OUTBOUND_CLICK under
         # ``outbound_clicks`` in extra; the catalog metric key is ``outbound``.
@@ -134,8 +140,15 @@ _GENERIC_POST_EXTRA_KEYS = (
     "replies",
     "reposts",
     "outbound",
+    "profile_visits",
+    "profile_activity",
+    "post_follows",
     "watch_time",
+    "avg_watch_time",
+    "skip_rate",
     "avg_view_pct",
+    "facebook_views",
+    "crossposted_views",
 )
 
 
@@ -161,6 +174,7 @@ def _post_metrics_to_dict(metrics, platform: str) -> dict[str, float]:
         ("shares", "shares"),
         ("saves", "saves"),
         ("clicks", "clicks"),
+        ("engagements", "interactions"),
         ("video_views", "views"),
     )
     for src, default_key in base_map:

--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -414,62 +414,69 @@ class FacebookProvider(SocialProvider):
     # ------------------------------------------------------------------
 
     def get_post_metrics(self, access_token: str, post_id: str) -> PostMetrics:
-        metrics = [
-            "post_impressions",
-            "post_engaged_users",
-            "post_clicks",
-            "post_reactions_by_type_total",
-        ]
+        # The /insights edge is not available for every object we publish
+        # (notably single-photo posts), and Meta has removed several legacy
+        # post insight metrics. Engagement summary fields are available on
+        # feed posts, photos, and videos.
         resp = self._request(
             "GET",
-            f"{BASE_URL}/{post_id}/insights",
+            f"{BASE_URL}/{post_id}",
             access_token=access_token,
-            params={"metric": ",".join(metrics)},
+            params={"fields": "id,reactions.summary(total_count),comments.summary(true),shares"},
         )
         data = resp.json()
-        values: dict = {}
-        for entry in data.get("data", []):
-            name = entry.get("name", "")
-            val = entry.get("values", [{}])[0].get("value", 0)
-            values[name] = val
-
-        reactions = values.get("post_reactions_by_type_total", {})
-        total_likes = reactions.get("like", 0) + reactions.get("love", 0) if isinstance(reactions, dict) else 0
 
         return PostMetrics(
-            impressions=values.get("post_impressions", 0),
-            engagements=values.get("post_engaged_users", 0),
-            clicks=values.get("post_clicks", 0),
-            likes=total_likes,
-            extra={"raw_insights": values},
+            likes=data.get("reactions", {}).get("summary", {}).get("total_count", 0),
+            comments=data.get("comments", {}).get("summary", {}).get("total_count", 0),
+            shares=data.get("shares", {}).get("count", 0),
+            extra={"raw_data": data},
         )
 
     def get_account_metrics(self, access_token: str, date_range: tuple[datetime, datetime]) -> AccountMetrics:
         page_id = self.credentials.get("page_id", "me")
-        metrics = ["page_impressions", "page_engaged_users", "page_fans"]
-        resp = self._request(
-            "GET",
-            f"{BASE_URL}/{page_id}/insights",
-            access_token=access_token,
-            params={
-                "metric": ",".join(metrics),
-                "since": int(date_range[0].timestamp()),
-                "until": int(date_range[1].timestamp()),
-            },
-        )
-        data = resp.json()
         values: dict = {}
-        for entry in data.get("data", []):
-            name = entry.get("name", "")
-            val = entry.get("values", [{}])[0].get("value", 0)
-            values[name] = val
+        for metric in ("page_impressions", "page_impressions_unique", "page_post_engagements", "page_daily_follows"):
+            values.update(self._get_page_insight_metric(access_token, page_id, metric, date_range))
 
         return AccountMetrics(
             impressions=values.get("page_impressions", 0),
-            reach=values.get("page_engaged_users", 0),
-            followers=values.get("page_fans", 0),
+            reach=values.get("page_impressions_unique", 0),
+            followers_gained=values.get("page_daily_follows", 0),
             extra={"raw_insights": values},
         )
+
+    def _get_page_insight_metric(
+        self,
+        access_token: str,
+        page_id: str,
+        metric: str,
+        date_range: tuple[datetime, datetime],
+    ) -> dict:
+        try:
+            resp = self._request(
+                "GET",
+                f"{BASE_URL}/{page_id}/insights",
+                access_token=access_token,
+                params={
+                    "metric": metric,
+                    "period": "day",
+                    "since": int(date_range[0].timestamp()),
+                    "until": int(date_range[1].timestamp()),
+                },
+            )
+        except APIError as exc:
+            message = str(exc).lower()
+            if "valid insights metric" in message or "nonexisting field" in message:
+                logger.info("Skipping unavailable Facebook page insight metric %s", metric)
+                return {}
+            raise
+
+        values: dict = {}
+        for entry in resp.json().get("data", []):
+            name = entry.get("name", "")
+            values[name] = sum((point.get("value") or 0) for point in entry.get("values", []))
+        return values
 
     # ------------------------------------------------------------------
     # Inbox

--- a/providers/instagram.py
+++ b/providers/instagram.py
@@ -393,39 +393,65 @@ class InstagramProvider(SocialProvider):
     # ------------------------------------------------------------------
 
     def get_post_metrics(self, access_token: str, post_id: str) -> PostMetrics:
-        metrics = ["impressions", "reach", "engagement", "saved"]
-        resp = self._request(
-            "GET",
-            f"{BASE_URL}/{post_id}/insights",
-            access_token=access_token,
-            params={"metric": ",".join(metrics)},
-        )
-        data = resp.json()
         values: dict = {}
-        for entry in data.get("data", []):
-            name = entry.get("name", "")
-            val = entry.get("values", [{}])[0].get("value", 0)
-            values[name] = val
+        for metric in (
+            "reach",
+            "views",
+            "saved",
+            "likes",
+            "comments",
+            "shares",
+            "total_interactions",
+            "follows",
+            "profile_visits",
+            "profile_activity",
+            "ig_reels_video_view_total_time",
+            "ig_reels_avg_watch_time",
+            "reels_skip_rate",
+            "reposts",
+            "facebook_views",
+            "crossposted_views",
+            "total_views",
+            "total_likes",
+            "total_comments",
+            "link_clicks",
+        ):
+            values.update(self._get_media_insight_metric(access_token, post_id, metric))
 
         return PostMetrics(
-            impressions=values.get("impressions", 0),
             reach=values.get("reach", 0),
-            engagements=values.get("engagement", 0),
+            video_views=values.get("views", 0),
+            likes=values.get("likes", values.get("total_likes", 0)),
+            comments=values.get("comments", values.get("total_comments", 0)),
+            shares=values.get("shares", 0),
+            engagements=values.get("total_interactions", 0),
             saves=values.get("saved", 0),
-            extra={"raw_insights": values},
+            clicks=values.get("link_clicks", 0),
+            extra={
+                "follows": values.get("follows", 0),
+                "profile_visits": values.get("profile_visits", 0),
+                "profile_activity": values.get("profile_activity", 0),
+                "watch_time": values.get("ig_reels_video_view_total_time", 0) / 60000,
+                "avg_watch_time": values.get("ig_reels_avg_watch_time", 0) / 60000,
+                "skip_rate": values.get("reels_skip_rate", 0),
+                "reposts": values.get("reposts", 0),
+                "facebook_views": values.get("facebook_views", 0),
+                "crossposted_views": values.get("crossposted_views", 0),
+                "total_views": values.get("total_views", 0),
+                "raw_insights": values,
+            },
         )
 
     def get_account_metrics(self, access_token: str, date_range: tuple[datetime, datetime]) -> AccountMetrics:
         ig_user_id = self.credentials.get("ig_user_id", "me")
         since = int(date_range[0].timestamp())
         until = int(date_range[1].timestamp())
-        metrics = ["reach", "follower_count", "profile_views"]
         resp = self._request(
             "GET",
             f"{BASE_URL}/{ig_user_id}/insights",
             access_token=access_token,
             params={
-                "metric": ",".join(metrics),
+                "metric": "reach,follower_count",
                 "period": "day",
                 "since": since,
                 "until": until,
@@ -443,7 +469,7 @@ class InstagramProvider(SocialProvider):
             f"{BASE_URL}/{ig_user_id}/insights",
             access_token=access_token,
             params={
-                "metric": "views",
+                "metric": "views,profile_views",
                 "period": "day",
                 "metric_type": "total_value",
                 "since": since,
@@ -452,9 +478,9 @@ class InstagramProvider(SocialProvider):
         )
         views_data = views_resp.json()
         for entry in views_data.get("data", []):
-            if entry.get("name") == "views":
-                values["views"] = entry.get("total_value", {}).get("value", 0)
-                break
+            name = entry.get("name")
+            if name:
+                values[name] = entry.get("total_value", {}).get("value", 0)
 
         return AccountMetrics(
             reach=values.get("reach", 0),
@@ -465,6 +491,30 @@ class InstagramProvider(SocialProvider):
                 "raw_insights": values,
             },
         )
+
+    def _get_media_insight_metric(self, access_token: str, post_id: str, metric: str) -> dict:
+        try:
+            resp = self._request(
+                "GET",
+                f"{BASE_URL}/{post_id}/insights",
+                access_token=access_token,
+                params={"metric": metric},
+            )
+        except APIError as exc:
+            message = str(exc).lower()
+            if "must be one of" in message or "not supported" in message or "valid insights metric" in message:
+                logger.info("Skipping unavailable Instagram media insight metric %s", metric)
+                return {}
+            raise
+
+        values: dict = {}
+        for entry in resp.json().get("data", []):
+            name = entry.get("name", "")
+            value = entry.get("total_value", {}).get("value")
+            if value is None:
+                value = entry.get("values", [{}])[0].get("value", 0)
+            values[name] = value
+        return values
 
     # ------------------------------------------------------------------
     # Inbox

--- a/providers/instagram_login.py
+++ b/providers/instagram_login.py
@@ -396,38 +396,64 @@ class InstagramLoginProvider(SocialProvider):
     # ------------------------------------------------------------------
 
     def get_post_metrics(self, access_token: str, post_id: str) -> PostMetrics:
-        metrics = ["impressions", "reach", "engagement", "saved"]
-        resp = self._request(
-            "GET",
-            f"{API_BASE}/{post_id}/insights",
-            access_token=access_token,
-            params={"metric": ",".join(metrics)},
-        )
-        data = resp.json()
         values: dict = {}
-        for entry in data.get("data", []):
-            name = entry.get("name", "")
-            val = entry.get("values", [{}])[0].get("value", 0)
-            values[name] = val
+        for metric in (
+            "reach",
+            "views",
+            "saved",
+            "likes",
+            "comments",
+            "shares",
+            "total_interactions",
+            "follows",
+            "profile_visits",
+            "profile_activity",
+            "ig_reels_video_view_total_time",
+            "ig_reels_avg_watch_time",
+            "reels_skip_rate",
+            "reposts",
+            "facebook_views",
+            "crossposted_views",
+            "total_views",
+            "total_likes",
+            "total_comments",
+            "link_clicks",
+        ):
+            values.update(self._get_media_insight_metric(access_token, post_id, metric))
 
         return PostMetrics(
-            impressions=values.get("impressions", 0),
             reach=values.get("reach", 0),
-            engagements=values.get("engagement", 0),
+            video_views=values.get("views", 0),
+            likes=values.get("likes", values.get("total_likes", 0)),
+            comments=values.get("comments", values.get("total_comments", 0)),
+            shares=values.get("shares", 0),
+            engagements=values.get("total_interactions", 0),
             saves=values.get("saved", 0),
-            extra={"raw_insights": values},
+            clicks=values.get("link_clicks", 0),
+            extra={
+                "follows": values.get("follows", 0),
+                "profile_visits": values.get("profile_visits", 0),
+                "profile_activity": values.get("profile_activity", 0),
+                "watch_time": values.get("ig_reels_video_view_total_time", 0) / 60000,
+                "avg_watch_time": values.get("ig_reels_avg_watch_time", 0) / 60000,
+                "skip_rate": values.get("reels_skip_rate", 0),
+                "reposts": values.get("reposts", 0),
+                "facebook_views": values.get("facebook_views", 0),
+                "crossposted_views": values.get("crossposted_views", 0),
+                "total_views": values.get("total_views", 0),
+                "raw_insights": values,
+            },
         )
 
     def get_account_metrics(self, access_token: str, date_range: tuple[datetime, datetime]) -> AccountMetrics:
         since = int(date_range[0].timestamp())
         until = int(date_range[1].timestamp())
-        metrics = ["reach", "follower_count", "profile_views"]
         resp = self._request(
             "GET",
             f"{API_BASE}/me/insights",
             access_token=access_token,
             params={
-                "metric": ",".join(metrics),
+                "metric": "reach,follower_count",
                 "period": "day",
                 "since": since,
                 "until": until,
@@ -445,7 +471,7 @@ class InstagramLoginProvider(SocialProvider):
             f"{API_BASE}/me/insights",
             access_token=access_token,
             params={
-                "metric": "views",
+                "metric": "views,profile_views",
                 "period": "day",
                 "metric_type": "total_value",
                 "since": since,
@@ -454,9 +480,9 @@ class InstagramLoginProvider(SocialProvider):
         )
         views_data = views_resp.json()
         for entry in views_data.get("data", []):
-            if entry.get("name") == "views":
-                values["views"] = entry.get("total_value", {}).get("value", 0)
-                break
+            name = entry.get("name")
+            if name:
+                values[name] = entry.get("total_value", {}).get("value", 0)
 
         return AccountMetrics(
             reach=values.get("reach", 0),
@@ -467,6 +493,30 @@ class InstagramLoginProvider(SocialProvider):
                 "raw_insights": values,
             },
         )
+
+    def _get_media_insight_metric(self, access_token: str, post_id: str, metric: str) -> dict:
+        try:
+            resp = self._request(
+                "GET",
+                f"{API_BASE}/{post_id}/insights",
+                access_token=access_token,
+                params={"metric": metric},
+            )
+        except APIError as exc:
+            message = str(exc).lower()
+            if "must be one of" in message or "not supported" in message or "valid insights metric" in message:
+                logger.info("Skipping unavailable Instagram media insight metric %s", metric)
+                return {}
+            raise
+
+        values: dict = {}
+        for entry in resp.json().get("data", []):
+            name = entry.get("name", "")
+            value = entry.get("total_value", {}).get("value")
+            if value is None:
+                value = entry.get("values", [{}])[0].get("value", 0)
+            values[name] = value
+        return values
 
     # ------------------------------------------------------------------
     # Inbox

--- a/tests/providers/test_facebook.py
+++ b/tests/providers/test_facebook.py
@@ -1,3 +1,4 @@
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, call
 
 import pytest
@@ -217,3 +218,91 @@ def test_publish_multi_photo_cleans_up_after_partial_staging_failure():
         )
 
     provider._request.assert_any_call("DELETE", "https://graph.facebook.com/v21.0/photo-1", access_token="page-token")
+
+
+# ---------------------------------------------------------------------------
+# Analytics
+# ---------------------------------------------------------------------------
+
+
+def test_post_metrics_read_from_object_summary_fields():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        return_value=MagicMock(
+            json=MagicMock(
+                return_value={
+                    "id": "post-1",
+                    "reactions": {"summary": {"total_count": 25}},
+                    "comments": {"summary": {"total_count": 8}},
+                    "shares": {"count": 3},
+                }
+            )
+        )
+    )
+
+    metrics = provider.get_post_metrics("page-token", "post-1")
+
+    assert metrics.likes == 25
+    assert metrics.comments == 8
+    assert metrics.shares == 3
+    provider._request.assert_called_once_with(
+        "GET",
+        "https://graph.facebook.com/v21.0/post-1",
+        access_token="page-token",
+        params={"fields": "id,reactions.summary(total_count),comments.summary(true),shares"},
+    )
+
+
+def test_account_metrics_fetches_page_insights_individually():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret", "page_id": "page-1"})
+    provider._request = MagicMock(
+        side_effect=[
+            MagicMock(json=MagicMock(return_value={"data": [{"name": "page_impressions", "values": [{"value": 10}]}]})),
+            MagicMock(
+                json=MagicMock(return_value={"data": [{"name": "page_impressions_unique", "values": [{"value": 8}]}]})
+            ),
+            MagicMock(
+                json=MagicMock(return_value={"data": [{"name": "page_post_engagements", "values": [{"value": 3}]}]})
+            ),
+            MagicMock(json=MagicMock(return_value={"data": [{"name": "page_daily_follows", "values": [{"value": 2}]}]})),
+        ]
+    )
+
+    metrics = provider.get_account_metrics(
+        "page-token",
+        (
+            datetime(2026, 6, 18, tzinfo=UTC),
+            datetime(2026, 6, 19, tzinfo=UTC),
+        ),
+    )
+
+    assert metrics.impressions == 10
+    assert metrics.reach == 8
+    assert metrics.followers_gained == 2
+    assert metrics.extra["raw_insights"]["page_post_engagements"] == 3
+    provider._request.assert_has_calls(
+        [
+            call(
+                "GET",
+                "https://graph.facebook.com/v21.0/page-1/insights",
+                access_token="page-token",
+                params={
+                    "metric": "page_impressions",
+                    "period": "day",
+                    "since": 1781740800,
+                    "until": 1781827200,
+                },
+            ),
+            call(
+                "GET",
+                "https://graph.facebook.com/v21.0/page-1/insights",
+                access_token="page-token",
+                params={
+                    "metric": "page_impressions_unique",
+                    "period": "day",
+                    "since": 1781740800,
+                    "until": 1781827200,
+                },
+            ),
+        ]
+    )

--- a/tests/providers/test_instagram.py
+++ b/tests/providers/test_instagram.py
@@ -1,8 +1,10 @@
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, call
 
+from apps.analytics.tasks import _post_metrics_to_dict
 from providers.instagram import InstagramProvider
 from providers.instagram_login import InstagramLoginProvider
+from providers.types import PostMetrics
 
 
 def test_get_user_pages_returns_linked_instagram_business_accounts():
@@ -105,7 +107,6 @@ def test_account_metrics_use_current_instagram_insights_metrics():
                         "data": [
                             {"name": "reach", "values": [{"value": 12}]},
                             {"name": "follower_count", "values": [{"value": 34}]},
-                            {"name": "profile_views", "values": [{"value": 5}]},
                         ]
                     }
                 )
@@ -118,7 +119,12 @@ def test_account_metrics_use_current_instagram_insights_metrics():
                                 "name": "views",
                                 "period": "day",
                                 "total_value": {"value": 67},
-                            }
+                            },
+                            {
+                                "name": "profile_views",
+                                "period": "day",
+                                "total_value": {"value": 5},
+                            },
                         ]
                     }
                 )
@@ -146,7 +152,7 @@ def test_account_metrics_use_current_instagram_insights_metrics():
                 "https://graph.facebook.com/v21.0/ig-1/insights",
                 access_token="page-token",
                 params={
-                    "metric": "reach,follower_count,profile_views",
+                    "metric": "reach,follower_count",
                     "period": "day",
                     "since": 1781740800,
                     "until": 1781827200,
@@ -157,7 +163,7 @@ def test_account_metrics_use_current_instagram_insights_metrics():
                 "https://graph.facebook.com/v21.0/ig-1/insights",
                 access_token="page-token",
                 params={
-                    "metric": "views",
+                    "metric": "views,profile_views",
                     "period": "day",
                     "metric_type": "total_value",
                     "since": 1781740800,
@@ -178,7 +184,6 @@ def test_instagram_login_account_metrics_use_current_insights_metrics():
                         "data": [
                             {"name": "reach", "values": [{"value": 12}]},
                             {"name": "follower_count", "values": [{"value": 34}]},
-                            {"name": "profile_views", "values": [{"value": 5}]},
                         ]
                     }
                 )
@@ -191,7 +196,12 @@ def test_instagram_login_account_metrics_use_current_insights_metrics():
                                 "name": "views",
                                 "period": "day",
                                 "total_value": {"value": 67},
-                            }
+                            },
+                            {
+                                "name": "profile_views",
+                                "period": "day",
+                                "total_value": {"value": 5},
+                            },
                         ]
                     }
                 )
@@ -219,7 +229,7 @@ def test_instagram_login_account_metrics_use_current_insights_metrics():
                 "https://graph.instagram.com/v21.0/me/insights",
                 access_token="ig-token",
                 params={
-                    "metric": "reach,follower_count,profile_views",
+                    "metric": "reach,follower_count",
                     "period": "day",
                     "since": 1781740800,
                     "until": 1781827200,
@@ -230,7 +240,7 @@ def test_instagram_login_account_metrics_use_current_insights_metrics():
                 "https://graph.instagram.com/v21.0/me/insights",
                 access_token="ig-token",
                 params={
-                    "metric": "views",
+                    "metric": "views,profile_views",
                     "period": "day",
                     "metric_type": "total_value",
                     "since": 1781740800,
@@ -239,3 +249,37 @@ def test_instagram_login_account_metrics_use_current_insights_metrics():
             ),
         ]
     )
+
+
+def test_instagram_extra_post_metrics_map_to_dashboard_keys():
+    metrics = PostMetrics(
+        reach=10,
+        video_views=20,
+        engagements=7,
+        clicks=3,
+        extra={
+            "follows": 2,
+            "profile_visits": 4,
+            "profile_activity": 5,
+            "watch_time": 1.5,
+            "avg_watch_time": 0.25,
+            "skip_rate": 12.5,
+            "facebook_views": 6,
+            "crossposted_views": 8,
+        },
+    )
+
+    out = _post_metrics_to_dict(metrics, "instagram")
+
+    assert out["reach"] == 10
+    assert out["views"] == 20
+    assert out["interactions"] == 7
+    assert out["clicks"] == 3
+    assert out["post_follows"] == 2
+    assert out["profile_visits"] == 4
+    assert out["profile_activity"] == 5
+    assert out["watch_time"] == 1.5
+    assert out["avg_watch_time"] == 0.25
+    assert out["skip_rate"] == 12.5
+    assert out["facebook_views"] == 6
+    assert out["crossposted_views"] == 8


### PR DESCRIPTION
## Summary

Updates Meta analytics collection for current Facebook and Instagram API behavior:

- moves Facebook post analytics off the brittle `/insights` edge and onto object summary fields for reactions, comments, and shares
- fetches Facebook page insight metrics independently so one removed metric does not fail the whole account sync
- splits Instagram account insights so `profile_views` is requested with `metric_type=total_value`
- replaces deprecated Instagram media metrics such as `impressions`/`engagement` with current metrics including `views`, `total_interactions`, Reels watch-time/skip-rate, crosspost views, profile activity, and per-media follows
- adds dashboard/storage mapping for new Instagram metric keys while preserving account-level follower growth via `follows`

## Root Cause

Meta removed or changed several legacy Insights metrics. Batched requests failed when any metric was no longer accepted, and some published Facebook object types do not expose the `insights` edge at all.

## Validation

- Migrated the local development DB to the current branch schema (`composer.0017_post_proposed_publish_at`).
- Local Meta provider metric-call harness passed with Meta-shaped success responses and removed-metric API errors; no warnings were emitted.
- Local analytics capture/display service verification passed: temporary Instagram account/post snapshot rows flowed through `account_analytics_bundle`, hero cards, chart chips, engagement, follower growth, and post-detail metric tiles, then were rolled back.
- Verified imports cleanly with Django setup: `apps.analytics.tasks` imports and the `background_task` `process_tasks` management command loads successfully.
- Local development DB has zero connected Facebook/Instagram accounts, so live Meta API calls could not be run from this checkout.
- `process_tasks` was not run because the local queue contains unrelated publisher/inbox jobs and the reviewer blocked executing the shared worker.
- Focused analytics/provider suite passed with no warnings after filtering the Python 3.14-only Django deprecation: `PYTHONWARNINGS="ignore:'asyncio.iscoroutinefunction' is deprecated:DeprecationWarning:django.contrib.auth.decorators" python -m pytest apps/api/tests/test_analytics_router.py apps/mcp/tests/test_rest_parity.py apps/mcp/tests/test_transport.py tests/providers/test_facebook.py tests/providers/test_instagram.py -q` -> 80 passed.
- Provider regression suite passed after the lint fix: `python -m pytest tests/providers/test_facebook.py tests/providers/test_instagram.py -q` -> 16 passed.
- Same focused suite also passed unfiltered after creating ignored local `staticfiles/`; the only warnings were third-party Python 3.14 Django deprecations.
- Full local suite under the available Python 3.14.3 environment did not pass: 836 passed, 60 failed due to Django test-client `Context.__copy__` errors across template-rendering tests. Python 3.12 is not installed locally, so I could not rerun the full suite under the repo's expected runtime.
- `python -m ruff check .` passed.
- `python -m ruff format --check .` passed.