### PR TITLE
fix: store Facebook upstream publish IDs

### DIFF
--- a/apps/publisher/engine.py
+++ b/apps/publisher/engine.py
@@ -220,6 +220,12 @@ class PublishEngine:
 
             if result["success"]:
                 platform_post.platform_post_id = result.get("platform_post_id", "")
+                platform_extra_updates = result.get("platform_extra_updates") or {}
+                if platform_extra_updates:
+                    platform_post.platform_extra = {
+                        **(platform_post.platform_extra or {}),
+                        **platform_extra_updates,
+                    }
                 platform_post.status = PlatformPost.Status.PUBLISHED
                 platform_post.published_at = timezone.now()
                 platform_post.save()
@@ -454,12 +460,30 @@ class PublishEngine:
                 "platform_post_id": result.platform_post_id,
                 "url": result.url,
                 "response": result.extra,
+                "platform_extra_updates": self._platform_extra_updates(platform, result),
             }
         finally:
             # Clean up temp files regardless of success/failure
             for path in temp_files:
                 with contextlib.suppress(OSError):
                     os.unlink(path)
+
+    @staticmethod
+    def _platform_extra_updates(platform: str, result) -> dict:
+        if platform != "facebook":
+            return {}
+
+        extra = result.extra or {}
+        upstream_ids = {"insights_post_id": result.platform_post_id}
+        if extra.get("post_id"):
+            upstream_ids["feed_post_id"] = extra["post_id"]
+        if extra.get("id"):
+            upstream_ids["response_id"] = extra["id"]
+        if extra.get("video_id"):
+            upstream_ids["video_id"] = extra["video_id"]
+        if extra.get("photo_ids"):
+            upstream_ids["photo_ids"] = extra["photo_ids"]
+        return {"facebook_upstream_ids": upstream_ids}
 
     @staticmethod
     def _resolve_post_type(

--- a/apps/publisher/tests.py
+++ b/apps/publisher/tests.py
@@ -195,6 +195,32 @@ class DispatchExtraInjectionTest(SimpleTestCase):
         _access_token, content = mock_provider.publish_post.call_args.args
         self.assertNotIn("author", content.extra)
 
+    @patch("apps.publisher.engine.get_provider")
+    @patch("apps.publisher.engine._resolve_publish_credentials", return_value={})
+    def test_facebook_dispatch_returns_upstream_id_metadata(self, _mock_creds, mock_get_provider):
+        engine, platform_post, mock_provider = _build_dispatch_mocks(
+            platform="facebook",
+            account_platform_id="page-1",
+        )
+        mock_provider.publish_post.return_value = PublishResult(
+            platform_post_id="page-1_post-1",
+            url="https://www.facebook.com/page-1_post-1",
+            extra={"id": "video-1", "post_id": "page-1_post-1", "video_id": "video-1"},
+        )
+        mock_get_provider.return_value = mock_provider
+
+        result = engine._dispatch_to_provider(platform_post)
+
+        self.assertEqual(
+            result["platform_extra_updates"]["facebook_upstream_ids"],
+            {
+                "insights_post_id": "page-1_post-1",
+                "feed_post_id": "page-1_post-1",
+                "response_id": "video-1",
+                "video_id": "video-1",
+            },
+        )
+
 
 class ResolvePublishCredentialsTest(SimpleTestCase):
     @patch("apps.publisher.engine.resolve_platform_credentials", return_value={"client_id": "id"})
@@ -292,6 +318,47 @@ class NonRetryableFailureTest(TestCase):
         self.assertEqual(self.platform_post.retry_count, 1)
         self.assertIsNotNone(self.platform_post.next_retry_at)
         self.assertEqual(PublishLog.objects.filter(platform_post=self.platform_post).count(), 1)
+
+    def test_success_persists_facebook_upstream_id_metadata(self):
+        from apps.composer.models import PlatformPost
+
+        self.account.platform = "facebook"
+        self.account.account_platform_id = "page-1"
+        self.account.save(update_fields=["platform", "account_platform_id", "updated_at"])
+        self.platform_post.platform_extra = {"existing": "kept"}
+        self.platform_post.save(update_fields=["platform_extra", "updated_at"])
+
+        engine = PublishEngine()
+        with patch.object(
+            PublishEngine,
+            "_dispatch_to_provider",
+            return_value={
+                "success": True,
+                "platform_post_id": "page-1_post-1",
+                "platform_extra_updates": {
+                    "facebook_upstream_ids": {
+                        "insights_post_id": "page-1_post-1",
+                        "feed_post_id": "page-1_post-1",
+                        "video_id": "video-1",
+                    }
+                },
+            },
+        ):
+            result = engine._publish_platform_post(self.platform_post)
+
+        self.assertTrue(result["success"])
+        self.platform_post.refresh_from_db()
+        self.assertEqual(self.platform_post.status, PlatformPost.Status.PUBLISHED)
+        self.assertEqual(self.platform_post.platform_post_id, "page-1_post-1")
+        self.assertEqual(self.platform_post.platform_extra["existing"], "kept")
+        self.assertEqual(
+            self.platform_post.platform_extra["facebook_upstream_ids"],
+            {
+                "insights_post_id": "page-1_post-1",
+                "feed_post_id": "page-1_post-1",
+                "video_id": "video-1",
+            },
+        )
 
 
 class PublishedPostLeavesQueueTest(TestCase):

--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -6,8 +6,10 @@ import logging
 from datetime import datetime
 from urllib.parse import urlencode, urlparse
 
+import httpx
+
 from .base import SocialProvider
-from .exceptions import APIError, OAuthError, PublishError
+from .exceptions import APIError, OAuthError, PublishError, RateLimitError
 from .types import (
     AccountMetrics,
     AccountProfile,
@@ -389,10 +391,24 @@ class FacebookProvider(SocialProvider):
             json=payload,
         )
         data = resp.json()
+        video_id = data["id"]
+        video_fields: dict = {}
+        try:
+            video_fields = self._request(
+                "GET",
+                f"{BASE_URL}/{video_id}",
+                access_token=access_token,
+                params={"fields": "post_id,permalink_url"},
+            ).json()
+        except (APIError, RateLimitError, httpx.HTTPError) as exc:
+            logger.debug("Facebook video %s post_id unavailable: %s", video_id, exc)
+
+        post_id = video_fields.get("post_id") or video_id
+        url = video_fields.get("permalink_url") or f"https://www.facebook.com/{post_id}"
         return PublishResult(
-            platform_post_id=data["id"],
-            url=f"https://www.facebook.com/{data['id']}",
-            extra=data,
+            platform_post_id=post_id,
+            url=url,
+            extra={**data, **video_fields, "video_id": video_id},
         )
 
     # ------------------------------------------------------------------

--- a/tests/providers/test_facebook.py
+++ b/tests/providers/test_facebook.py
@@ -1,9 +1,10 @@
 from unittest.mock import MagicMock, call
 
+import httpx
 import pytest
 
-from providers.exceptions import PublishError
-from providers.facebook import FacebookProvider
+from providers.exceptions import PublishError, RateLimitError
+from providers.facebook import BASE_URL, FacebookProvider
 from providers.types import PostType, PublishContent
 
 
@@ -131,6 +132,100 @@ def test_is_video_url_ignores_query_string():
     assert FacebookProvider._is_video_url("https://cdn.example.com/clip.mp4?X-Amz-Sig=abc&x=1") is True
     assert FacebookProvider._is_video_url("https://cdn.example.com/clip.MOV") is True
     assert FacebookProvider._is_video_url("https://cdn.example.com/pic.jpg?X-Amz-Sig=abc") is False
+
+
+def test_publish_video_resolves_feed_post_id_for_analytics():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        side_effect=[
+            MagicMock(json=MagicMock(return_value={"id": "video-1"})),
+            MagicMock(
+                json=MagicMock(
+                    return_value={
+                        "post_id": "page-1_post-1",
+                        "permalink_url": "https://www.facebook.com/page-1/videos/video-1/",
+                    }
+                )
+            ),
+        ]
+    )
+
+    result = provider.publish_post(
+        "page-token",
+        PublishContent(
+            text="Video caption",
+            media_urls=["https://cdn.example.com/clip.mp4"],
+            post_type=PostType.VIDEO,
+            extra={"page_id": "page-1"},
+        ),
+    )
+
+    assert result.platform_post_id == "page-1_post-1"
+    assert result.url == "https://www.facebook.com/page-1/videos/video-1/"
+    assert result.extra["video_id"] == "video-1"
+    provider._request.assert_has_calls(
+        [
+            call(
+                "POST",
+                f"{BASE_URL}/page-1/videos",
+                access_token="page-token",
+                json={"file_url": "https://cdn.example.com/clip.mp4", "description": "Video caption"},
+            ),
+            call(
+                "GET",
+                f"{BASE_URL}/video-1",
+                access_token="page-token",
+                params={"fields": "post_id,permalink_url"},
+            ),
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    "lookup_error",
+    [
+        RateLimitError("rate limited", platform="Facebook"),
+        httpx.ConnectError("connection failed"),
+    ],
+)
+def test_publish_video_treats_metadata_lookup_failures_as_best_effort(lookup_error):
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        side_effect=[
+            MagicMock(json=MagicMock(return_value={"id": "video-1"})),
+            lookup_error,
+        ]
+    )
+
+    result = provider.publish_post(
+        "page-token",
+        PublishContent(
+            text="Video caption",
+            media_urls=["https://cdn.example.com/clip.mp4"],
+            post_type=PostType.VIDEO,
+            extra={"page_id": "page-1"},
+        ),
+    )
+
+    assert result.platform_post_id == "video-1"
+    assert result.url == "https://www.facebook.com/video-1"
+    assert result.extra["video_id"] == "video-1"
+    provider._request.assert_has_calls(
+        [
+            call(
+                "POST",
+                f"{BASE_URL}/page-1/videos",
+                access_token="page-token",
+                json={"file_url": "https://cdn.example.com/clip.mp4", "description": "Video caption"},
+            ),
+            call(
+                "GET",
+                f"{BASE_URL}/video-1",
+                access_token="page-token",
+                params={"fields": "post_id,permalink_url"},
+            ),
+        ]
+    )
 
 
 def test_publish_multi_photo_rejects_video_media():


### PR DESCRIPTION
## What does this PR do?

Stores Facebook upstream publish identifiers returned during publishing so follow-up analytics can target the correct Facebook feed, video, photo, or response objects. Video publishing now resolves the feed `post_id` and permalink after upload, while the publish engine persists those IDs in `platform_extra["facebook_upstream_ids"]` without discarding existing metadata.

## Why?

Facebook video uploads can return a video object ID, while analytics and permalink flows often need the associated feed post ID. Keeping the relevant upstream IDs with the platform post gives later sync jobs a reliable source of truth instead of relying only on the saved `platform_post_id`.

## How to test

- `DJANGO_SETTINGS_MODULE=config.settings.test SECRET_KEY=test-secret-key-not-for-production DATABASE_URL=postgres://postgres:postgres@localhost:5432/brightbean_test DB_HOST=localhost DB_USER=postgres DB_PASSWORD=postgres .venv/bin/python -m pytest apps/publisher/tests.py tests/providers/test_facebook.py -vv --tb=short`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`

## Checklist

- [x] Tests pass (`pytest`)
- [x] Lint passes (`ruff check .` and `ruff format --check .`)
- [x] Documentation updated (if applicable)

No documentation changes were needed for this internal publishing metadata fix.