### PR TITLE
fix: meta analytics metrics

### DIFF
--- a/apps/analytics/derive.py
+++ b/apps/analytics/derive.py
@@ -24,6 +24,17 @@ class DerivedMetric:
     kind: str  # "count" | "percent" | "minutes"
 
 
+def calculate_engagement_rate(engagements: float, views: float | None = None, reach: float | None = None) -> float:
+    denominator = 0.0
+    if views and views > 0:
+        denominator = float(views)
+    elif reach and reach > 0:
+        denominator = float(reach)
+    if denominator <= 0:
+        return 0.0
+    return round((float(engagements) / denominator) * 100, 2)
+
+
 def _split(values: list[float], days: int) -> tuple[list[float], list[float]]:
     """Return (current, previous) windows of ``days`` length, latest-last."""
     if not values:
@@ -74,7 +85,10 @@ def engagement_rate(
     daily denom is available; otherwise the daily numerator only.
     """
     parts_keys = [k for k in series_by_metric if k in ENGAGEMENT_PARTS]
-    denom_key = next((d for d in ENGAGEMENT_DENOMINATORS if d in series_by_metric), None)
+    denom_key = next(
+        (d for d in ENGAGEMENT_DENOMINATORS if d in series_by_metric and sum(series_by_metric.get(d, [])[-days:]) > 0),
+        None,
+    )
 
     # Keep the full 2*days window through ``_split`` so the previous-period
     # numerator and denominator are both populated for the delta calc. The
@@ -86,26 +100,34 @@ def engagement_rate(
         aligned = [s + [0.0] * (max_len - len(s)) for s in aligned]
         parts_series_per_day = [sum(day_values) for day_values in zip(*aligned, strict=False)]
 
+    denom_series_by_metric = {d: list(series_by_metric.get(d, []))[-2 * days :] for d in ENGAGEMENT_DENOMINATORS}
     denom_series_per_day = list(series_by_metric.get(denom_key, []))[-2 * days :] if denom_key else []
 
     parts_cur, parts_prev = _split(parts_series_per_day, days)
     if denom_key:
-        denom_cur_total = sum(denom_series_per_day[-days:]) or 1.0
-        denom_prev_total = sum(denom_series_per_day[-2 * days : -days]) or 1.0
+        denom_cur_total = sum(denom_series_per_day[-days:])
+        denom_prev_total = sum(denom_series_per_day[-2 * days : -days])
     else:
-        denom_cur_total = float(fallback_followers) or 1.0
-        denom_prev_total = float(fallback_followers) or 1.0
+        denom_cur_total = float(fallback_followers)
+        denom_prev_total = float(fallback_followers)
 
-    rate_cur = (sum(parts_cur) / denom_cur_total) * 100
-    rate_prev = (sum(parts_prev) / denom_prev_total) * 100
+    rate_cur = (sum(parts_cur) / denom_cur_total) * 100 if denom_cur_total > 0 else 0.0
+    rate_prev = (sum(parts_prev) / denom_prev_total) * 100 if denom_prev_total > 0 else 0.0
     delta = ((rate_cur - rate_prev) / rate_prev) * 100 if rate_prev else 0.0
 
     # Sparkline = CURRENT window only.
     parts_cur_window = parts_series_per_day[-days:]
-    denom_cur_window = denom_series_per_day[-days:] if denom_series_per_day else []
-    if denom_cur_window and len(denom_cur_window) == len(parts_cur_window):
+    denom_cur_windows = {key: values[-days:] for key, values in denom_series_by_metric.items() if values}
+    if denom_cur_windows:
+
+        def daily_denominator(index: int) -> float:
+            return next(
+                (values[index] for values in denom_cur_windows.values() if index < len(values) and values[index] > 0),
+                0.0,
+            )
+
         sparkline = [
-            (parts_cur_window[i] / denom_cur_window[i]) * 100 if denom_cur_window[i] else 0.0
+            (parts_cur_window[i] / daily_denominator(i)) * 100 if daily_denominator(i) > 0 else 0.0
             for i in range(len(parts_cur_window))
         ]
     else:

--- a/apps/analytics/metrics.py
+++ b/apps/analytics/metrics.py
@@ -40,11 +40,11 @@ ACCOUNT_ONLY: set[str] = {"follows", "followers", "subscribers"}
 # plan are in place). Verified against each platform's published insights API.
 PLATFORM_METRICS: dict[str, list[str]] = {
     # IG media insights: reach, views (replaced impressions Apr-2025), likes,
-    # comments, saved, shares, total_interactions; follower growth at account level.
+    # comments, saved, shares, total_interactions; follows when daily deltas exist.
     "instagram": ["reach", "views", "likes", "comments", "saves", "shares", "follows", "engagement"],
     "instagram_login": ["reach", "views", "likes", "comments", "saves", "shares", "follows", "engagement"],
-    # FB post insights: impressions, reach (unique), reactions, comments, shares, clicks.
-    "facebook": ["impressions", "reach", "reactions", "comments", "shares", "clicks", "follows", "engagement"],
+    # FB post insights: media views, unique media views, reactions, comments, shares, clicks.
+    "facebook": ["views", "reach", "reactions", "comments", "shares", "clicks", "follows", "engagement"],
     # LinkedIn share statistics: impressions, reactions, comments, reposts, clicks, engagement.
     "linkedin_company": ["impressions", "reactions", "comments", "reposts", "clicks", "follows", "engagement"],
     # LinkedIn Personal: only socialActions counts (no impressions/reach per API).
@@ -118,7 +118,7 @@ ENGAGEMENT_PARTS: list[str] = [
 
 # Candidate denominators in priority order (first match wins). If none of
 # these exist on the platform, the engagement card is suppressed in the UI.
-ENGAGEMENT_DENOMINATORS: list[str] = ["reach", "impressions", "views", "plays"]
+ENGAGEMENT_DENOMINATORS: list[str] = ["views", "reach", "impressions", "plays"]
 
 
 def post_metrics_for(platform: str) -> list[str]:

--- a/apps/analytics/migrations/0002_snapshot_raw_errors.py
+++ b/apps/analytics/migrations/0002_snapshot_raw_errors.py
@@ -1,0 +1,30 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("analytics", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="accountinsightssnapshot",
+            name="errors",
+            field=models.JSONField(blank=True, default=dict),
+        ),
+        migrations.AddField(
+            model_name="accountinsightssnapshot",
+            name="raw",
+            field=models.JSONField(blank=True, default=dict),
+        ),
+        migrations.AddField(
+            model_name="postinsightssnapshot",
+            name="errors",
+            field=models.JSONField(blank=True, default=dict),
+        ),
+        migrations.AddField(
+            model_name="postinsightssnapshot",
+            name="raw",
+            field=models.JSONField(blank=True, default=dict),
+        ),
+    ]

--- a/apps/analytics/models.py
+++ b/apps/analytics/models.py
@@ -27,6 +27,8 @@ class AccountInsightsSnapshot(models.Model):
     # Stored as float so we can hold both counts (integers) and rates (e.g.
     # avg_view_pct, engagement). Templates format based on metrics.METRICS[kind].
     value = models.FloatField(default=0.0)
+    raw = models.JSONField(default=dict, blank=True)
+    errors = models.JSONField(default=dict, blank=True)
     captured_at = models.DateTimeField(auto_now=True)
 
     class Meta:
@@ -56,6 +58,8 @@ class PostInsightsSnapshot(models.Model):
     metric_key = models.CharField(max_length=40)
     date = models.DateField()
     value = models.FloatField(default=0.0)
+    raw = models.JSONField(default=dict, blank=True)
+    errors = models.JSONField(default=dict, blank=True)
     captured_at = models.DateTimeField(auto_now=True)
 
     class Meta:

--- a/apps/analytics/services.py
+++ b/apps/analytics/services.py
@@ -436,6 +436,50 @@ def follower_growth_metric(
         series = series_map[growth_metric]
     else:
         series = _series_for(account, growth_metric, timezone.now().date(), days)
+    if growth_metric == "followers":
+        end = timezone.now().date()
+        current_start = end - timedelta(days=days - 1)
+        previous_start = end - timedelta(days=(2 * days) - 1)
+        rows = list(
+            AccountInsightsSnapshot.objects.filter(
+                social_account=account,
+                metric_key=growth_metric,
+                date__gte=previous_start,
+                date__lte=end,
+            )
+            .order_by("date")
+            .values_list("date", "value")
+        )
+
+        def window_delta(start: dt_date, stop: dt_date) -> float:
+            values = [value for day, value in rows if start <= day <= stop]
+            if len(values) < 2:
+                return 0.0
+            return max(float(values[-1]) - float(values[0]), 0.0)
+
+        cur_val = window_delta(current_start, end)
+        prev_val = window_delta(previous_start, current_start - timedelta(days=1))
+        delta = ((cur_val - prev_val) / prev_val) * 100 if prev_val else 0.0
+        by_day = {day: float(value) for day, value in rows}
+        previous_value = next(
+            (float(value) for day, value in reversed(rows) if day < current_start),
+            None,
+        )
+        daily_series: list[float] = []
+        for i in range(days):
+            day = current_start + timedelta(days=i)
+            value = by_day.get(day)
+            if value is None:
+                daily_series.append(0.0)
+                continue
+            daily_series.append(max(value - previous_value, 0.0) if previous_value is not None else 0.0)
+            previous_value = value
+        return growth_metric, DerivedMetric(
+            value=cur_val,
+            delta=round(delta, 1),
+            series=daily_series,
+            kind=kind_of(growth_metric),
+        )
     return growth_metric, derive(series, days, kind_of(growth_metric))
 
 

--- a/apps/analytics/tasks.py
+++ b/apps/analytics/tasks.py
@@ -22,6 +22,7 @@ import contextlib
 import logging
 from datetime import date as dt_date
 from datetime import timedelta
+from uuid import UUID
 
 from background_task import background
 from django.db import transaction
@@ -182,6 +183,27 @@ def _post_metrics_to_dict(metrics, platform: str) -> dict[str, float]:
         if v is not None:
             with contextlib.suppress(TypeError, ValueError):
                 out[dest_key] = float(v)
+    from .metrics import PLATFORM_METRICS
+
+    if "engagement" in PLATFORM_METRICS.get(platform, []):
+        from .derive import calculate_engagement_rate
+
+        engagement_parts = (
+            out.get("likes", 0.0)
+            + out.get("reactions", 0.0)
+            + out.get("comments", 0.0)
+            + out.get("replies", 0.0)
+            + out.get("shares", 0.0)
+            + out.get("reposts", 0.0)
+            + out.get("saves", 0.0)
+            + out.get("clicks", 0.0)
+            + out.get("outbound", 0.0)
+        )
+        out["engagement"] = calculate_engagement_rate(
+            engagement_parts,
+            views=out.get("views", 0.0),
+            reach=out.get("reach", 0.0),
+        )
     return out
 
 
@@ -253,6 +275,8 @@ def _resolve_provider(account):
             }
         except MastodonAppRegistration.DoesNotExist:
             pass
+    elif account.platform == "facebook":
+        credentials = {**credentials, "page_id": account.account_platform_id}
     elif account.platform == "instagram":
         credentials = {**credentials, "ig_user_id": account.account_platform_id}
     return get_provider(account.platform, credentials)
@@ -278,7 +302,14 @@ def _is_insufficient_scope(exc: Exception) -> bool:
     )
 
 
-def _write_account_snapshot(account, metric_values: dict[str, float], on_date: dt_date) -> int:
+def _write_account_snapshot(
+    account,
+    metric_values: dict[str, float],
+    on_date: dt_date,
+    *,
+    raw: dict | None = None,
+    errors: dict | None = None,
+) -> int:
     from .models import AccountInsightsSnapshot
 
     if not metric_values:
@@ -289,13 +320,20 @@ def _write_account_snapshot(account, metric_values: dict[str, float], on_date: d
             social_account=account,
             metric_key=key,
             date=on_date,
-            defaults={"value": value},
+            defaults={"value": value, "raw": raw or {}, "errors": errors or {}},
         )
         count += 1
     return count
 
 
-def _write_post_snapshot(post, metric_values: dict[str, float], on_date: dt_date) -> int:
+def _write_post_snapshot(
+    post,
+    metric_values: dict[str, float],
+    on_date: dt_date,
+    *,
+    raw: dict | None = None,
+    errors: dict | None = None,
+) -> int:
     from .models import PostInsightsSnapshot
 
     if not metric_values:
@@ -306,7 +344,7 @@ def _write_post_snapshot(post, metric_values: dict[str, float], on_date: dt_date
             platform_post=post,
             metric_key=key,
             date=on_date,
-            defaults={"value": value},
+            defaults={"value": value, "raw": raw or {}, "errors": errors or {}},
         )
         count += 1
     return count
@@ -382,7 +420,15 @@ def _sync_account_metrics(account, on_date: dt_date) -> None:
                 _mark_needs_reconnect(account)
             logger.warning("get_account_metrics failed for %s on %s: %s", account, target, exc)
             return
-        _write_account_snapshot(account, _account_metrics_to_dict(metrics, account.platform), target)
+        _refresh_follower_count(account, metrics)
+        extra = getattr(metrics, "extra", {}) or {}
+        _write_account_snapshot(
+            account,
+            _account_metrics_to_dict(metrics, account.platform),
+            target,
+            raw=extra.get("raw_insights", {}),
+            errors=extra.get("insight_errors", {}),
+        )
 
     if account.platform == "youtube":
         _sync_youtube_post_analytics(account, provider, on_date)
@@ -445,12 +491,26 @@ def _sync_youtube_post_analytics(account, provider, on_date: dt_date) -> None:
         post = posts_by_pid.get(pid)
         if post is None:
             continue
-        _write_post_snapshot(post, _post_metrics_to_dict(metrics, "youtube"), on_date)
+        extra = getattr(metrics, "extra", {}) or {}
+        _write_post_snapshot(
+            post,
+            _post_metrics_to_dict(metrics, "youtube"),
+            on_date,
+            raw=extra.get("raw_insights", extra),
+            errors=extra.get("insight_errors", {}),
+        )
 
 
 def _sync_post_metrics(post, on_date: dt_date) -> None:
     """Fetch this post's current metrics and write today's snapshot rows."""
     account = post.social_account
+    if account.platform in {"facebook", "instagram", "instagram_login"} and _looks_like_uuid(post.platform_post_id):
+        logger.warning(
+            "Skipping %s analytics for PlatformPost %s because platform_post_id looks like an internal UUID.",
+            account.platform,
+            post.id,
+        )
+        return
     provider = _resolve_provider(account)
     try:
         metrics = provider.get_post_metrics(account.oauth_access_token, post.platform_post_id)
@@ -461,7 +521,39 @@ def _sync_post_metrics(post, on_date: dt_date) -> None:
             _mark_needs_reconnect(account)
         logger.warning("get_post_metrics failed for post %s (%s): %s", post.id, account.platform, exc)
         return
-    _write_post_snapshot(post, _post_metrics_to_dict(metrics, account.platform), on_date)
+    extra = getattr(metrics, "extra", {}) or {}
+    _write_post_snapshot(
+        post,
+        _post_metrics_to_dict(metrics, account.platform),
+        on_date,
+        raw={
+            "fields": extra.get("raw_fields", {}),
+            "insights": extra.get("raw_insights", {}),
+            "insight_post_id": extra.get("insight_post_id"),
+            "attempted_insight_post_ids": extra.get("attempted_insight_post_ids", []),
+        },
+        errors=extra.get("insight_errors", {}),
+    )
+
+
+def _looks_like_uuid(value: str) -> bool:
+    if not value:
+        return False
+    try:
+        UUID(str(value))
+    except (TypeError, ValueError):
+        return False
+    return True
+
+
+def _refresh_follower_count(account, metrics) -> None:
+    followers = getattr(metrics, "followers", 0) or 0
+    if followers <= 0 and account.follower_count != 0:
+        return
+    if followers == account.follower_count:
+        return
+    account.follower_count = followers
+    account.save(update_fields=["follower_count", "updated_at"])
 
 
 def _mark_needs_reconnect(account):

--- a/development_specs/meta-analytics-manual-tests.md
+++ b/development_specs/meta-analytics-manual-tests.md
@@ -1,0 +1,55 @@
+# Meta Analytics Manual Test Plan
+
+Use a Page/Instagram account that has granted the analytics scopes and replace
+IDs/tokens with real values.
+
+## Facebook Page
+
+```text
+/{page_id}/insights?metric=page_media_view,page_total_media_view_unique,page_follows,page_post_engagements&period=day&since={since}&until={until}
+```
+
+## Facebook Post
+
+```text
+/{facebook_post_id}/insights?metric=post_media_view,post_total_media_view_unique,post_clicks,post_reactions_by_type_total
+```
+
+## Facebook Post Fields
+
+```text
+/{facebook_post_id}?fields=id,message,created_time,permalink_url,full_picture,shares,comments.limit(0).summary(true),reactions.limit(0).summary(true)
+```
+
+## Instagram User
+
+```text
+/{ig_user_id}?fields=id,username,name,profile_picture_url,followers_count,media_count
+```
+
+## Instagram Account Insights
+
+```text
+/{ig_user_id}/insights?metric=reach,views,profile_views,accounts_engaged,total_interactions&period=day&since={since}&until={until}
+```
+
+## Instagram Media Fields
+
+```text
+/{ig_user_id}/media?fields=id,caption,media_type,media_product_type,media_url,thumbnail_url,permalink,timestamp,like_count,comments_count
+```
+
+## Instagram Media Insights
+
+```text
+/{ig_media_id}/insights?metric=reach,views,likes,comments,saved,shares,total_interactions
+```
+
+Expected UI checks:
+
+- Facebook shows Views, not Impressions.
+- Facebook uses Reactions, not Likes.
+- Instagram shows Views.
+- Engagement rate is 0 when views and reach are 0.
+- Unsupported metrics log warnings and do not stop the dashboard from loading.
+- 7D, 30D, and 90D filters update totals and chart data.

--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -8,6 +8,7 @@ from urllib.parse import urlencode, urlparse
 
 from .base import SocialProvider
 from .exceptions import APIError, OAuthError, PublishError
+from .meta_insights import fetch_insights_safe, parse_insights_response
 from .types import (
     AccountMetrics,
     AccountProfile,
@@ -26,9 +27,33 @@ from .types import (
 
 logger = logging.getLogger(__name__)
 
-BASE_URL = "https://graph.facebook.com/v21.0"
-OAUTH_URL = "https://www.facebook.com/v21.0/dialog/oauth"
+BASE_URL = "https://graph.facebook.com/v25.0"
+OAUTH_URL = "https://www.facebook.com/v25.0/dialog/oauth"
 TOKEN_URL = f"{BASE_URL}/oauth/access_token"
+FACEBOOK_PAGE_INSIGHTS = [
+    "page_media_view",
+    "page_total_media_view_unique",
+    "page_daily_follows_unique",
+    "page_follows",
+    "page_post_engagements",
+]
+FACEBOOK_POST_INSIGHTS = [
+    "post_media_view",
+    "post_total_media_view_unique",
+    "post_clicks",
+    "post_reactions_by_type_total",
+]
+FACEBOOK_POST_FIELDS = [
+    "id",
+    "message",
+    "created_time",
+    "permalink_url",
+    "full_picture",
+    "post_id",
+    "shares",
+    "comments.limit(0).summary(true)",
+    "reactions.limit(0).summary(true)",
+]
 
 # Facebook caps the ``attached_media`` array on a single feed post. Larger sets
 # must use the album-creation flow, which this provider does not implement.
@@ -39,7 +64,7 @@ VIDEO_URL_SUFFIXES = (".mp4", ".mov")
 
 
 class FacebookProvider(SocialProvider):
-    """Facebook Graph API v21.0 provider."""
+    """Facebook Graph API v25.0 provider."""
 
     def __init__(self, credentials: dict | None = None):
         creds = dict(credentials or {})
@@ -91,9 +116,8 @@ class FacebookProvider(SocialProvider):
 
     @property
     def analytics_only_scopes(self) -> list[str]:
-        # ``read_insights`` is required for page-level account insights
-        # (page_impressions_unique, page_daily_follows). Only requested in
-        # OAuth when this platform's analytics is enabled.
+        # ``read_insights`` is required for page/post insights. Only requested
+        # in OAuth when this platform's analytics is enabled.
         return ["read_insights"]
 
     @property
@@ -210,7 +234,7 @@ class FacebookProvider(SocialProvider):
             "GET",
             f"{BASE_URL}/me/accounts",
             access_token=access_token,
-            params={"fields": "id,name,access_token,category,picture"},
+            params={"fields": "id,name,access_token,category,picture,followers_count"},
         )
         data = resp.json()
         if "error" in data:
@@ -233,6 +257,7 @@ class FacebookProvider(SocialProvider):
                     "access_token": page.get("access_token", ""),
                     "category": page.get("category", ""),
                     "picture": picture_url,
+                    "followers_count": page.get("followers_count", 0),
                 }
             )
         return pages
@@ -286,11 +311,8 @@ class FacebookProvider(SocialProvider):
             json=payload,
         )
         data = resp.json()
-        return PublishResult(
-            platform_post_id=data["id"],
-            url=f"https://www.facebook.com/{data.get('post_id', data['id'])}",
-            extra=data,
-        )
+        post_id = data.get("post_id", data["id"])
+        return PublishResult(platform_post_id=post_id, url=f"https://www.facebook.com/{post_id}", extra=data)
 
     def _publish_multi_photo(self, access_token: str, page_id: str, content: PublishContent) -> PublishResult:
         urls = content.media_urls
@@ -414,61 +436,146 @@ class FacebookProvider(SocialProvider):
     # ------------------------------------------------------------------
 
     def get_post_metrics(self, access_token: str, post_id: str) -> PostMetrics:
-        metrics = [
-            "post_impressions",
-            "post_engaged_users",
-            "post_clicks",
-            "post_reactions_by_type_total",
-        ]
-        resp = self._request(
-            "GET",
-            f"{BASE_URL}/{post_id}/insights",
-            access_token=access_token,
-            params={"metric": ",".join(metrics)},
-        )
-        data = resp.json()
-        values: dict = {}
-        for entry in data.get("data", []):
-            name = entry.get("name", "")
-            val = entry.get("values", [{}])[0].get("value", 0)
-            values[name] = val
+        fields, insight_candidates = self._resolve_post_fields(access_token, post_id)
+        values, errors, insight_post_id = self._get_post_insights(access_token, insight_candidates)
 
         reactions = values.get("post_reactions_by_type_total", {})
-        total_likes = reactions.get("like", 0) + reactions.get("love", 0) if isinstance(reactions, dict) else 0
+        if isinstance(reactions, dict) and reactions:
+            reactions_total = sum(reactions.values())
+        else:
+            reactions_total = fields.get("reactions", {}).get("summary", {}).get("total_count", 0)
+
+        comments = self._summary_total(fields, "comments")
+        shares = self._share_count(fields)
 
         return PostMetrics(
-            impressions=values.get("post_impressions", 0),
-            engagements=values.get("post_engaged_users", 0),
+            reach=values.get("post_total_media_view_unique", 0),
             clicks=values.get("post_clicks", 0),
-            likes=total_likes,
-            extra={"raw_insights": values},
+            likes=0,
+            comments=comments,
+            shares=shares,
+            video_views=values.get("post_media_view", 0),
+            extra={
+                "reactions": reactions_total,
+                "raw_fields": fields,
+                "raw_insights": values,
+                "insight_errors": errors,
+                "insight_post_id": insight_post_id,
+                "attempted_insight_post_ids": insight_candidates,
+            },
         )
+
+    def _resolve_post_fields(self, access_token: str, post_id: str) -> tuple[dict, list[str]]:
+        fields = self._get_post_fields(access_token, post_id)
+        candidate_ids = [fields.get("post_id")]
+        page_id = self.credentials.get("page_id")
+        if page_id and "_" not in str(post_id):
+            candidate_ids.append(f"{page_id}_{post_id}")
+        candidate_ids.append(post_id)
+
+        deduped_candidate_ids = list(dict.fromkeys(str(candidate_id) for candidate_id in candidate_ids if candidate_id))
+        best_fields = fields
+
+        for candidate_id in deduped_candidate_ids:
+            if not candidate_id or candidate_id == post_id:
+                continue
+            feed_fields = self._get_post_fields(access_token, candidate_id)
+            if feed_fields:
+                best_fields = {**fields, **feed_fields}
+                break
+        return best_fields, deduped_candidate_ids
+
+    def _get_post_insights(self, access_token: str, post_ids: list[str]) -> tuple[dict, dict[str, str], str]:
+        metric = ",".join(FACEBOOK_POST_INSIGHTS)
+        errors_by_post_id: dict[str, str] = {}
+        for post_id in post_ids:
+            endpoint = f"{BASE_URL}/{post_id}/insights"
+            try:
+                resp = self._request(
+                    "GET",
+                    endpoint,
+                    access_token=access_token,
+                    params={"metric": metric},
+                )
+            except APIError as exc:
+                errors_by_post_id[post_id] = str(exc)
+                logger.warning("Skipping unsupported Facebook post insights at %s: %s", endpoint, exc)
+                continue
+            return parse_insights_response(resp.json()), {}, post_id
+
+        error_text = "; ".join(f"{post_id}: {error}" for post_id, error in errors_by_post_id.items())
+        return {}, {key: error_text for key in FACEBOOK_POST_INSIGHTS}, post_ids[0] if post_ids else ""
+
+    def _get_post_fields(self, access_token: str, post_id: str) -> dict:
+        try:
+            fields_resp = self._request(
+                "GET",
+                f"{BASE_URL}/{post_id}",
+                access_token=access_token,
+                params={"fields": ",".join(FACEBOOK_POST_FIELDS)},
+            )
+            return fields_resp.json()
+        except APIError as exc:
+            logger.debug("Facebook post %s fields unavailable: %s", post_id, exc)
+            return {}
+
+    @staticmethod
+    def _summary_total(data: dict, key: str) -> int:
+        value = data.get(key, {})
+        if isinstance(value, int):
+            return value
+        if isinstance(value, dict):
+            return value.get("summary", {}).get("total_count", 0) or 0
+        return 0
+
+    @staticmethod
+    def _share_count(data: dict) -> int:
+        value = data.get("shares", {})
+        if isinstance(value, int):
+            return value
+        if isinstance(value, dict):
+            return value.get("count", 0) or 0
+        return 0
 
     def get_account_metrics(self, access_token: str, date_range: tuple[datetime, datetime]) -> AccountMetrics:
         page_id = self.credentials.get("page_id", "me")
-        metrics = ["page_impressions", "page_engaged_users", "page_fans"]
-        resp = self._request(
-            "GET",
-            f"{BASE_URL}/{page_id}/insights",
+        values, errors = fetch_insights_safe(
+            self._request,
+            platform=self.platform_name,
+            endpoint=f"{BASE_URL}/{page_id}/insights",
             access_token=access_token,
-            params={
-                "metric": ",".join(metrics),
+            metrics=FACEBOOK_PAGE_INSIGHTS,
+            base_params={
+                "period": "day",
                 "since": int(date_range[0].timestamp()),
                 "until": int(date_range[1].timestamp()),
             },
+            endpoint_type="page",
         )
-        data = resp.json()
-        values: dict = {}
-        for entry in data.get("data", []):
-            name = entry.get("name", "")
-            val = entry.get("values", [{}])[0].get("value", 0)
-            values[name] = val
+
+        followers = 0
+        try:
+            page_resp = self._request(
+                "GET",
+                f"{BASE_URL}/{page_id}",
+                access_token=access_token,
+                params={"fields": "followers_count"},
+            )
+            followers = page_resp.json().get("followers_count", 0)
+        except APIError as exc:
+            logger.debug("Facebook page %s follower count unavailable: %s", page_id, exc)
+        if not followers:
+            followers = values.get("page_follows", 0)
 
         return AccountMetrics(
-            impressions=values.get("page_impressions", 0),
-            reach=values.get("page_engaged_users", 0),
-            followers=values.get("page_fans", 0),
-            extra={"raw_insights": values},
+            followers=followers,
+            followers_gained=values.get("page_daily_follows_unique", 0),
+            reach=values.get("page_total_media_view_unique", 0),
+            extra={
+                "views": values.get("page_media_view", 0),
+                "raw_insights": values,
+                "insight_errors": errors,
+            },
         )
 
     # ------------------------------------------------------------------

--- a/providers/instagram.py
+++ b/providers/instagram.py
@@ -13,6 +13,7 @@ from urllib.parse import urlencode
 
 from .base import SocialProvider
 from .exceptions import APIError, OAuthError, PublishError
+from .meta_insights import fetch_insights_safe
 from .types import (
     AccountMetrics,
     AccountProfile,
@@ -31,9 +32,37 @@ from .types import (
 
 logger = logging.getLogger(__name__)
 
-BASE_URL = "https://graph.facebook.com/v21.0"
-OAUTH_URL = "https://www.facebook.com/v21.0/dialog/oauth"
+BASE_URL = "https://graph.facebook.com/v25.0"
+OAUTH_URL = "https://www.facebook.com/v25.0/dialog/oauth"
 TOKEN_URL = f"{BASE_URL}/oauth/access_token"
+INSTAGRAM_ACCOUNT_INSIGHTS = [
+    "reach",
+    "views",
+    "profile_views",
+    "accounts_engaged",
+    "total_interactions",
+]
+INSTAGRAM_MEDIA_INSIGHTS = [
+    "reach",
+    "views",
+    "likes",
+    "comments",
+    "saved",
+    "shares",
+    "total_interactions",
+]
+INSTAGRAM_MEDIA_FIELDS = [
+    "id",
+    "caption",
+    "media_type",
+    "media_product_type",
+    "media_url",
+    "thumbnail_url",
+    "permalink",
+    "timestamp",
+    "like_count",
+    "comments_count",
+]
 
 # Polling settings for container status checks
 CONTAINER_POLL_INTERVAL = 2  # seconds
@@ -41,7 +70,7 @@ CONTAINER_POLL_MAX_ATTEMPTS = 60
 
 
 class InstagramProvider(SocialProvider):
-    """Instagram Graph API provider (via Facebook Graph API v21.0)."""
+    """Instagram Graph API provider (via Facebook Graph API v25.0)."""
 
     def __init__(self, credentials: dict | None = None):
         creds = dict(credentials or {})
@@ -83,6 +112,8 @@ class InstagramProvider(SocialProvider):
             "instagram_content_publish",
             "instagram_manage_comments",
             "instagram_manage_insights",
+            "pages_show_list",
+            "pages_read_engagement",
         ]
 
     @property
@@ -169,7 +200,7 @@ class InstagramProvider(SocialProvider):
             "GET",
             f"{BASE_URL}/{ig_user_id}",
             access_token=access_token,
-            params={"fields": "id,username,name,profile_picture_url,followers_count"},
+            params={"fields": "id,username,name,profile_picture_url,followers_count,media_count"},
         )
         data = resp.json()
         return AccountProfile(
@@ -199,7 +230,7 @@ class InstagramProvider(SocialProvider):
             params={
                 "fields": (
                     "id,name,access_token,category,picture,"
-                    "instagram_business_account{id,username,name,profile_picture_url,followers_count}"
+                    "instagram_business_account{id,username,name,profile_picture_url,followers_count,media_count}"
                 ),
             },
         )
@@ -393,76 +424,68 @@ class InstagramProvider(SocialProvider):
     # ------------------------------------------------------------------
 
     def get_post_metrics(self, access_token: str, post_id: str) -> PostMetrics:
-        metrics = ["impressions", "reach", "engagement", "saved"]
-        resp = self._request(
-            "GET",
-            f"{BASE_URL}/{post_id}/insights",
+        fields = self._get_media_fields(access_token, post_id)
+        values, errors = fetch_insights_safe(
+            self._request,
+            platform=self.platform_name,
+            endpoint=f"{BASE_URL}/{post_id}/insights",
             access_token=access_token,
-            params={"metric": ",".join(metrics)},
+            metrics=INSTAGRAM_MEDIA_INSIGHTS,
+            endpoint_type="media",
         )
-        data = resp.json()
-        values: dict = {}
-        for entry in data.get("data", []):
-            name = entry.get("name", "")
-            val = entry.get("values", [{}])[0].get("value", 0)
-            values[name] = val
+        likes = values.get("likes", fields.get("like_count", 0))
+        comments = values.get("comments", fields.get("comments_count", 0))
 
         return PostMetrics(
-            impressions=values.get("impressions", 0),
             reach=values.get("reach", 0),
-            engagements=values.get("engagement", 0),
+            likes=likes,
+            comments=comments,
             saves=values.get("saved", 0),
-            extra={"raw_insights": values},
+            shares=values.get("shares", 0),
+            video_views=values.get("views", 0),
+            extra={
+                "total_interactions": values.get("total_interactions", 0),
+                "raw_fields": fields,
+                "raw_insights": values,
+                "insight_errors": errors,
+            },
         )
 
     def get_account_metrics(self, access_token: str, date_range: tuple[datetime, datetime]) -> AccountMetrics:
         ig_user_id = self.credentials.get("ig_user_id", "me")
         since = int(date_range[0].timestamp())
         until = int(date_range[1].timestamp())
-        metrics = ["reach", "follower_count", "profile_views"]
-        resp = self._request(
-            "GET",
-            f"{BASE_URL}/{ig_user_id}/insights",
+        values, errors = fetch_insights_safe(
+            self._request,
+            platform=self.platform_name,
+            endpoint=f"{BASE_URL}/{ig_user_id}/insights",
             access_token=access_token,
-            params={
-                "metric": ",".join(metrics),
+            metrics=INSTAGRAM_ACCOUNT_INSIGHTS,
+            base_params={
                 "period": "day",
                 "since": since,
                 "until": until,
             },
-        )
-        data = resp.json()
-        values: dict = {}
-        for entry in data.get("data", []):
-            name = entry.get("name", "")
-            val = entry.get("values", [{}])[0].get("value", 0)
-            values[name] = val
-
-        views_resp = self._request(
-            "GET",
-            f"{BASE_URL}/{ig_user_id}/insights",
-            access_token=access_token,
-            params={
-                "metric": "views",
-                "period": "day",
-                "metric_type": "total_value",
-                "since": since,
-                "until": until,
+            metric_params={
+                "views": {"metric_type": "total_value"},
+                "profile_views": {"metric_type": "total_value"},
+                "accounts_engaged": {"metric_type": "total_value"},
+                "total_interactions": {"metric_type": "total_value"},
             },
+            endpoint_type="account",
         )
-        views_data = views_resp.json()
-        for entry in views_data.get("data", []):
-            if entry.get("name") == "views":
-                values["views"] = entry.get("total_value", {}).get("value", 0)
-                break
+        followers = self._get_profile_fields(access_token, ig_user_id).get("followers_count", 0)
 
         return AccountMetrics(
             reach=values.get("reach", 0),
-            followers=values.get("follower_count", 0),
+            followers=followers,
             profile_views=values.get("profile_views", 0),
             extra={
                 "views": values.get("views", 0),
+                "accounts_engaged": values.get("accounts_engaged", 0),
+                "total_interactions": values.get("total_interactions", 0),
                 "raw_insights": values,
+                "insight_errors": errors,
             },
         )
 
@@ -541,3 +564,27 @@ class InstagramProvider(SocialProvider):
             "No Instagram Business Account found linked to any Facebook Page",
             platform=self.platform_name,
         )
+
+    def _get_profile_fields(self, access_token: str, ig_user_id: str) -> dict:
+        try:
+            return self._request(
+                "GET",
+                f"{BASE_URL}/{ig_user_id}",
+                access_token=access_token,
+                params={"fields": "id,username,name,profile_picture_url,followers_count,media_count"},
+            ).json()
+        except APIError as exc:
+            logger.debug("Instagram profile fields unavailable for %s: %s", ig_user_id, exc)
+            return {}
+
+    def _get_media_fields(self, access_token: str, media_id: str) -> dict:
+        try:
+            return self._request(
+                "GET",
+                f"{BASE_URL}/{media_id}",
+                access_token=access_token,
+                params={"fields": ",".join(INSTAGRAM_MEDIA_FIELDS)},
+            ).json()
+        except APIError as exc:
+            logger.debug("Instagram media fields unavailable for %s: %s", media_id, exc)
+            return {}

--- a/providers/instagram_login.py
+++ b/providers/instagram_login.py
@@ -20,6 +20,7 @@ from urllib.parse import urlencode
 
 from .base import SocialProvider
 from .exceptions import APIError, OAuthError, PublishError
+from .meta_insights import fetch_insights_safe
 from .types import (
     AccountMetrics,
     AccountProfile,
@@ -41,7 +42,35 @@ logger = logging.getLogger(__name__)
 AUTH_URL = "https://www.instagram.com/oauth/authorize"
 TOKEN_URL = "https://api.instagram.com/oauth/access_token"
 GRAPH_HOST = "https://graph.instagram.com"
-API_BASE = f"{GRAPH_HOST}/v21.0"
+API_BASE = f"{GRAPH_HOST}/v25.0"
+INSTAGRAM_ACCOUNT_INSIGHTS = [
+    "reach",
+    "views",
+    "profile_views",
+    "accounts_engaged",
+    "total_interactions",
+]
+INSTAGRAM_MEDIA_INSIGHTS = [
+    "reach",
+    "views",
+    "likes",
+    "comments",
+    "saved",
+    "shares",
+    "total_interactions",
+]
+INSTAGRAM_MEDIA_FIELDS = [
+    "id",
+    "caption",
+    "media_type",
+    "media_product_type",
+    "media_url",
+    "thumbnail_url",
+    "permalink",
+    "timestamp",
+    "like_count",
+    "comments_count",
+]
 
 # Container polling
 CONTAINER_POLL_INTERVAL = 2  # seconds
@@ -239,7 +268,7 @@ class InstagramLoginProvider(SocialProvider):
             f"{API_BASE}/me",
             access_token=access_token,
             params={
-                "fields": "user_id,username,name,profile_picture_url,followers_count,biography",
+                "fields": "user_id,username,name,profile_picture_url,followers_count,media_count,biography",
             },
         )
         data = resp.json()
@@ -396,75 +425,67 @@ class InstagramLoginProvider(SocialProvider):
     # ------------------------------------------------------------------
 
     def get_post_metrics(self, access_token: str, post_id: str) -> PostMetrics:
-        metrics = ["impressions", "reach", "engagement", "saved"]
-        resp = self._request(
-            "GET",
-            f"{API_BASE}/{post_id}/insights",
+        fields = self._get_media_fields(access_token, post_id)
+        values, errors = fetch_insights_safe(
+            self._request,
+            platform=self.platform_name,
+            endpoint=f"{API_BASE}/{post_id}/insights",
             access_token=access_token,
-            params={"metric": ",".join(metrics)},
+            metrics=INSTAGRAM_MEDIA_INSIGHTS,
+            endpoint_type="media",
         )
-        data = resp.json()
-        values: dict = {}
-        for entry in data.get("data", []):
-            name = entry.get("name", "")
-            val = entry.get("values", [{}])[0].get("value", 0)
-            values[name] = val
+        likes = values.get("likes", fields.get("like_count", 0))
+        comments = values.get("comments", fields.get("comments_count", 0))
 
         return PostMetrics(
-            impressions=values.get("impressions", 0),
             reach=values.get("reach", 0),
-            engagements=values.get("engagement", 0),
+            likes=likes,
+            comments=comments,
             saves=values.get("saved", 0),
-            extra={"raw_insights": values},
+            shares=values.get("shares", 0),
+            video_views=values.get("views", 0),
+            extra={
+                "total_interactions": values.get("total_interactions", 0),
+                "raw_fields": fields,
+                "raw_insights": values,
+                "insight_errors": errors,
+            },
         )
 
     def get_account_metrics(self, access_token: str, date_range: tuple[datetime, datetime]) -> AccountMetrics:
         since = int(date_range[0].timestamp())
         until = int(date_range[1].timestamp())
-        metrics = ["reach", "follower_count", "profile_views"]
-        resp = self._request(
-            "GET",
-            f"{API_BASE}/me/insights",
+        values, errors = fetch_insights_safe(
+            self._request,
+            platform=self.platform_name,
+            endpoint=f"{API_BASE}/me/insights",
             access_token=access_token,
-            params={
-                "metric": ",".join(metrics),
+            metrics=INSTAGRAM_ACCOUNT_INSIGHTS,
+            base_params={
                 "period": "day",
                 "since": since,
                 "until": until,
             },
-        )
-        data = resp.json()
-        values: dict = {}
-        for entry in data.get("data", []):
-            name = entry.get("name", "")
-            val = entry.get("values", [{}])[0].get("value", 0)
-            values[name] = val
-
-        views_resp = self._request(
-            "GET",
-            f"{API_BASE}/me/insights",
-            access_token=access_token,
-            params={
-                "metric": "views",
-                "period": "day",
-                "metric_type": "total_value",
-                "since": since,
-                "until": until,
+            metric_params={
+                "views": {"metric_type": "total_value"},
+                "profile_views": {"metric_type": "total_value"},
+                "accounts_engaged": {"metric_type": "total_value"},
+                "total_interactions": {"metric_type": "total_value"},
             },
+            endpoint_type="account",
         )
-        views_data = views_resp.json()
-        for entry in views_data.get("data", []):
-            if entry.get("name") == "views":
-                values["views"] = entry.get("total_value", {}).get("value", 0)
-                break
+        followers = self._get_profile_fields(access_token).get("followers_count", 0)
 
         return AccountMetrics(
             reach=values.get("reach", 0),
-            followers=values.get("follower_count", 0),
+            followers=followers,
             profile_views=values.get("profile_views", 0),
             extra={
                 "views": values.get("views", 0),
+                "accounts_engaged": values.get("accounts_engaged", 0),
+                "total_interactions": values.get("total_interactions", 0),
                 "raw_insights": values,
+                "insight_errors": errors,
             },
         )
 
@@ -512,6 +533,30 @@ class InstagramLoginProvider(SocialProvider):
         )
         data = resp.json()
         return ReplyResult(platform_message_id=data.get("id", ""), extra=data)
+
+    def _get_profile_fields(self, access_token: str) -> dict:
+        try:
+            return self._request(
+                "GET",
+                f"{API_BASE}/me",
+                access_token=access_token,
+                params={"fields": "user_id,username,name,profile_picture_url,followers_count,media_count"},
+            ).json()
+        except APIError as exc:
+            logger.debug("Instagram Login profile fields unavailable: %s", exc)
+            return {}
+
+    def _get_media_fields(self, access_token: str, media_id: str) -> dict:
+        try:
+            return self._request(
+                "GET",
+                f"{API_BASE}/{media_id}",
+                access_token=access_token,
+                params={"fields": ",".join(INSTAGRAM_MEDIA_FIELDS)},
+            ).json()
+        except APIError as exc:
+            logger.debug("Instagram Login media fields unavailable for %s: %s", media_id, exc)
+            return {}
 
     # ------------------------------------------------------------------
     # Token management

--- a/providers/meta_insights.py
+++ b/providers/meta_insights.py
@@ -1,0 +1,94 @@
+"""Helpers shared by Meta-backed providers."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from .exceptions import APIError
+
+logger = logging.getLogger(__name__)
+
+META_PERMISSION_ERROR_CODES = {10, 190, 200}
+META_PERMISSION_ERROR_MARKERS = (
+    "access token",
+    "authorization",
+    "authorized",
+    "insufficient",
+    "oauth",
+    "permission",
+    "permissions",
+    "scope",
+)
+
+
+def parse_insights_response(data: dict[str, Any]) -> dict[str, Any]:
+    values: dict[str, Any] = {}
+    for entry in data.get("data", []):
+        name = entry.get("name", "")
+        if not name:
+            continue
+        if "total_value" in entry:
+            values[name] = entry.get("total_value", {}).get("value", 0)
+            continue
+        values[name] = entry.get("values", [{}])[0].get("value", 0)
+    return values
+
+
+def is_meta_permission_error(exc: APIError) -> bool:
+    """Return true for Meta auth/scope errors that should trigger reconnect handling."""
+    error = exc.raw_response.get("error") if isinstance(exc.raw_response, dict) else None
+    error = error if isinstance(error, dict) else {}
+    code = error.get("code")
+    message = " ".join(
+        str(value)
+        for value in (
+            error.get("message"),
+            error.get("type"),
+            error.get("error_user_msg"),
+            exc,
+        )
+        if value
+    ).lower()
+
+    if code in META_PERMISSION_ERROR_CODES:
+        return True
+    if exc.status_code == 403:
+        return True
+    return any(marker in message for marker in META_PERMISSION_ERROR_MARKERS)
+
+
+def fetch_insights_safe(
+    request: Callable[..., Any],
+    *,
+    platform: str,
+    endpoint: str,
+    access_token: str,
+    metrics: list[str],
+    base_params: dict[str, Any] | None = None,
+    metric_params: dict[str, dict[str, Any]] | None = None,
+    endpoint_type: str = "insights",
+) -> tuple[dict[str, Any], dict[str, str]]:
+    """Fetch Meta insights one metric at a time so one invalid metric cannot fail all metrics."""
+    values: dict[str, Any] = {}
+    errors: dict[str, str] = {}
+    for metric in metrics:
+        params = {**(base_params or {}), **(metric_params or {}).get(metric, {}), "metric": metric}
+        try:
+            resp = request("GET", endpoint, access_token=access_token, params=params)
+        except APIError as exc:
+            if is_meta_permission_error(exc):
+                raise
+            errors[metric] = str(exc)
+            logger.warning(
+                "Skipping unsupported %s %s metric %s at %s: %s",
+                platform,
+                endpoint_type,
+                metric,
+                endpoint,
+                exc,
+            )
+            continue
+        values.update(parse_insights_response(resp.json()))
+    return values, errors

--- a/tests/providers/test_facebook.py
+++ b/tests/providers/test_facebook.py
@@ -2,9 +2,19 @@ from unittest.mock import MagicMock, call
 
 import pytest
 
-from providers.exceptions import PublishError
+from providers.exceptions import APIError, PublishError
 from providers.facebook import FacebookProvider
 from providers.types import PostType, PublishContent
+
+FACEBOOK_POST_FIELDS_PARAM = (
+    "id,message,created_time,permalink_url,full_picture,post_id,shares,"
+    "comments.limit(0).summary(true),reactions.limit(0).summary(true)"
+)
+FACEBOOK_POST_INSIGHTS_PARAM = "post_media_view,post_total_media_view_unique,post_clicks,post_reactions_by_type_total"
+
+
+def _resp(data):
+    return MagicMock(json=MagicMock(return_value=data))
 
 
 def test_publish_multi_photo_post_stages_photos_then_publishes_feed_post():
@@ -34,19 +44,19 @@ def test_publish_multi_photo_post_stages_photos_then_publishes_feed_post():
         [
             call(
                 "POST",
-                "https://graph.facebook.com/v21.0/page-1/photos",
+                "https://graph.facebook.com/v25.0/page-1/photos",
                 access_token="page-token",
                 json={"url": "https://cdn.example.com/one.jpg", "published": False},
             ),
             call(
                 "POST",
-                "https://graph.facebook.com/v21.0/page-1/photos",
+                "https://graph.facebook.com/v25.0/page-1/photos",
                 access_token="page-token",
                 json={"url": "https://cdn.example.com/two.jpg", "published": False},
             ),
             call(
                 "POST",
-                "https://graph.facebook.com/v21.0/page-1/feed",
+                "https://graph.facebook.com/v25.0/page-1/feed",
                 access_token="page-token",
                 json={
                     "attached_media": [{"media_fbid": "photo-1"}, {"media_fbid": "photo-2"}],
@@ -113,11 +123,11 @@ def test_publish_single_photo_uses_photos_edge_without_staging():
         ),
     )
 
-    assert result.platform_post_id == "photo-1"
+    assert result.platform_post_id == "page-1_post-1"
     assert result.url == "https://www.facebook.com/page-1_post-1"
     provider._request.assert_called_once_with(
         "POST",
-        "https://graph.facebook.com/v21.0/page-1/photos",
+        "https://graph.facebook.com/v25.0/page-1/photos",
         access_token="page-token",
         json={"url": "https://cdn.example.com/one.jpg", "message": "Single image caption"},
     )
@@ -189,8 +199,8 @@ def test_publish_multi_photo_cleans_up_staged_photos_on_feed_failure():
 
     provider._request.assert_has_calls(
         [
-            call("DELETE", "https://graph.facebook.com/v21.0/photo-1", access_token="page-token"),
-            call("DELETE", "https://graph.facebook.com/v21.0/photo-2", access_token="page-token"),
+            call("DELETE", "https://graph.facebook.com/v25.0/photo-1", access_token="page-token"),
+            call("DELETE", "https://graph.facebook.com/v25.0/photo-2", access_token="page-token"),
         ]
     )
 
@@ -216,4 +226,405 @@ def test_publish_multi_photo_cleans_up_after_partial_staging_failure():
             ),
         )
 
