### PR TITLE
fix: store facebook upstream publish ids

### DIFF
--- a/apps/publisher/engine.py
+++ b/apps/publisher/engine.py
@@ -212,6 +212,12 @@ class PublishEngine:
 
             if result["success"]:
                 platform_post.platform_post_id = result.get("platform_post_id", "")
+                platform_extra_updates = result.get("platform_extra_updates") or {}
+                if platform_extra_updates:
+                    platform_post.platform_extra = {
+                        **(platform_post.platform_extra or {}),
+                        **platform_extra_updates,
+                    }
                 platform_post.status = PlatformPost.Status.PUBLISHED
                 platform_post.published_at = timezone.now()
                 platform_post.save()
@@ -426,12 +432,30 @@ class PublishEngine:
                 "platform_post_id": result.platform_post_id,
                 "url": result.url,
                 "response": result.extra,
+                "platform_extra_updates": self._platform_extra_updates(platform, result),
             }
         finally:
             # Clean up temp files regardless of success/failure
             for path in temp_files:
                 with contextlib.suppress(OSError):
                     os.unlink(path)
+
+    @staticmethod
+    def _platform_extra_updates(platform: str, result) -> dict:
+        if platform != "facebook":
+            return {}
+
+        extra = result.extra or {}
+        upstream_ids = {"insights_post_id": result.platform_post_id}
+        if extra.get("post_id"):
+            upstream_ids["feed_post_id"] = extra["post_id"]
+        if extra.get("id"):
+            upstream_ids["response_id"] = extra["id"]
+        if extra.get("video_id"):
+            upstream_ids["video_id"] = extra["video_id"]
+        if extra.get("photo_ids"):
+            upstream_ids["photo_ids"] = extra["photo_ids"]
+        return {"facebook_upstream_ids": upstream_ids}
 
     @staticmethod
     def _resolve_post_type(

--- a/apps/publisher/tests.py
+++ b/apps/publisher/tests.py
@@ -195,6 +195,32 @@ class DispatchExtraInjectionTest(SimpleTestCase):
         _access_token, content = mock_provider.publish_post.call_args.args
         self.assertNotIn("author", content.extra)
 
+    @patch("apps.publisher.engine.get_provider")
+    @patch("apps.publisher.engine._resolve_publish_credentials", return_value={})
+    def test_facebook_dispatch_returns_upstream_id_metadata(self, _mock_creds, mock_get_provider):
+        engine, platform_post, mock_provider = _build_dispatch_mocks(
+            platform="facebook",
+            account_platform_id="page-1",
+        )
+        mock_provider.publish_post.return_value = PublishResult(
+            platform_post_id="page-1_post-1",
+            url="https://www.facebook.com/page-1_post-1",
+            extra={"id": "video-1", "post_id": "page-1_post-1", "video_id": "video-1"},
+        )
+        mock_get_provider.return_value = mock_provider
+
+        result = engine._dispatch_to_provider(platform_post)
+
+        self.assertEqual(
+            result["platform_extra_updates"]["facebook_upstream_ids"],
+            {
+                "insights_post_id": "page-1_post-1",
+                "feed_post_id": "page-1_post-1",
+                "response_id": "video-1",
+                "video_id": "video-1",
+            },
+        )
+
 
 class ResolvePublishCredentialsTest(SimpleTestCase):
     @patch("apps.publisher.engine.resolve_platform_credentials", return_value={"client_id": "id"})
@@ -266,3 +292,44 @@ class NonRetryableFailureTest(TestCase):
         self.assertEqual(self.platform_post.retry_count, 1)
         self.assertIsNotNone(self.platform_post.next_retry_at)
         self.assertEqual(PublishLog.objects.filter(platform_post=self.platform_post).count(), 1)
+
+    def test_success_persists_facebook_upstream_id_metadata(self):
+        from apps.composer.models import PlatformPost
+
+        self.account.platform = "facebook"
+        self.account.account_platform_id = "page-1"
+        self.account.save(update_fields=["platform", "account_platform_id", "updated_at"])
+        self.platform_post.platform_extra = {"existing": "kept"}
+        self.platform_post.save(update_fields=["platform_extra", "updated_at"])
+
+        engine = PublishEngine()
+        with patch.object(
+            PublishEngine,
+            "_dispatch_to_provider",
+            return_value={
+                "success": True,
+                "platform_post_id": "page-1_post-1",
+                "platform_extra_updates": {
+                    "facebook_upstream_ids": {
+                        "insights_post_id": "page-1_post-1",
+                        "feed_post_id": "page-1_post-1",
+                        "video_id": "video-1",
+                    }
+                },
+            },
+        ):
+            result = engine._publish_platform_post(self.platform_post)
+
+        self.assertTrue(result["success"])
+        self.platform_post.refresh_from_db()
+        self.assertEqual(self.platform_post.status, PlatformPost.Status.PUBLISHED)
+        self.assertEqual(self.platform_post.platform_post_id, "page-1_post-1")
+        self.assertEqual(self.platform_post.platform_extra["existing"], "kept")
+        self.assertEqual(
+            self.platform_post.platform_extra["facebook_upstream_ids"],
+            {
+                "insights_post_id": "page-1_post-1",
+                "feed_post_id": "page-1_post-1",
+                "video_id": "video-1",
+            },
+        )

--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -389,10 +389,24 @@ class FacebookProvider(SocialProvider):
             json=payload,
         )
         data = resp.json()
