### PR TITLE
fix: resolve per-account provider credentials at all get_provider call sites

### DIFF
--- a/apps/inbox/management/commands/backfill_inbox.py
+++ b/apps/inbox/management/commands/backfill_inbox.py
@@ -51,9 +51,11 @@ class Command(BaseCommand):
 
         self.stdout.write(f"Backfilling {days} days of messages for {accounts.count()} account(s)...")
 
+        from apps.publisher.engine import _resolve_publish_credentials
+
         for account in accounts:
             try:
-                provider = get_provider(account.platform)
+                provider = get_provider(account.platform, _resolve_publish_credentials(account))
                 messages = provider.get_messages(
                     access_token=account.oauth_access_token,
                     since=since,

--- a/apps/inbox/tasks.py
+++ b/apps/inbox/tasks.py
@@ -59,8 +59,10 @@ class InboxSyncEngine:
 
     def _sync_account(self, account):
         """Sync messages for a single social account."""
+        from apps.publisher.engine import _resolve_publish_credentials
+
         try:
-            provider = get_provider(account.platform)
+            provider = get_provider(account.platform, _resolve_publish_credentials(account))
         except ValueError:
             logger.warning("No provider for platform %s", account.platform)
             return

--- a/apps/inbox/tests/test_sync.py
+++ b/apps/inbox/tests/test_sync.py
@@ -72,3 +72,41 @@ def test_first_message_on_quiet_account_still_notifies(connected_account):
         with patch.object(InboxSyncEngine, "_notify_new_message") as notify_new:
             InboxSyncEngine().sync_all()
         notify_new.assert_called_once()
+
+
+@pytest.mark.django_db
+def test_mastodon_sync_passes_per_account_instance_url(workspace):
+    # Regression: sync used to call get_provider(platform) with no credentials, so the
+    # federated MastodonProvider got instance_url="" and built scheme-less URLs like
+    # "/api/v1/notifications" -> httpx.UnsupportedProtocol. The account's instance_url
+    # must reach the provider. is_safe_url is patched so the SSRF check stays hermetic
+    # (it does a real DNS lookup otherwise).
+    from apps.social_accounts.models import MastodonAppRegistration
+
+    # Persisted so sync_all() picks it up; referenced only via the DB query.
+    SocialAccount.objects.create(
+        workspace=workspace,
+        platform="mastodon",
+        account_platform_id="masto-1",
+        account_name="Masto Test",
+        instance_url="https://mastodon.social",
+        oauth_access_token="tok",
+        connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+    )
+    MastodonAppRegistration.objects.create(
+        instance_url="https://mastodon.social",
+        client_id="cid",
+        client_secret="csecret",
+    )
+
+    with (
+        patch("apps.inbox.tasks.get_provider") as get_provider,
+        patch("apps.common.validators.is_safe_url", return_value=True),
+    ):
+        get_provider.return_value.get_messages.return_value = []
+        InboxSyncEngine().sync_all()
+
+    get_provider.assert_called_once()
+    platform, credentials = get_provider.call_args.args
+    assert platform == "mastodon"
+    assert credentials["instance_url"] == "https://mastodon.social"

--- a/apps/inbox/views.py
+++ b/apps/inbox/views.py
@@ -225,7 +225,9 @@ def send_reply(request, workspace_id, message_id):
 
     # Attempt to post reply via provider
     try:
-        provider = get_provider(account.platform)
+        from apps.publisher.engine import _resolve_publish_credentials
+
+        provider = get_provider(account.platform, _resolve_publish_credentials(account))
         result = provider.reply_to_message(
             access_token=account.oauth_access_token,
             message_id=message.platform_message_id,

--- a/apps/publisher/engine.py
+++ b/apps/publisher/engine.py
@@ -73,7 +73,15 @@ def _resolve_publish_credentials(account):
                 account.id,
             )
     elif platform == "bluesky" and account.instance_url:
-        credentials["pds_url"] = account.instance_url
+        from apps.common.validators import is_safe_url
+
+        if is_safe_url(account.instance_url):
+            credentials["pds_url"] = account.instance_url
+        else:
+            logger.warning(
+                "Bluesky PDS URL failed SSRF check for account %s",
+                account.id,
+            )
     elif platform == "instagram":
         credentials["ig_user_id"] = account.account_platform_id
 

--- a/apps/publisher/tests.py
+++ b/apps/publisher/tests.py
@@ -208,6 +208,32 @@ class ResolvePublishCredentialsTest(SimpleTestCase):
 
         self.assertEqual(credentials["ig_user_id"], "17841400000000000")
 
+    @patch("apps.common.validators.is_safe_url", return_value=True)
+    @patch("apps.publisher.engine.resolve_platform_credentials", return_value={})
+    def test_bluesky_safe_pds_url_is_injected(self, _mock_resolve, _mock_is_safe_url):
+        account = MagicMock()
+        account.platform = "bluesky"
+        account.instance_url = "https://pds.example.com"
+        account.workspace.organization_id = "org-1"
+
+        credentials = _resolve_publish_credentials(account)
+
+        self.assertEqual(credentials["pds_url"], "https://pds.example.com")
+
+    @patch("apps.common.validators.is_safe_url", return_value=False)
+    @patch("apps.publisher.engine.resolve_platform_credentials", return_value={})
+    def test_bluesky_unsafe_pds_url_is_rejected(self, _mock_resolve, _mock_is_safe_url):
+        # The Bluesky pds_url sets the outbound host, so a URL that fails the SSRF
+        # check must not reach the provider — parity with the Mastodon gate.
+        account = MagicMock()
+        account.platform = "bluesky"
+        account.instance_url = "http://169.254.169.254"
+        account.workspace.organization_id = "org-1"
+
+        credentials = _resolve_publish_credentials(account)
+
+        self.assertNotIn("pds_url", credentials)
+
 
 class NonRetryableFailureTest(TestCase):
     """_publish_platform_post must honor the exception's ``retryable`` flag."""

--- a/apps/social_accounts/tasks.py
+++ b/apps/social_accounts/tasks.py
@@ -27,27 +27,13 @@ def check_social_account_health(account_id: str):
         logger.warning("Health check: account %s not found, skipping", account_id)
         return
 
-    # Load app credentials (.env dominant, admin-entered org creds as fallback).
-    from apps.credentials.models import PlatformCredential, resolve_platform_credentials
+    # Resolve per-account credentials via the shared resolver: org/.env app creds
+    # plus per-account federation metadata (Mastodon instance_url behind an SSRF
+    # check, Bluesky pds_url, Instagram ig_user_id). Shared with the publish engine
+    # and inbox sync so every get_provider call resolves credentials identically.
+    from apps.publisher.engine import _resolve_publish_credentials
 
-    credentials = resolve_platform_credentials(account.platform, account.workspace.organization_id)
-
-    # For Mastodon, inject instance-specific client credentials
-    if account.platform == PlatformCredential.Platform.MASTODON and account.instance_url:
-        from .models import MastodonAppRegistration
-
-        try:
-            reg = MastodonAppRegistration.objects.get(instance_url=account.instance_url)
-            credentials = {
-                **credentials,
-                "instance_url": account.instance_url,
-                "client_id": reg.client_id,
-                "client_secret": reg.client_secret,
-            }
-        except MastodonAppRegistration.DoesNotExist:
-            pass
-    elif account.platform == PlatformCredential.Platform.INSTAGRAM:
-        credentials = {**credentials, "ig_user_id": account.account_platform_id}
+    credentials = _resolve_publish_credentials(account)
 
     try:
         provider = get_provider(account.platform, credentials)

--- a/apps/social_accounts/tests/test_tasks.py
+++ b/apps/social_accounts/tests/test_tasks.py
@@ -88,6 +88,33 @@ class TestCheckSocialAccountHealth:
         assert credentials["ig_user_id"] == "17841400000000000"
         mock_provider.get_profile.assert_called_once_with("page-token")
 
+    @patch("apps.common.validators.is_safe_url", return_value=True)
+    @patch("providers.get_provider")
+    def test_mastodon_health_check_injects_instance_url_without_registration(
+        self, mock_get_provider, _mock_is_safe_url, workspace
+    ):
+        # Regression: the old inline resolver set instance_url only *inside* the
+        # MastodonAppRegistration lookup, so an account with no registration row had
+        # instance_url dropped -> empty base URL. The shared resolver sets it first.
+        # is_safe_url is patched to keep the SSRF check off the network.
+        account = SocialAccount.objects.create(
+            workspace=workspace,
+            platform="mastodon",
+            account_platform_id="masto-1",
+            account_name="Masto",
+            instance_url="https://mastodon.social",
+            oauth_access_token="tok",
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+        mock_provider = MagicMock()
+        mock_provider.get_profile.return_value = _profile(platform_id="masto-1", name="Masto")
+        mock_get_provider.return_value = mock_provider
+
+        check_social_account_health.now(str(account.id))
+
+        _platform, credentials = mock_get_provider.call_args.args
+        assert credentials["instance_url"] == "https://mastodon.social"
+
     @patch("providers.get_provider")
     def test_failed_health_check_sets_error(self, mock_get_provider, connected_account):
         mock_provider = MagicMock()


### PR DESCRIPTION
## What does this PR do?

Makes every `get_provider(...)` call site resolve per-account credentials through the one shared resolver, and hardens that resolver. Three commits:

1. **`fix(inbox)`** — inbox sync, reply, and backfill now pass `_resolve_publish_credentials(account)` to `get_provider` instead of calling it with no credentials.
2. **`fix(social-accounts)`** — the health-check task drops its divergent inline credential block and reuses the shared resolver.
3. **`fix(publisher)`** — the resolver's Bluesky `pds_url` branch is now gated by `is_safe_url`, matching the Mastodon branch.

## Why?

- **Root cause (production error):** the inbox app called `get_provider(account.platform)` with no credentials, so the federated `MastodonProvider` received an empty `instance_url` and built scheme-less URLs like `/api/v1/notifications`, which httpx rejects with `UnsupportedProtocol`. Every other `get_provider` caller already resolved per-account credentials — the inbox app was the lone exception (sync, `send_reply`, and `backfill_inbox`).
- **Divergent copy:** `check_social_account_health` kept its own weaker credential logic — it dropped `instance_url` entirely when no `MastodonAppRegistration` row existed, and applied no SSRF check. Reusing `_resolve_publish_credentials` fixes both gaps and removes the duplication.
- **SSRF asymmetry:** the resolver's Bluesky branch set the outbound `pds_url` host straight from the user-controlled `account.instance_url` with no validation, while the Mastodon branch already gated `instance_url` through `is_safe_url`. Closing this at the central chokepoint protects the publish engine, inbox paths, and health check uniformly. (Surfaced by `/security-review`; `resolve_public_ip` IP-pinning was intentionally not used, consistent with the webhook dispatcher's documented choice to rely on `is_safe_url` + OS-resolver-cache reuse and avoid an httpx-transport dependency.)

## How to test

```bash
docker start brightbean-studio-postgres-1
.venv/bin/python -m pytest apps/inbox/ apps/social_accounts/ apps/publisher/ -q   # 75 passed
.venv/bin/ruff check .  &&  .venv/bin/ruff format --check .
```

New regression tests: Mastodon `instance_url` reaches the provider on sync (`test_sync.py`) and on health check (`test_tasks.py`); Bluesky `pds_url` is injected when safe and dropped when it fails the SSRF check (`publisher/tests.py`).

Optional manual check against a connected Mastodon account:
```bash
python manage.py backfill_inbox --platform mastodon --days 1   # no UnsupportedProtocol; messages pulled
```

## Checklist

- [x] Tests pass (`pytest`) — affected apps inbox / social_accounts / publisher: 75 passed
- [x] Lint passes (`ruff check .` and `ruff format --check .`) on changed files
- [ ] Documentation updated (if applicable) — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)