-    provider._request.assert_any_call("DELETE", "https://graph.facebook.com/v21.0/photo-1", access_token="page-token")
+    provider._request.assert_any_call("DELETE", "https://graph.facebook.com/v25.0/photo-1", access_token="page-token")
+
+
+def test_get_user_pages_includes_follower_count():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        return_value=MagicMock(
+            json=MagicMock(
+                return_value={
+                    "data": [
+                        {
+                            "id": "page-1",
+                            "name": "Page One",
+                            "access_token": "page-token",
+                            "category": "Media",
+                            "followers_count": 123,
+                            "picture": {"data": {"url": "https://example.com/avatar.jpg"}},
+                        }
+                    ]
+                }
+            )
+        )
+    )
+
+    pages = provider.get_user_pages("user-token")
+
+    assert pages[0]["followers_count"] == 123
+    provider._request.assert_called_once_with(
+        "GET",
+        "https://graph.facebook.com/v25.0/me/accounts",
+        access_token="user-token",
+        params={"fields": "id,name,access_token,category,picture,followers_count"},
+    )
+
+
+def test_get_profile_uses_user_safe_fields():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        return_value=_resp(
+            {
+                "id": "user-1",
+                "name": "User One",
+                "picture": {"data": {"url": "https://example.com/user.jpg"}},
+            }
+        )
+    )
+
+    profile = provider.get_profile("user-token")
+
+    assert profile.platform_id == "user-1"
+    assert profile.name == "User One"
+    assert profile.avatar_url == "https://example.com/user.jpg"
+    assert profile.follower_count == 0
+    provider._request.assert_called_once_with(
+        "GET",
+        "https://graph.facebook.com/v25.0/me",
+        access_token="user-token",
+        params={"fields": "id,name,picture"},
+    )
+
+
+def test_get_post_metrics_uses_v25_media_view_metrics_and_object_counts():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        side_effect=[
+            _resp(
+                {
+                    "id": "page-1_post-1",
+                    "shares": {"count": 7},
+                    "comments": {"summary": {"total_count": 5}},
+                    "reactions": {"summary": {"total_count": 9}},
+                }
+            ),
+            _resp(
+                {
+                    "data": [
+                        {"name": "post_media_view", "values": [{"value": 54}]},
+                        {"name": "post_total_media_view_unique", "values": [{"value": 42}]},
+                        {"name": "post_clicks", "values": [{"value": 4}]},
+                        {
+                            "name": "post_reactions_by_type_total",
+                            "values": [{"value": {"like": 3, "love": 2, "wow": 1}}],
+                        },
+                    ]
+                }
+            ),
+        ]
+    )
+
+    metrics = provider.get_post_metrics("page-token", "page-1_post-1")
+
+    assert metrics.video_views == 54
+    assert metrics.reach == 42
+    assert metrics.clicks == 4
+    assert metrics.likes == 0
+    assert metrics.comments == 5
+    assert metrics.shares == 7
+    assert metrics.extra["reactions"] == 6
+    provider._request.assert_has_calls(
+        [
+            call(
+                "GET",
+                "https://graph.facebook.com/v25.0/page-1_post-1",
+                access_token="page-token",
+                params={"fields": FACEBOOK_POST_FIELDS_PARAM},
+            ),
+            call(
+                "GET",
+                "https://graph.facebook.com/v25.0/page-1_post-1/insights",
+                access_token="page-token",
+                params={"metric": FACEBOOK_POST_INSIGHTS_PARAM},
+            ),
+        ]
+    )
+
+
+def test_get_post_metrics_keeps_object_counts_when_insights_edge_is_missing():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        side_effect=[
+            _resp(
+                {
+                    "id": "page-1_post-1",
+                    "shares": {"count": 3},
+                    "comments": {"summary": {"total_count": 2}},
+                    "reactions": {"summary": {"total_count": 4}},
+                }
+            ),
+            APIError("nonexisting field insights", platform="Facebook"),
+        ]
+    )
+
+    metrics = provider.get_post_metrics("page-token", "page-1_post-1")
+
+    assert metrics.video_views == 0
+    assert metrics.reach == 0
+    assert metrics.comments == 2
+    assert metrics.shares == 3
+    assert metrics.extra["reactions"] == 4
+    assert set(metrics.extra["insight_errors"]) == {
+        "post_media_view",
+        "post_total_media_view_unique",
+        "post_clicks",
+        "post_reactions_by_type_total",
+    }
+
+
+def test_get_post_metrics_accepts_integer_object_counts():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        side_effect=[
+            _resp({"id": "page-1_post-1", "shares": 3, "comments": 2}),
+            _resp({"data": []}),
+        ]
+    )
+
+    metrics = provider.get_post_metrics("page-token", "page-1_post-1")
+
+    assert metrics.comments == 2
+    assert metrics.shares == 3
+
+
+def test_get_post_metrics_resolves_photo_id_to_feed_post_for_comments_and_shares():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        side_effect=[
+            _resp({"id": "photo-1", "post_id": "page-1_post-1"}),
+            _resp(
+                {
+                    "id": "page-1_post-1",
+                    "shares": {"count": 2},
+                    "comments": {"summary": {"total_count": 4}},
+                    "reactions": {"summary": {"total_count": 5}},
+                }
+            ),
+            _resp(
+                {
+                    "data": [
+                        {"name": "post_media_view", "values": [{"value": 500}]},
+                        {"name": "post_total_media_view_unique", "values": [{"value": 300}]},
+                        {"name": "post_clicks", "values": [{"value": 20}]},
+                        {
+                            "name": "post_reactions_by_type_total",
+                            "values": [{"value": {"like": 10, "love": 3, "haha": 2}}],
+                        },
+                    ]
+                }
+            ),
+        ]
+    )
+
+    metrics = provider.get_post_metrics("page-token", "photo-1")
+
+    assert metrics.video_views == 500
+    assert metrics.reach == 300
+    assert metrics.clicks == 20
+    assert metrics.comments == 4
+    assert metrics.shares == 2
+    assert metrics.extra["reactions"] == 15
+    provider._request.assert_any_call(
+        "GET",
+        "https://graph.facebook.com/v25.0/page-1_post-1/insights",
+        access_token="page-token",
+        params={"metric": FACEBOOK_POST_INSIGHTS_PARAM},
+    )
+
+
+def test_get_post_metrics_tries_page_scoped_feed_id_for_numeric_object_id():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret", "page_id": "page-1"})
+    provider._request = MagicMock(
+        side_effect=[
+            _resp({"id": "1668168861075953"}),
+            _resp(
+                {
+                    "id": "page-1_1668168861075953",
+                    "shares": {"count": 8},
+                    "comments": {"summary": {"total_count": 6}},
+                    "reactions": {"summary": {"total_count": 3}},
+                }
+            ),
+            _resp(
+                {
+                    "data": [
+                        {"name": "post_media_view", "values": [{"value": 90}]},
+                        {"name": "post_total_media_view_unique", "values": [{"value": 70}]},
+                        {"name": "post_clicks", "values": [{"value": 5}]},
+                        {"name": "post_reactions_by_type_total", "values": [{"value": {"like": 3}}]},
+                    ]
+                }
+            ),
+        ]
+    )
+
+    metrics = provider.get_post_metrics("page-token", "1668168861075953")
+
+    assert metrics.video_views == 90
+    assert metrics.reach == 70
+    assert metrics.comments == 6
+    assert metrics.shares == 8
+    assert metrics.extra["insight_post_id"] == "page-1_1668168861075953"
+    provider._request.assert_any_call(
+        "GET",
+        "https://graph.facebook.com/v25.0/page-1_1668168861075953",
+        access_token="page-token",
+        params={"fields": FACEBOOK_POST_FIELDS_PARAM},
+    )
+    provider._request.assert_any_call(
+        "GET",
+        "https://graph.facebook.com/v25.0/page-1_1668168861075953/insights",
+        access_token="page-token",
+        params={"metric": FACEBOOK_POST_INSIGHTS_PARAM},
+    )
+
+
+def test_get_post_metrics_tries_next_candidate_when_feed_id_has_no_insights_edge():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret", "page_id": "page-1"})
+    provider._request = MagicMock(
+        side_effect=[
+            _resp({"id": "1668168861075953"}),
+            _resp({"id": "page-1_1668168861075953", "comments": {"summary": {"total_count": 2}}}),
+            APIError("nonexisting field insights", platform="Facebook"),
+            _resp(
+                {
+                    "data": [
+                        {"name": "post_media_view", "values": [{"value": 12}]},
+                        {"name": "post_total_media_view_unique", "values": [{"value": 10}]},
+                    ]
+                }
+            ),
+        ]
+    )
+
+    metrics = provider.get_post_metrics("page-token", "1668168861075953")
+
+    assert metrics.video_views == 12
+    assert metrics.reach == 10
+    assert metrics.comments == 2
+    assert metrics.extra["insight_post_id"] == "1668168861075953"
+    assert metrics.extra["attempted_insight_post_ids"] == ["page-1_1668168861075953", "1668168861075953"]
+    provider._request.assert_any_call(
+        "GET",
+        "https://graph.facebook.com/v25.0/page-1_1668168861075953/insights",
+        access_token="page-token",
+        params={"metric": FACEBOOK_POST_INSIGHTS_PARAM},
+    )
+    provider._request.assert_any_call(
+        "GET",
+        "https://graph.facebook.com/v25.0/1668168861075953/insights",
+        access_token="page-token",
+        params={"metric": FACEBOOK_POST_INSIGHTS_PARAM},
+    )
+
+
+def test_get_post_metrics_reports_batched_insights_failure_for_each_metric():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        side_effect=[
+            _resp({"id": "page-1_post-1", "comments": {"summary": {"total_count": 1}}}),
+            APIError("nonexisting field insights", platform="Facebook", raw_response={"error": {"code": 100}}),
+        ]
+    )
+
+    metrics = provider.get_post_metrics("page-token", "page-1_post-1")
+
+    assert metrics.video_views == 0
+    assert metrics.reach == 0
+    assert metrics.clicks == 0
+    assert metrics.comments == 1
+    assert metrics.extra["reactions"] == 0
+    assert "post_total_media_view_unique" in metrics.extra["insight_errors"]
+
+
+def test_get_account_metrics_uses_v25_page_media_view_metrics_and_followers_count():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret", "page_id": "page-1"})
+    provider._request = MagicMock(
+        side_effect=[
+            _resp({"data": [{"name": "page_media_view", "values": [{"value": 100}]}]}),
+            _resp({"data": [{"name": "page_total_media_view_unique", "values": [{"value": 80}]}]}),
+            _resp({"data": [{"name": "page_daily_follows_unique", "values": [{"value": 6}]}]}),
+            _resp({"data": [{"name": "page_follows", "values": [{"value": 532790}]}]}),
+            _resp({"data": [{"name": "page_post_engagements", "values": [{"value": 11}]}]}),
+            _resp({"followers_count": 250}),
+        ]
+    )
+
+    metrics = provider.get_account_metrics(
+        "page-token", (MagicMock(timestamp=lambda: 10), MagicMock(timestamp=lambda: 20))
+    )
+
+    assert metrics.followers == 250
+    assert metrics.followers_gained == 6
+    assert metrics.reach == 80
+    assert metrics.extra["views"] == 100
+    provider._request.assert_has_calls(
+        [
+            call(
+                "GET",
+                "https://graph.facebook.com/v25.0/page-1/insights",
+                access_token="page-token",
+                params={"metric": "page_media_view", "period": "day", "since": 10, "until": 20},
+            ),
+            call(
+                "GET",
+                "https://graph.facebook.com/v25.0/page-1/insights",
+                access_token="page-token",
+                params={"metric": "page_total_media_view_unique", "period": "day", "since": 10, "until": 20},
+            ),
+            call(
+                "GET",
+                "https://graph.facebook.com/v25.0/page-1/insights",
+                access_token="page-token",
+                params={"metric": "page_daily_follows_unique", "period": "day", "since": 10, "until": 20},
+            ),
+            call(
+                "GET",
+                "https://graph.facebook.com/v25.0/page-1/insights",
+                access_token="page-token",
+                params={"metric": "page_follows", "period": "day", "since": 10, "until": 20},
+            ),
+            call(
+                "GET",
+                "https://graph.facebook.com/v25.0/page-1/insights",
+                access_token="page-token",
+                params={"metric": "page_post_engagements", "period": "day", "since": 10, "until": 20},
+            ),
+            call(
+                "GET",
+                "https://graph.facebook.com/v25.0/page-1",
+                access_token="page-token",
+                params={"fields": "followers_count"},
+            ),
+        ]
+    )
+
+
+def test_get_account_metrics_uses_page_follows_only_as_total_fallback():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret", "page_id": "page-1"})
+    provider._request = MagicMock(
+        side_effect=[
+            _resp({"data": []}),
+            _resp({"data": []}),
+            _resp({"data": [{"name": "page_daily_follows_unique", "values": [{"value": 4}]}]}),
+            _resp({"data": [{"name": "page_follows", "values": [{"value": 532790}]}]}),
+            _resp({"data": []}),
+            APIError("followers_count unavailable", platform="Facebook"),
+        ]
+    )
+
+    metrics = provider.get_account_metrics(
+        "page-token", (MagicMock(timestamp=lambda: 10), MagicMock(timestamp=lambda: 20))
+    )
+
+    assert metrics.followers == 532790
+    assert metrics.followers_gained == 4
+
+
+def test_facebook_analytics_uuid_guard_detects_internal_ids():
+    from apps.analytics.tasks import _looks_like_uuid
+
+    assert _looks_like_uuid("0c77c88e-73f4-4986-a93f-87af966bb4ad") is True
+    assert _looks_like_uuid("123456789_987654321") is False
+    assert _looks_like_uuid("123456789") is False