+        video_id = data["id"]
+        video_fields: dict = {}
+        try:
+            video_fields = self._request(
+                "GET",
+                f"{BASE_URL}/{video_id}",
+                access_token=access_token,
+                params={"fields": "post_id,permalink_url"},
+            ).json()
+        except APIError as exc:
+            logger.debug("Facebook video %s post_id unavailable: %s", video_id, exc)
+
+        post_id = video_fields.get("post_id") or video_id
+        url = video_fields.get("permalink_url") or f"https://www.facebook.com/{post_id}"
         return PublishResult(
-            platform_post_id=data["id"],
-            url=f"https://www.facebook.com/{data['id']}",
-            extra=data,
+            platform_post_id=post_id,
+            url=url,
+            extra={**data, **video_fields, "video_id": video_id},
         )
 
     # ------------------------------------------------------------------

--- a/tests/providers/test_facebook.py
+++ b/tests/providers/test_facebook.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, call
 import pytest
 
 from providers.exceptions import PublishError
-from providers.facebook import FacebookProvider
+from providers.facebook import BASE_URL, FacebookProvider
 from providers.types import PostType, PublishContent
 
 
@@ -137,12 +137,14 @@ def test_publish_video_resolves_feed_post_id_for_analytics():
     provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
     provider._request = MagicMock(
         side_effect=[
-            _resp({"id": "video-1"}),
-            _resp(
-                {
-                    "post_id": "page-1_post-1",
-                    "permalink_url": "https://www.facebook.com/page-1/videos/video-1/",
-                }
+            MagicMock(json=MagicMock(return_value={"id": "video-1"})),
+            MagicMock(
+                json=MagicMock(
+                    return_value={
+                        "post_id": "page-1_post-1",
+                        "permalink_url": "https://www.facebook.com/page-1/videos/video-1/",
+                    }
+                )
             ),
         ]
     )
@@ -164,13 +166,13 @@ def test_publish_video_resolves_feed_post_id_for_analytics():
         [
             call(
                 "POST",
-                "https://graph.facebook.com/v25.0/page-1/videos",
+                f"{BASE_URL}/page-1/videos",
                 access_token="page-token",
                 json={"file_url": "https://cdn.example.com/clip.mp4", "description": "Video caption"},
             ),
             call(
                 "GET",
-                "https://graph.facebook.com/v25.0/video-1",
+                f"{BASE_URL}/video-1",
                 access_token="page-token",
                 params={"fields": "post_id,permalink_url"},
             ),

--- a/tests/providers/test_facebook.py
+++ b/tests/providers/test_facebook.py
@@ -133,6 +133,51 @@ def test_is_video_url_ignores_query_string():
     assert FacebookProvider._is_video_url("https://cdn.example.com/pic.jpg?X-Amz-Sig=abc") is False
 
 
+def test_publish_video_resolves_feed_post_id_for_analytics():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        side_effect=[
+            _resp({"id": "video-1"}),
+            _resp(
+                {
+                    "post_id": "page-1_post-1",
+                    "permalink_url": "https://www.facebook.com/page-1/videos/video-1/",
+                }
+            ),
+        ]
+    )
+
+    result = provider.publish_post(
+        "page-token",
+        PublishContent(
+            text="Video caption",
+            media_urls=["https://cdn.example.com/clip.mp4"],
+            post_type=PostType.VIDEO,
+            extra={"page_id": "page-1"},
+        ),
+    )
+
+    assert result.platform_post_id == "page-1_post-1"
+    assert result.url == "https://www.facebook.com/page-1/videos/video-1/"
+    assert result.extra["video_id"] == "video-1"
+    provider._request.assert_has_calls(
+        [
+            call(
+                "POST",
+                "https://graph.facebook.com/v25.0/page-1/videos",
+                access_token="page-token",
+                json={"file_url": "https://cdn.example.com/clip.mp4", "description": "Video caption"},
+            ),
+            call(
+                "GET",
+                "https://graph.facebook.com/v25.0/video-1",
+                access_token="page-token",
+                params={"fields": "post_id,permalink_url"},
+            ),
+        ]
+    )
+
+
 def test_publish_multi_photo_rejects_video_media():
     """Mixed image+video must fail with a clear error before any photo is staged."""
     provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})


### PR DESCRIPTION
## Summary

This PR stores the correct upstream Facebook post identifiers after publishing, so analytics imports can use the real Facebook feed post ID instead of a video/photo response ID or BrightBean internal UUID.

## Changes

- Resolve Facebook video publish responses to their associated `post_id`.
- Store Facebook upstream ID metadata in `PlatformPost.platform_extra.facebook_upstream_ids`.
- Preserve useful IDs such as `insights_post_id`, `feed_post_id`, `response_id`, `video_id`, and `photo_ids`.
- Update publisher flow to persist provider `extra` metadata after successful publish.
- Add/update Facebook provider tests for upstream post ID handling.

## Why

Facebook post insights must be requested using the real Facebook post ID. If we store the wrong ID, calls like `/{post_id}/insights` fail with errors such as:

```text
Tried accessing nonexisting field (insights)