### PR TITLE
fix(analytics): stop re-syncing YouTube accounts flagged for analytics reconnect

### DIFF
--- a/apps/analytics/tasks.py
+++ b/apps/analytics/tasks.py
@@ -569,7 +569,16 @@ def sync_all_account_analytics() -> None:
     for account in accounts:
         # Account-level: at most once per day per account. Skip if today's
         # row already exists so an hourly cron doesn't turn into 24 API calls.
-        if not AccountInsightsSnapshot.objects.filter(social_account=account, date=today).exists():
+        # Also skip accounts already flagged for analytics reconnect — their
+        # token can't read the Analytics API, so retrying only re-fails and
+        # re-logs every hour. Reconnecting clears the flag and runs a one-shot
+        # backfill (see backfill_account_analytics), so the cron resumes on its
+        # own. The per-post Data-API loop below still runs (it uses the
+        # publish/read scopes the account already has).
+        if (
+            not account.analytics_needs_reconnect
+            and not AccountInsightsSnapshot.objects.filter(social_account=account, date=today).exists()
+        ):
             _sync_account_metrics(account, today)
 
         # Per-post: only those whose cadence window has elapsed

--- a/apps/analytics/tests/test_tasks.py
+++ b/apps/analytics/tests/test_tasks.py
@@ -1,0 +1,48 @@
+"""Tests for analytics background tasks."""
+
+from unittest.mock import patch
+
+import pytest
+
+from apps.analytics.tasks import sync_all_account_analytics
+from apps.social_accounts.models import AnalyticsPlatformConfig, SocialAccount
+
+
+@pytest.fixture
+def workspace(db, organization):
+    from apps.workspaces.models import Workspace
+
+    return Workspace.objects.create(name="Test WS", organization=organization)
+
+
+def _youtube_account(workspace, *, platform_id, needs_reconnect):
+    return SocialAccount.objects.create(
+        workspace=workspace,
+        platform="youtube",
+        account_platform_id=platform_id,
+        account_name=f"YT {platform_id}",
+        oauth_access_token="token",
+        oauth_refresh_token="refresh",
+        connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        analytics_needs_reconnect=needs_reconnect,
+    )
+
+
+@pytest.mark.django_db
+class TestSyncAllAccountAnalytics:
+    @patch("apps.analytics.tasks._sync_account_metrics")
+    def test_skips_accounts_flagged_for_reconnect(self, mock_sync_account_metrics, workspace):
+        """An account already flagged ``analytics_needs_reconnect`` must not
+        trigger another Analytics-API account-metrics attempt (the call that
+        re-fails and re-logs every hour), while an unflagged account still does.
+        """
+        # A seed migration may already have a youtube row; ensure it's enabled.
+        AnalyticsPlatformConfig.objects.update_or_create(platform="youtube", defaults={"is_enabled": True})
+        healthy = _youtube_account(workspace, platform_id="healthy", needs_reconnect=False)
+        flagged = _youtube_account(workspace, platform_id="flagged", needs_reconnect=True)
+
+        sync_all_account_analytics.now()
+
+        synced_ids = {call.args[0].id for call in mock_sync_account_metrics.call_args_list}
+        assert healthy.id in synced_ids
+        assert flagged.id not in synced_ids


### PR DESCRIPTION
## What does this PR do?

Makes the hourly `sync_all_account_analytics` cron skip the YouTube Analytics-API account-metrics call for accounts already flagged `analytics_needs_reconnect`. Adds the first test module for `apps/analytics`.

## Why?

The cron calls the YouTube Analytics API (`get_account_metrics` → `youtubeanalytics.googleapis.com/v2/reports`) for every connected account. Accounts whose stored OAuth token predates the analytics rollout (~2026-06-02) lack the `yt-analytics.readonly` scope, so the call returns `403 ACCESS_TOKEN_SCOPE_INSUFFICIENT`.

That failure is **already handled** — it's caught, logged, the account is flagged `analytics_needs_reconnect`, and a "Reconnect for analytics" CTA is shown. Nothing is broken and publishing is unaffected. But a failed account never writes an `AccountInsightsSnapshot` row, so the existing `exists()` short-circuit never kicks in and the cron **retried it every hour, indefinitely** — one failed API call + one `WARNING` per flagged account per hour. This was surfacing as recurring noise in the worker logs:

```
WARNING tasks get_account_metrics failed for <account> (YouTube): YouTube API error 403: insufficient authentication scopes
```

### Approach

Add `not account.analytics_needs_reconnect` to the guard around the `_sync_account_metrics` call in the cron loop. Notes:

- **Auto-resumes:** reconnecting sets `analytics_needs_reconnect=False` and enqueues the one-shot `backfill_account_analytics`, so the cron picks the account back up on the next tick — no manual intervention.
- **Per-post metrics preserved:** the per-post Data-API loop sits outside the guarded block and still runs for flagged accounts (it uses the `youtube.readonly` scope they already have). The per-video Analytics call is reached only from inside `_sync_account_metrics`, so it's correctly skipped too.
- **Guard placed only in the cron**, not in the shared `_sync_account_metrics`; the other caller (`backfill_account_analytics`) runs right after the flag is cleared on reconnect, so it must not be gated.

> Note: this only stops the recurring log noise. It does **not** restore analytics for already-affected accounts — those YouTube accounts still need to be reconnected to re-grant the scope.

## How to test

```
docker start brightbean-studio-postgres-1   # pytest needs the dockerized Postgres
pytest apps/analytics/tests/test_tasks.py
```

The new test enables `youtube` analytics, creates two connected YouTube accounts (one flagged for reconnect, one not), runs the cron, and asserts `_sync_account_metrics` is called for the healthy account but **not** the flagged one.

## Checklist

- [x] Tests pass (`pytest apps/analytics/tests/test_tasks.py`)
- [x] Lint passes (`ruff check` and `ruff format --check` on the changed files)
- [ ] Documentation updated (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)