--- a/tests/providers/test_instagram.py
+++ b/tests/providers/test_instagram.py
@@ -5,6 +5,10 @@ from providers.instagram import InstagramProvider
 from providers.instagram_login import InstagramLoginProvider
 
 
+def _resp(data):
+    return MagicMock(json=MagicMock(return_value=data))
+
+
 def test_get_user_pages_returns_linked_instagram_business_accounts():
     provider = InstagramProvider({"client_id": "id", "client_secret": "secret"})
     provider._request = MagicMock(
@@ -54,12 +58,12 @@ def test_get_user_pages_returns_linked_instagram_business_accounts():
     ]
     provider._request.assert_called_once_with(
         "GET",
-        "https://graph.facebook.com/v21.0/me/accounts",
+        "https://graph.facebook.com/v25.0/me/accounts",
         access_token="user-token",
         params={
             "fields": (
                 "id,name,access_token,category,picture,"
-                "instagram_business_account{id,username,name,profile_picture_url,followers_count}"
+                "instagram_business_account{id,username,name,profile_picture_url,followers_count,media_count}"
             ),
         },
     )
@@ -99,30 +103,12 @@ def test_account_metrics_use_current_instagram_insights_metrics():
     provider = InstagramProvider({"client_id": "id", "client_secret": "secret", "ig_user_id": "ig-1"})
     provider._request = MagicMock(
         side_effect=[
-            MagicMock(
-                json=MagicMock(
-                    return_value={
-                        "data": [
-                            {"name": "reach", "values": [{"value": 12}]},
-                            {"name": "follower_count", "values": [{"value": 34}]},
-                            {"name": "profile_views", "values": [{"value": 5}]},
-                        ]
-                    }
-                )
-            ),
-            MagicMock(
-                json=MagicMock(
-                    return_value={
-                        "data": [
-                            {
-                                "name": "views",
-                                "period": "day",
-                                "total_value": {"value": 67},
-                            }
-                        ]
-                    }
-                )
-            ),
+            _resp({"data": [{"name": "reach", "values": [{"value": 12}]}]}),
+            _resp({"data": [{"name": "views", "period": "day", "total_value": {"value": 67}}]}),
+            _resp({"data": [{"name": "profile_views", "values": [{"value": 5}]}]}),
+            _resp({"data": [{"name": "accounts_engaged", "values": [{"value": 8}]}]}),
+            _resp({"data": [{"name": "total_interactions", "values": [{"value": 9}]}]}),
+            _resp({"followers_count": 34}),
         ]
     )
 
