### PR TITLE
fix(tiktok): meet Content Posting API UX requirements for audit

### DIFF
--- a/apps/calendar/tasks.py
+++ b/apps/calendar/tasks.py
@@ -1,5 +1,6 @@
 """Background tasks for the Content Calendar (F-2.3)."""
 
+import copy
 import logging
 import zoneinfo
 from datetime import datetime, timedelta
@@ -102,6 +103,11 @@ def generate_recurring_posts():
                             platform_specific_caption=pp.platform_specific_caption,
                             platform_specific_first_comment=pp.platform_specific_first_comment,
                             platform_specific_media=pp.platform_specific_media,
+                            # Carry per-platform settings (e.g. TikTok privacy level,
+                            # comment/duet/stitch toggles, disclosure flags) into each
+                            # recurrence. Without this the publisher falls back to
+                            # provider defaults and loses the creator's choices.
+                            platform_extra=copy.deepcopy(pp.platform_extra) if pp.platform_extra else {},
                             scheduled_at=pp_scheduled,
                             status="scheduled",
                         )

--- a/apps/calendar/tests.py
+++ b/apps/calendar/tests.py
@@ -485,6 +485,64 @@ class RecurringPostTimezoneTests(TestCase):
         self.assertEqual(local_dates[-1], date(2026, 6, 20))
 
 