@@ -143,10 +129,10 @@ def test_account_metrics_use_current_instagram_insights_metrics():
         [
             call(
                 "GET",
-                "https://graph.facebook.com/v21.0/ig-1/insights",
+                "https://graph.facebook.com/v25.0/ig-1/insights",
                 access_token="page-token",
                 params={
-                    "metric": "reach,follower_count,profile_views",
+                    "metric": "reach",
                     "period": "day",
                     "since": 1781740800,
                     "until": 1781827200,
@@ -154,7 +140,7 @@ def test_account_metrics_use_current_instagram_insights_metrics():
             ),
             call(
                 "GET",
-                "https://graph.facebook.com/v21.0/ig-1/insights",
+                "https://graph.facebook.com/v25.0/ig-1/insights",
                 access_token="page-token",
                 params={
                     "metric": "views",
@@ -164,38 +150,88 @@ def test_account_metrics_use_current_instagram_insights_metrics():
                     "until": 1781827200,
                 },
             ),
+            call(
+                "GET",
+                "https://graph.facebook.com/v25.0/ig-1/insights",
+                access_token="page-token",
+                params={
+                    "metric": "profile_views",
+                    "period": "day",
+                    "since": 1781740800,
+                    "until": 1781827200,
+                    "metric_type": "total_value",
+                },
+            ),
+            call(
+                "GET",
+                "https://graph.facebook.com/v25.0/ig-1/insights",
+                access_token="page-token",
+                params={
+                    "metric": "accounts_engaged",
+                    "period": "day",
+                    "since": 1781740800,
+                    "until": 1781827200,
+                    "metric_type": "total_value",
+                },
+            ),
+            call(
+                "GET",
+                "https://graph.facebook.com/v25.0/ig-1/insights",
+                access_token="page-token",
+                params={
+                    "metric": "total_interactions",
+                    "period": "day",
+                    "since": 1781740800,
+                    "until": 1781827200,
+                    "metric_type": "total_value",
+                },
+            ),
+            call(
+                "GET",
+                "https://graph.facebook.com/v25.0/ig-1",
+                access_token="page-token",
+                params={"fields": "id,username,name,profile_picture_url,followers_count,media_count"},
+            ),
         ]
     )
+
+
+def test_instagram_media_metrics_use_current_metrics_and_field_fallbacks():
+    provider = InstagramProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        side_effect=[
+            _resp({"id": "ig-media-1", "like_count": 12, "comments_count": 3}),
+            _resp({"data": [{"name": "reach", "values": [{"value": 250}]}]}),
+            _resp({"data": [{"name": "views", "values": [{"value": 400}]}]}),
+            _resp({"data": [{"name": "likes", "values": [{"value": 12}]}]}),
+            _resp({"data": [{"name": "comments", "values": [{"value": 3}]}]}),
+            _resp({"data": [{"name": "saved", "values": [{"value": 5}]}]}),
+            _resp({"data": [{"name": "shares", "values": [{"value": 2}]}]}),
+            _resp({"data": [{"name": "total_interactions", "values": [{"value": 22}]}]}),
+        ]
+    )
+
+    metrics = provider.get_post_metrics("page-token", "ig-media-1")
+
+    assert metrics.video_views == 400
+    assert metrics.reach == 250
+    assert metrics.likes == 12
+    assert metrics.comments == 3
+    assert metrics.saves == 5
+    assert metrics.shares == 2
+    assert metrics.extra["total_interactions"] == 22
 
 
 def test_instagram_login_account_metrics_use_current_insights_metrics():
     provider = InstagramLoginProvider({"client_id": "id", "client_secret": "secret"})
     provider._request = MagicMock(
         side_effect=[
-            MagicMock(
-                json=MagicMock(
-                    return_value={
-                        "data": [
-                            {"name": "reach", "values": [{"value": 12}]},
-                            {"name": "follower_count", "values": [{"value": 34}]},
-                            {"name": "profile_views", "values": [{"value": 5}]},
-                        ]
-                    }
-                )
-            ),
-            MagicMock(
-                json=MagicMock(
-                    return_value={
-                        "data": [
-                            {
-                                "name": "views",
-                                "period": "day",
-                                "total_value": {"value": 67},
-                            }
-                        ]
-                    }
-                )
-            ),
+            _resp({"data": [{"name": "reach", "values": [{"value": 12}]}]}),
+            _resp({"data": [{"name": "views", "period": "day", "total_value": {"value": 67}}]}),
+            _resp({"data": [{"name": "profile_views", "values": [{"value": 5}]}]}),
+            _resp({"data": [{"name": "accounts_engaged", "values": [{"value": 8}]}]}),
+            _resp({"data": [{"name": "total_interactions", "values": [{"value": 9}]}]}),
+            _resp({"followers_count": 34}),
         ]
     )
 