+class RecurringPostPlatformExtraTests(TestCase):
+    """Recurrence clones must carry each PlatformPost's platform_extra so the
+    creator's per-platform settings (e.g. TikTok privacy + interaction flags)
+    survive into every generated occurrence rather than reverting to provider
+    defaults at publish time.
+    """
+
+    def test_recurrence_preserves_platform_extra(self):
+        org = Organization.objects.create(name="Extra Org")
+        ws = Workspace.objects.create(organization=org, name="Extra WS")
+        utc = zoneinfo.ZoneInfo("UTC")
+        account = SocialAccount.objects.create(
+            workspace=ws,
+            platform="tiktok",
+            account_platform_id="tt-extra",
+            account_name="TikTok",
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+        source = Post.objects.create(
+            workspace=ws,
+            caption="extra-recurrence",
+            scheduled_at=datetime(2026, 3, 2, 9, 0, tzinfo=utc),
+        )
+        tiktok_extra = {
+            "privacy_level": "SELF_ONLY",
+            "disable_comment": False,
+            "disable_duet": True,
+            "disable_stitch": False,
+            "brand_organic_toggle": True,
+            "brand_content_toggle": False,
+            "is_aigc": False,
+        }
+        PlatformPost.objects.create(
+            post=source,
+            social_account=account,
+            platform_extra=tiktok_extra,
+            scheduled_at=source.scheduled_at,
+            status="scheduled",
+        )
+        RecurrenceRule.objects.create(
+            post=source,
+            frequency=RecurrenceRule.Frequency.WEEKLY,
+            interval=1,
+            end_date=date(2026, 4, 30),
+        )
+
+        fixed_now = datetime(2026, 3, 1, 12, 0, tzinfo=utc)
+        with patch("apps.calendar.tasks.timezone.now", return_value=fixed_now):
+            generated = generate_recurring_posts()
+
+        self.assertGreater(generated, 0)
+        clones = Post.objects.filter(workspace=ws, caption="extra-recurrence").exclude(id=source.id)
+        self.assertTrue(clones.exists())
+        for clone in clones:
+            clone_pp = clone.platform_posts.get(social_account=account)
+            self.assertEqual(clone_pp.platform_extra, tiktok_extra)
+
+
 class PublishTabTimezoneTests(TestCase):
     """The publish tabs must render times in a user-supplied ?tz= without 500ing."""
 

--- a/apps/composer/tests/test_account_scope.py
+++ b/apps/composer/tests/test_account_scope.py
@@ -221,22 +221,24 @@ class TikTokExtrasSyncTests(AccountScopeTestsBase):
         extra = self.tt_pp.platform_extra
         self.assertEqual(extra["privacy_level"], "SELF_ONLY")
         self.assertFalse(extra["disable_comment"])
-        # "Reuse of content" checkbox absent from POST → both flags disabled.
+        # Duet/Stitch checkboxes absent from POST → both interactions disabled.
         self.assertTrue(extra["disable_duet"])
         self.assertTrue(extra["disable_stitch"])
         self.assertTrue(extra["brand_content_toggle"])
         self.assertFalse(extra["brand_organic_toggle"])
         self.assertTrue(extra["is_aigc"])
 
-    def test_allow_reuse_enables_duet_and_stitch_together(self):
+    def test_duet_and_stitch_toggle_independently(self):
+        # Duet on, Stitch left off → only stitch disabled. Confirms the two
+        # interactions are controlled independently (TikTok's per-interaction rule).
         response = self.client.post(
             self.save_url,
-            data=self._tiktok_payload(privacy_level="SELF_ONLY", allow_reuse="true"),
+            data=self._tiktok_payload(privacy_level="SELF_ONLY", allow_duet="true"),
         )
         self.assertIn(response.status_code, (200, 204, 302))
         self.tt_pp.refresh_from_db()
         self.assertFalse(self.tt_pp.platform_extra["disable_duet"])
-        self.assertFalse(self.tt_pp.platform_extra["disable_stitch"])
+        self.assertTrue(self.tt_pp.platform_extra["disable_stitch"])
 
     def test_invalid_privacy_level_left_unset(self):
         response = self.client.post(self.save_url, data=self._tiktok_payload(privacy_level="BOGUS"))
@@ -262,3 +264,36 @@ class TikTokExtrasSyncTests(AccountScopeTestsBase):
         self.assertIn(response.status_code, (200, 204, 302))
         self.tt_pp.refresh_from_db()
         self.assertEqual(self.tt_pp.platform_extra, {"privacy_level": "SELF_ONLY"})
+
+
+class TikTokComposerDefaultsTests(AccountScopeTestsBase):
+    """TikTok's audit requires the composer to ship NO default privacy level and
+    NO pre-checked interaction toggles. The defaults live in the Alpine init in
+    templates/composer/compose.html, so these guard the rendered expressions
+    against silently regressing back to a default.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.compose_url = reverse("composer:compose", kwargs={"workspace_id": self.workspace.id})
+
+    def test_privacy_renders_with_no_default(self):
+        response = self.client.get(self.compose_url)
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode()
+        # No pre-selected privacy level (TikTok "no default value" rule)…
+        self.assertIn("privacy_level || ''", html)
+        self.assertNotIn("privacy_level || 'PUBLIC_TO_EVERYONE'", html)
+        # …and the creator-info effect must not auto-select an option either.
+        self.assertNotIn("ttPrivacy = opts[0]", html)
+
+    def test_interaction_toggles_unchecked_by_default(self):
+        response = self.client.get(self.compose_url)
+        self.assertEqual(response.status_code, 200)
+        html = response.content.decode()
+        # Comment / Duet / Stitch start unchecked unless a saved extra explicitly
+        # enabled them (=== false). A truthy-but-empty platformExtras[accId] ({})
+        # must NOT count as "enabled", so each guard checks its field, not the object.
+        self.assertIn("ttAllowComment: platformExtras[accId]?.disable_comment === false", html)
+        self.assertIn("ttAllowDuet: platformExtras[accId]?.disable_duet === false", html)
+        self.assertIn("ttAllowStitch: platformExtras[accId]?.disable_stitch === false", html)

--- a/apps/composer/views.py
+++ b/apps/composer/views.py
@@ -187,14 +187,13 @@ def _sync_platform_posts(request, post, workspace, initial_status=None):
                 # An empty/invalid submit (required-validation bypassed) must
                 # not wipe a previously saved choice.
                 privacy = (pp.platform_extra or {}).get("privacy_level", "")
-            # "Reuse of content" mirrors TikTok's own UI: one switch covering
-            # Duet, Stitch, stickers and story reuse — the API still takes
-            # the two flags separately.
-            allow_reuse = request.POST.get(f"tiktok_allow_reuse_{acc_id}") == "true"
+            # Comment / Duet / Stitch are independent interaction settings —
+            # TikTok's UX guidelines require a separate toggle per interaction,
+            # each greyed out on its own when the creator disabled it.
             extra = {
                 "disable_comment": request.POST.get(f"tiktok_allow_comment_{acc_id}") != "true",
-                "disable_duet": not allow_reuse,
-                "disable_stitch": not allow_reuse,
+                "disable_duet": request.POST.get(f"tiktok_allow_duet_{acc_id}") != "true",
+                "disable_stitch": request.POST.get(f"tiktok_allow_stitch_{acc_id}") != "true",
                 "brand_organic_toggle": request.POST.get(f"tiktok_brand_organic_{acc_id}") == "true",
                 "brand_content_toggle": request.POST.get(f"tiktok_brand_content_{acc_id}") == "true",
                 "is_aigc": request.POST.get(f"tiktok_is_aigc_{acc_id}") == "true",

--- a/apps/publisher/engine.py
+++ b/apps/publisher/engine.py
@@ -300,6 +300,7 @@ class PublishEngine:
             attachments = [pm for pm in attachments if pm.media_asset.media_type == "video"]
 
         first_media_type = None
+        primary_video_duration = None
         app_url = getattr(settings, "APP_URL", "").rstrip("/")
         try:
             for pm in attachments:
@@ -309,6 +310,11 @@ class PublishEngine:
                 # Track the first media type for post type detection
                 if first_media_type is None:
                     first_media_type = asset.media_type
+
+                # Capture the first video's duration so providers can enforce
+                # platform max-duration limits (e.g. TikTok max_video_post_duration_sec).
+                if primary_video_duration is None and asset.media_type == "video":
+                    primary_video_duration = asset.duration or None
 
                 # Collect the public/presigned URL for this asset
                 url = asset.file.url
@@ -404,6 +410,7 @@ class PublishEngine:
                 post_type=post_type,
                 extra=extra,
                 link_url=link_url,
+                video_duration_sec=primary_video_duration,
             )
 
             logger.info(

--- a/providers/tiktok.py
+++ b/providers/tiktok.py
@@ -270,7 +270,7 @@ class TikTokProvider(SocialProvider):
                 retryable=False,
             )
 
-        self._check_creator_privacy_options(access_token, privacy_level)
+        self._check_creator_constraints(access_token, privacy_level, content)
 
         # Prefer FILE_UPLOAD: PULL_FROM_URL requires the source domain to be
         # verified with TikTok, which presigned S3/R2 URLs can't satisfy.
@@ -284,8 +284,8 @@ class TikTokProvider(SocialProvider):
             retryable=False,
         )
 
-    def _check_creator_privacy_options(self, access_token: str, privacy_level: str) -> None:
-        """Validate the requested privacy level against creator_info.
+    def _check_creator_constraints(self, access_token: str, privacy_level: str, content: PublishContent) -> None:
+        """Validate privacy level and video duration against creator_info.
 
         A creator_info failure is logged and ignored — a transient outage of
         that endpoint must not block publishing; the video init call surfaces
@@ -307,6 +307,20 @@ class TikTokProvider(SocialProvider):
                 message = f"{message} {UNAUDITED_CLIENT_HINT}"
             raise PublishError(
                 message,
+                platform=self.platform_name,
+                raw_response=info,
+                retryable=False,
+            )
+
+        # TikTok's UX guidelines require checking the video against the
+        # creator's max post duration before uploading. Skip silently when
+        # either value is unknown (0/None) so we never block on missing data.
+        max_duration = info.get("max_video_post_duration_sec")
+        duration = content.video_duration_sec
+        if max_duration and duration and duration > max_duration:
+            raise PublishError(
+                f"Video is {round(duration)}s long but TikTok allows at most "
+                f"{int(max_duration)}s for this account. Trim the video and try again.",
                 platform=self.platform_name,
                 raw_response=info,
                 retryable=False,

--- a/providers/types.py
+++ b/providers/types.py
@@ -142,3 +142,6 @@ class PublishContent:
     description: str | None = None
     first_comment: str | None = None
     extra: dict = field(default_factory=dict)
+    # Duration of the primary video in seconds, when known. Lets providers
+    # enforce platform limits (e.g. TikTok's max_video_post_duration_sec).
+    video_duration_sec: float | None = None

--- a/templates/composer/compose.html
+++ b/templates/composer/compose.html
@@ -745,9 +745,10 @@
                              tt: null,
                              ttLoading: false,
                              ttLoaded: false,
-                             ttPrivacy: platformExtras[accId]?.privacy_level || 'PUBLIC_TO_EVERYONE',
-                             ttAllowComment: !platformExtras[accId]?.disable_comment,
-                             ttAllowReuse: !(platformExtras[accId]?.disable_duet || platformExtras[accId]?.disable_stitch),
+                             ttPrivacy: platformExtras[accId]?.privacy_level || '',
+                             ttAllowComment: platformExtras[accId]?.disable_comment === false,
+                             ttAllowDuet: platformExtras[accId]?.disable_duet === false,
+                             ttAllowStitch: platformExtras[accId]?.disable_stitch === false,
                              ttDisclose: !!(platformExtras[accId]?.brand_organic_toggle || platformExtras[accId]?.brand_content_toggle),
                              ttBrandOrganic: !!platformExtras[accId]?.brand_organic_toggle,
                              ttBrandContent: !!platformExtras[accId]?.brand_content_toggle,
@@ -768,6 +769,11 @@
                                      SELF_ONLY: 'Only you',
                                  })[level] || level;
                              },
+                             get ttLabelPrompt() {
+                                 if (this.ttBrandContent) return `Your photo/video will be labeled as 'Paid partnership'`;
+                                 if (this.ttBrandOrganic) return `Your photo/video will be labeled as 'Promotional content'`;
+                                 return '';
+                             },
                          }"
                          x-effect="if (charLimits[accId]?.platform === 'tiktok' && !ttLoaded && !ttLoading) {
                              ttLoading = true;
@@ -777,9 +783,10 @@
                                      if (data) {
                                          tt = data;
                                          if (data.comment_disabled) ttAllowComment = false;
-                                         if (data.duet_disabled && data.stitch_disabled) ttAllowReuse = false;
+                                         if (data.duet_disabled) ttAllowDuet = false;
+                                         if (data.stitch_disabled) ttAllowStitch = false;
                                          const opts = data.privacy_level_options || [];
-                                         if (opts.length && !opts.includes(ttPrivacy)) ttPrivacy = opts[0] || '';
+                                         if (ttPrivacy && opts.length && !opts.includes(ttPrivacy)) ttPrivacy = '';
                                      }
                                      ttLoaded = true;
                                  })
@@ -807,6 +814,7 @@
                                 <template x-for="lvl in ttOptions" :key="lvl">
                                     <option :value="lvl"
                                             :disabled="ttBrandContent && lvl === 'SELF_ONLY'"
+                                            :title="(ttBrandContent && lvl === 'SELF_ONLY') ? 'Branded content visibility cannot be set to private.' : ''"
                                             :selected="ttPrivacy === lvl"
                                             x-text="ttLabel(lvl)"></option>
                                 </template>
@@ -815,7 +823,7 @@
                             <p x-show="ttSelfOnlyLocked" class="text-[11px] text-amber-600 mt-1">
                                 This TikTok app hasn't passed TikTok's content audit yet — only private posting ("Only you") is available until the audit is approved.
                             </p>
-                            <p x-show="ttBrandContent" class="text-[11px] text-stone-400 mt-1">Branded content can't be set to "Only you".</p>
+                            <p x-show="ttBrandContent" class="text-[11px] text-stone-400 mt-1">Branded content visibility cannot be set to private.</p>
                         </div>
                         <!-- Cover: TikTok takes a frame timestamp, not an uploaded image -->
                         <div>
@@ -849,7 +857,9 @@
                                 </template>
                             </div>
                         </div>
-                        <!-- Interaction abilities -->
+                        <!-- Interaction abilities — separate per-interaction toggles.
+                             TikTok requires an independent checkbox per interaction,
+                             greyed out individually when disabled in creator settings. -->
                         <div>
                             <label class="block text-[11px] font-semibold text-stone-400 uppercase tracking-wider mb-1.5">Allow users to:</label>
                             <div class="space-y-2">
@@ -859,15 +869,17 @@
                                            class="bb-checkbox w-4 h-4 rounded border-stone-300">
                                     <span class="text-sm text-stone-700">Comment</span>
                                 </label>
-                                <label class="flex items-start gap-2"
-                                       :class="(tt?.duet_disabled && tt?.stitch_disabled) ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'">
-                                    <input type="checkbox" :name="'tiktok_allow_reuse_' + accId" value="true"
-                                           x-model="ttAllowReuse" :disabled="!!(tt?.duet_disabled && tt?.stitch_disabled)"
-                                           class="bb-checkbox w-4 h-4 mt-0.5 rounded border-stone-300">
-                                    <span class="text-sm text-stone-700">
-                                        Reuse of content
-                                        <span class="block text-[11px] text-stone-400 font-normal">Others can Duet, Stitch, use stickers and add this post to their story.</span>
-                                    </span>
+                                <label class="flex items-center gap-2" :class="tt?.duet_disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'">
+                                    <input type="checkbox" :name="'tiktok_allow_duet_' + accId" value="true"
+                                           x-model="ttAllowDuet" :disabled="!!tt?.duet_disabled"
+                                           class="bb-checkbox w-4 h-4 rounded border-stone-300">
+                                    <span class="text-sm text-stone-700">Duet</span>
+                                </label>
+                                <label class="flex items-center gap-2" :class="tt?.stitch_disabled ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'">
+                                    <input type="checkbox" :name="'tiktok_allow_stitch_' + accId" value="true"
+                                           x-model="ttAllowStitch" :disabled="!!tt?.stitch_disabled"
+                                           class="bb-checkbox w-4 h-4 rounded border-stone-300">
+                                    <span class="text-sm text-stone-700">Stitch</span>
                                 </label>
                             </div>
                         </div>
@@ -891,7 +903,7 @@
                                            class="bb-checkbox w-4 h-4 mt-0.5 rounded border-stone-300">
                                     <span class="text-sm text-stone-700">
                                         Your brand
-                                        <span class="block text-[11px] text-stone-400 font-normal">You're promoting your own business. The post will be labeled "Promotional content".</span>
+                                        <span class="block text-[11px] text-stone-400 font-normal">You are promoting yourself or your own business.</span>
                                     </span>
                                 </label>
                                 <label class="flex items-start gap-2 cursor-pointer">
@@ -901,9 +913,20 @@
                                            class="bb-checkbox w-4 h-4 mt-0.5 rounded border-stone-300">
                                     <span class="text-sm text-stone-700">
                                         Branded content
-                                        <span class="block text-[11px] text-stone-400 font-normal">You're promoting another brand or in a paid partnership. The post will be labeled "Paid partnership".</span>
+                                        <span class="block text-[11px] text-stone-400 font-normal">You are promoting another brand or a third party.</span>
                                     </span>
                                 </label>
+                                <!-- Exact TikTok content label prompt, shown once a disclosure option is selected -->
+                                <template x-if="ttLabelPrompt">
+                                    <p class="text-[11px] text-stone-600 bg-stone-50 border border-stone-200 rounded-md px-2 py-1.5" x-text="ttLabelPrompt"></p>
+                                </template>
+                                <!-- Disclosure requires at least one sub-option; gate submit via native validity -->
+                                <template x-if="!ttBrandOrganic && !ttBrandContent">
+                                    <p class="text-[11px] text-red-500">You need to indicate if your content promotes yourself, a third party, or both.</p>
+                                </template>
+                                <input type="text" tabindex="-1" aria-hidden="true" class="sr-only"
+                                       :required="ttDisclose"
+                                       :value="(ttBrandOrganic || ttBrandContent) ? '1' : ''">
                             </div>
                         </div>
                         <!-- AI-generated content -->
@@ -927,6 +950,10 @@
                                 <span><a href="https://www.tiktok.com/legal/page/global/bc-policy/en" target="_blank" rel="noopener" class="underline hover:text-stone-600">Branded Content Policy</a> and </span>
                             </template>
                             <a href="https://www.tiktok.com/legal/page/global/music-usage-confirmation/en" target="_blank" rel="noopener" class="underline hover:text-stone-600">Music Usage Confirmation</a>.
+                        </p>
+                        <!-- Processing-time notice (TikTok requires informing users of the publish delay) -->
+                        <p class="text-[11px] text-stone-400">
+                            After you publish, it may take a few minutes for your video to process and appear on your TikTok profile.
                         </p>
                     </div>
                 </template>

--- a/tests/providers/test_tiktok.py
+++ b/tests/providers/test_tiktok.py
@@ -473,6 +473,47 @@ class TestPublishPost:
         assert init_call.kwargs["json"]["post_info"]["privacy_level"] == "SELF_ONLY"
 
     @patch.object(TikTokProvider, "_request")
+    def test_video_over_max_duration_blocked_before_init(self, mock_request):
+        # creator_info caps duration at 600s; a 900s video must fail fast,
+        # non-retryable, without ever calling video/init.
+        mock_request.return_value = _creator_info_response(["PUBLIC_TO_EVERYONE", "SELF_ONLY"])
+
+        provider = TikTokProvider({"client_key": "k", "client_secret": "s"})
+        content = PublishContent(
+            text="Hello TikTok",
+            media_urls=["https://cdn.example.com/video.mp4"],
+            post_type=PostType.VIDEO,
+            extra={"privacy_level": "PUBLIC_TO_EVERYONE"},
+            video_duration_sec=900,
+        )
+        with pytest.raises(PublishError) as excinfo:
+            provider.publish_post("tok", content)
+
+        assert excinfo.value.retryable is False
+        assert "600" in str(excinfo.value)
+        urls = [call.args[1] for call in mock_request.call_args_list]
+        assert VIDEO_INIT_URL not in urls
+
+    @patch.object(TikTokProvider, "_request")
+    def test_video_within_max_duration_proceeds(self, mock_request):
+        mock_request.side_effect = [
+            _creator_info_response(["PUBLIC_TO_EVERYONE", "SELF_ONLY"]),
+            _init_response(),
+        ]
+
+        provider = TikTokProvider({"client_key": "k", "client_secret": "s"})
+        content = PublishContent(
+            text="Hello TikTok",
+            media_urls=["https://cdn.example.com/video.mp4"],
+            post_type=PostType.VIDEO,
+            extra={"privacy_level": "PUBLIC_TO_EVERYONE"},
+            video_duration_sec=120,
+        )
+        result = provider.publish_post("tok", content)
+
+        assert result.platform_post_id == "v_pub_url~123"
+
+    @patch.object(TikTokProvider, "_request")
     def test_creator_info_failure_does_not_block_publish(self, mock_request):
         mock_request.side_effect = [
             APIError("creator_info down", platform="TikTok", status_code=500),


### PR DESCRIPTION
## What does this PR do?

Brings the TikTok composer and publish path into compliance with TikTok's "Required UX Implementation in Your App" guidelines so the Content Posting API audit can be resubmitted.

- **Privacy (no default):** the "Who can see this post" selector starts unselected, and the creator-info effect clears an invalid saved value instead of auto-selecting one.
- **Interaction settings (split):** the combined "Reuse of content" toggle is split into separate **Comment / Duet / Stitch** checkboxes — each unchecked by default and greyed out independently based on `creator_info`.
- **Commercial content disclosure:** selecting "Your brand" / "Branded content" shows TikTok's exact label prompt (`Your photo/video will be labeled as 'Promotional content'` / `'Paid partnership'`; both → "Paid partnership"); enabling disclosure requires a sub-option (TikTok's exact message); branded content can't be private (SELF_ONLY option disabled + tooltip, and a prior SELF_ONLY choice is cleared).
- **Processing-delay notice** added per TikTok's "notify users after publishing" requirement.
- **Max video duration:** `PublishContent` now carries the primary video duration (populated from `MediaAsset.duration` in the publisher engine), and the provider blocks an over-limit video against `max_video_post_duration_sec` before calling `video/init`.

Also fixes a pre-existing bug: `generate_recurring_posts` dropped `platform_extra` when cloning `PlatformPost`s, so recurring TikTok posts lost their privacy/interaction/disclosure settings and fell back to provider defaults at publish time.

## Why?

The TikTok Content Posting API developer review was rejected for not following the "Required UX Implementation" guidelines (Content Disclosure Setting and related UX). These changes close the gaps so the integration matches TikTok's required UX and the audit can be resubmitted.

## How to test

1. Start Postgres and run the affected suites:
   ```
   docker start brightbean-studio-postgres-1 && .venv/bin/python -m pytest apps/composer/tests/test_account_scope.py tests/providers/test_tiktok.py apps/calendar/tests.py apps/publisher -q
   ```
2. In the composer with a TikTok account selected, confirm:
   - "Who can see this post" has no pre-selected value; submitting without choosing is blocked.
   - Comment / Duet / Stitch render as separate checkboxes, all unchecked.
   - Toggle "Disclose post content": "Your brand" shows "…labeled as 'Promotional content'"; "Branded content" (or both) shows "…'Paid partnership'"; selecting branded content disables/clears "Only you".
   - The "may take a few minutes to process" notice is shown.

## Checklist

- [x] Tests pass (`pytest`) — 898 passed
- [x] Lint passes (`ruff check .` and `ruff format --check .`)
- [x] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