@@ -216,10 +252,10 @@ def test_instagram_login_account_metrics_use_current_insights_metrics():
         [
             call(
                 "GET",
-                "https://graph.instagram.com/v21.0/me/insights",
+                "https://graph.instagram.com/v25.0/me/insights",
                 access_token="ig-token",
                 params={
-                    "metric": "reach,follower_count,profile_views",
+                    "metric": "reach",
                     "period": "day",
                     "since": 1781740800,
                     "until": 1781827200,
@@ -227,7 +263,7 @@ def test_instagram_login_account_metrics_use_current_insights_metrics():
             ),
             call(
                 "GET",
-                "https://graph.instagram.com/v21.0/me/insights",
+                "https://graph.instagram.com/v25.0/me/insights",
                 access_token="ig-token",
                 params={
                     "metric": "views",
@@ -236,6 +272,48 @@ def test_instagram_login_account_metrics_use_current_insights_metrics():
                     "since": 1781740800,
                     "until": 1781827200,
                 },
+            ),
+            call(
+                "GET",
+                "https://graph.instagram.com/v25.0/me/insights",
+                access_token="ig-token",
+                params={
+                    "metric": "profile_views",
+                    "period": "day",
+                    "since": 1781740800,
+                    "until": 1781827200,
+                    "metric_type": "total_value",
+                },
+            ),
+            call(
+                "GET",
+                "https://graph.instagram.com/v25.0/me/insights",
+                access_token="ig-token",
+                params={
+                    "metric": "accounts_engaged",
+                    "period": "day",
+                    "since": 1781740800,
+                    "until": 1781827200,
+                    "metric_type": "total_value",
+                },
+            ),
+            call(
+                "GET",
+                "https://graph.instagram.com/v25.0/me/insights",
+                access_token="ig-token",
+                params={
+                    "metric": "total_interactions",
+                    "period": "day",
+                    "since": 1781740800,
+                    "until": 1781827200,
+                    "metric_type": "total_value",
+                },
+            ),
+            call(
+                "GET",
+                "https://graph.instagram.com/v25.0/me",
+                access_token="ig-token",
+                params={"fields": "user_id,username,name,profile_picture_url,followers_count,media_count"},
             ),
         ]
     )

--- a/tests/providers/test_meta_insights.py
+++ b/tests/providers/test_meta_insights.py
@@ -1,0 +1,62 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from providers.exceptions import APIError
+from providers.meta_insights import fetch_insights_safe
+
+
+def _resp(data):
+    return MagicMock(json=MagicMock(return_value=data))
+
+
+def test_fetch_insights_safe_skips_invalid_metric_errors():
+    request = MagicMock(
+        side_effect=[
+            APIError(
+                "Meta API error 400: invalid metric",
+                platform="Facebook",
+                status_code=400,
+                raw_response={"error": {"code": 100, "message": "Tried accessing nonexisting field insights"}},
+            ),
+            _resp({"data": [{"name": "page_media_view", "values": [{"value": 10}]}]}),
+        ]
+    )
+
+    values, errors = fetch_insights_safe(
+        request,
+        platform="Facebook",
+        endpoint="https://graph.facebook.com/v25.0/page-1/insights",
+        access_token="page-token",
+        metrics=["bad_metric", "page_media_view"],
+    )
+
+    assert values == {"page_media_view": 10}
+    assert set(errors) == {"bad_metric"}
+
+
+def test_fetch_insights_safe_reraises_permission_errors():
+    permission_error = APIError(
+        "Meta API error 400: missing permission",
+        platform="Facebook",
+        status_code=400,
+        raw_response={
+            "error": {
+                "code": 200,
+                "type": "OAuthException",
+                "message": "Permissions error: read_insights is required.",
+            }
+        },
+    )
+    request = MagicMock(side_effect=permission_error)
+
+    with pytest.raises(APIError) as excinfo:
+        fetch_insights_safe(
+            request,
+            platform="Facebook",
+            endpoint="https://graph.facebook.com/v25.0/page-1/insights",
+            access_token="page-token",
+            metrics=["page_media_view"],
+        )
+
+    assert excinfo.value is permission_error

--- a/tests/test_analytics_derive.py
+++ b/tests/test_analytics_derive.py
@@ -1,0 +1,62 @@
+from apps.analytics.derive import calculate_engagement_rate, engagement_rate
+
+
+def test_calculate_engagement_rate_cases():
+    assert calculate_engagement_rate(20, views=100, reach=50) == 20.0
+    assert calculate_engagement_rate(20, views=0, reach=200) == 10.0
+    assert calculate_engagement_rate(20, views=0, reach=0) == 0
+    assert calculate_engagement_rate(0, views=100, reach=100) == 0
+
+
+def test_engagement_rate_prefers_views_denominator():
+    metric = engagement_rate(
+        {
+            "views": [100],
+            "reach": [50],
+            "reactions": [20],
+        },
+        days=1,
+    )
+
+    assert metric.value == 20.0
+
+
+def test_engagement_rate_falls_back_to_reach_when_views_are_zero():
+    metric = engagement_rate(
+        {
+            "views": [0],
+            "reach": [200],
+            "reactions": [20],
+        },
+        days=1,
+    )
+
+    assert metric.value == 10.0
+
+
+def test_engagement_rate_returns_zero_without_denominator():
+    metric = engagement_rate(
+        {
+            "views": [0],
+            "reach": [0],
+            "reactions": [20],
+            "clicks": [4],
+        },
+        days=1,
+    )
+
+    assert metric.value == 0.0
+    assert metric.series == [0.0]
+
+
+def test_engagement_rate_returns_zero_without_engagements():
+    metric = engagement_rate(
+        {
+            "views": [100],
+            "reach": [100],
+            "reactions": [0],
+        },
+        days=1,
+    )
+
+    assert metric.value == 0.0


### PR DESCRIPTION
## Summary

Squashes the Facebook/Instagram analytics fixes from `heidisoft:fix/facebook-analytics-v25` into a single commit for upstream review.

## What changed

- Corrects Meta analytics metric mapping and derivation behavior for Facebook and Instagram.
- Adds raw error capture for analytics snapshots.
- Adds shared Meta Insights helpers and expands Facebook/Instagram provider tests.
- Adds manual verification notes for Meta analytics flows.

## Validation

- `.venv/bin/python -m pytest tests/providers/test_facebook.py tests/providers/test_instagram.py tests/test_analytics_derive.py -q`
- Result: 31 passed
