### PR TITLE
feat(queue): stable slot-occupancy model with gaps + status guard rails

### DIFF
--- a/apps/calendar/services.py
+++ b/apps/calendar/services.py
@@ -152,6 +152,20 @@ def _is_protected(pp):
     return pp is not None and pp.status in PlatformPost.PROTECTED_STATUSES
 
 
+def _lock_channel(queue):
+    """Serialize slot writes for a channel within the current transaction.
+
+    Occupancy is computed from ``PlatformPost`` rows (the publisher's truth),
+    which a per-queue ``select_for_update`` on QueueEntry rows does not cover —
+    two concurrent ops on *different* queues of the same channel would otherwise
+    read the same free slot and double-book. Locking the ``SocialAccount`` row
+    makes every slot op on a channel mutually exclusive.
+    """
+    from apps.social_accounts.models import SocialAccount
+
+    list(SocialAccount.objects.select_for_update().filter(id=queue.social_account_id))
+
+
 def _ensure_entry(post, queue):
     """Return the post's QueueEntry, creating it (appended) if absent."""
     from django.db.models import Max
@@ -186,10 +200,13 @@ def add_post_next_available(post, queue):
     from django.db import transaction
 
     with transaction.atomic():
-        # Lock the queue's rows so two concurrent adds can't grab one slot.
-        list(queue.entries.select_for_update().values_list("id", flat=True))
+        _lock_channel(queue)
 
         pp = _platform_post_for(post, queue.social_account)
+        # A published/publishing post's schedule is history — never re-slot it
+        # (mirrors the guard in prioritize/reorder; protects the reslot endpoint).
+        if _is_protected(pp):
+            return queue.entries.filter(post=post).first()
         exclude = [pp.id] if pp is not None else []
         slot_dt = _next_available_slot(queue.social_account, exclude_pp_ids=exclude)
         if slot_dt is None:
@@ -211,20 +228,23 @@ def prioritize(post, queue):
     from django.db import transaction
 
     with transaction.atomic():
-        list(queue.entries.select_for_update().values_list("id", flat=True))
+        _lock_channel(queue)
 
         now = timezone.now()
         pp = _platform_post_for(post, queue.social_account)
 
         # This queue's movable entries (exclude `post`, exclude protected), each
-        # currently sitting on a future slot.
-        movable = []
-        for e in queue.entries.exclude(post=post).select_related("post").filter(assigned_slot_datetime__gt=now):
+        # keyed on the ``PlatformPost.scheduled_at`` the publisher fires on — NOT
+        # ``QueueEntry.assigned_slot_datetime``, which a manual calendar drag via
+        # ``reschedule_post`` can leave stale and divergent (then the ladder would
+        # mis-place the post or double-book a slot another post really holds).
+        movable = []  # (entry, pp, current_slot_dt)
+        for e in queue.entries.exclude(post=post).select_related("post"):
             p = _platform_post_for(e.post, queue.social_account)
-            if _is_protected(p):
+            if p is None or _is_protected(p) or p.scheduled_at is None or p.scheduled_at <= now:
                 continue
-            movable.append((e, p))
-        movable_dts = {e.assigned_slot_datetime for e, _ in movable}
+            movable.append((e, p, p.scheduled_at))
+        movable_dts = {dt for _, _, dt in movable}
 
         candidates = _next_slot_datetimes(queue.social_account, now, count=len(movable) + 2)
         if not candidates:
@@ -253,10 +273,8 @@ def prioritize(post, queue):
         # manual / out-of-horizon) nor already claimed by another mover — so the
         # ladder never double-books and never runs off the lookahead horizon.
         index_of = {dt: i for i, dt in enumerate(candidates)}
-        movers = [
-            (index_of[e.assigned_slot_datetime], e, p) for e, p in movable if e.assigned_slot_datetime in index_of
-        ]
-        mover_old_dts = {e.assigned_slot_datetime for _, e, _ in movers}
+        movers = [(index_of[dt], e, p) for e, p, dt in movable if dt in index_of]
+        mover_old_dts = {dt for _, _, dt in movable if dt in index_of}
         # Datetimes that must stay free: everything occupied on this channel
         # except the movers we are about to relocate (their slots are vacated).
         avoid_dts = (
@@ -297,8 +315,12 @@ def remove_from_queue(entry):
     with transaction.atomic():
         post = entry.post
         queue = entry.queue
+        _lock_channel(queue)
         pp = _platform_post_for(post, queue.social_account)
-        if pp is not None and pp.status == "scheduled" and pp.can_transition_to("draft"):
+        # Clear the schedule for any non-protected child (scheduled OR failed),
+        # not just 'scheduled', so a removed failed post stops rendering on the
+        # calendar at its past attempt time. Published/publishing stay (history).
+        if pp is not None and not _is_protected(pp) and pp.can_transition_to("draft"):
             transition_platform_post(pp, "draft")
         entry.delete()
         sync_post_scheduled_at(post)
@@ -307,59 +329,6 @@ def remove_from_queue(entry):
 def reslot_to_next_available(entry):
     """Free this entry's slot and move it to the queue's next gap."""
     return add_post_next_available(entry.post, entry.queue)
-
-
-def assign_queue_slots(queue):
-    """Recalculate assigned_slot_datetime for all entries in a queue.
-
-    Iterates entries in position order and assigns each to the next
-    available PostingSlot datetime for the queue's social account. For each
-    entry, writes the slot datetime to the matching ``PlatformPost`` (the one
-    whose ``social_account`` equals ``queue.social_account``) and keeps
-    ``QueueEntry.assigned_slot_datetime`` in sync. ``Post.scheduled_at`` is
-    then refreshed via ``sync_post_scheduled_at`` as min-of-children.
-
-    Entries whose matching ``PlatformPost`` has already gone out (or is
-    mid-publish) are skipped entirely: their schedule is history. Re-slotting
-    them would drag a published post forward onto a future slot, where the
-    calendar — which places chips by ``scheduled_at`` — would show it as
-    "published" in the future. Skipped entries neither move nor consume a slot,
-    so the live entries still flow into the soonest open times.
-    """
-    from apps.composer.models import PlatformPost
-    from apps.composer.services import sync_post_scheduled_at
-
-    entries = queue.entries.select_related("post").order_by("position")
-    if not entries.exists():
-        return
-
-    now = timezone.now()
-    slot_times = _next_slot_datetimes(queue.social_account, now, count=len(entries) + 10)
-
-    touched_posts = []
-    slot_idx = 0
-    for entry in entries:
-        pp = entry.post.platform_posts.filter(social_account=queue.social_account).first()
-
-        # Never re-slot an already-published/publishing post (see docstring).
-        if pp is not None and pp.status in PlatformPost.PROTECTED_STATUSES:
-            continue
-
-        slot_dt = slot_times[slot_idx] if slot_idx < len(slot_times) else None
-        slot_idx += 1
-
-        entry.assigned_slot_datetime = slot_dt
-        entry.save(update_fields=["assigned_slot_datetime"])
-
-        # Write the per-platform scheduled_at on the matching PlatformPost.
-        if pp is not None:
-            pp.scheduled_at = slot_dt
-            pp.save(update_fields=["scheduled_at", "updated_at"])
-
-        touched_posts.append(entry.post)
-
-    for post in touched_posts:
-        sync_post_scheduled_at(post)
 
 
 def add_to_queue(post, queue, priority=False):
@@ -387,7 +356,7 @@ def reorder_queue(queue, ordered_entry_ids):
     from django.db import transaction
 
     with transaction.atomic():
-        list(queue.entries.select_for_update().values_list("id", flat=True))
+        _lock_channel(queue)
 
         ordered = []
         for eid in ordered_entry_ids:
@@ -399,10 +368,12 @@ def reorder_queue(queue, ordered_entry_ids):
                 continue
             ordered.append((e, p))
 
-        # Redistribute only the datetimes already held, among the entries that
-        # hold one — never invent or drop a slot during a reorder.
-        slotted = [(e, p) for e, p in ordered if e.assigned_slot_datetime is not None]
-        slots = sorted(e.assigned_slot_datetime for e, _ in slotted)
+        # Redistribute the slot instants already held — keyed on the publisher's
+        # ``PlatformPost.scheduled_at`` (not ``assigned_slot_datetime``, which a
+        # manual drag can leave stale) — among the entries that hold one. Never
+        # invent or drop a slot during a reorder.
+        slotted = [(e, p) for e, p in ordered if p is not None and p.scheduled_at is not None]
+        slots = sorted(p.scheduled_at for _, p in slotted)
         for idx, (e, p) in enumerate(slotted):
             _write_slot(e, p, slots[idx])
 

--- a/apps/calendar/services.py
+++ b/apps/calendar/services.py
@@ -3,7 +3,6 @@
 import zoneinfo
 from datetime import datetime, time, timedelta
 
-from django.db import models
 from django.utils import timezone
 
 from .models import PostingSlot, Queue, QueueEntry
@@ -85,6 +84,212 @@ def _next_slot_datetimes(social_account, after_dt, count=30):
     return results
 
 
+# ---------------------------------------------------------------------------
+# Stable slot-occupancy model
+#
+# A queue's "slots" are the upcoming PostingSlot datetimes for its channel; each
+# is either OCCUPIED (a non-published post on the channel already holds that
+# instant) or a GAP. Operations are LOCAL — they fill or vacate a single slot
+# and never recompute unrelated entries — so an entry's time stays stable until
+# that entry is explicitly moved. Occupancy is keyed off PlatformPost.scheduled_at
+# (the publisher's source of truth), not the queue rows, so a manually-scheduled
+# post or a recurrence clone on the same channel also reserves its instant — no
+# double-booking. PROTECTED_STATUSES (published/publishing) are history and never
+# occupy a future candidate or get moved.
+# ---------------------------------------------------------------------------
+
+
+class QueueFullError(Exception):
+    """No open posting slot exists within the scheduling lookahead horizon."""
+
+
+def _occupied_datetimes(social_account, *, exclude_pp_ids=()):
+    """Future slot instants already claimed on this channel.
+
+    Non-published/-publishing PlatformPosts with a future ``scheduled_at`` on
+    ``social_account``. ``exclude_pp_ids`` drops a post's own row so it never
+    blocks itself while being re-slotted.
+    """
+    from apps.composer.models import PlatformPost
+
+    qs = (
+        PlatformPost.objects.filter(
+            social_account=social_account,
+            scheduled_at__isnull=False,
+            scheduled_at__gt=timezone.now(),
+        )
+        .exclude(status__in=PlatformPost.PROTECTED_STATUSES)
+        .exclude(id__in=list(exclude_pp_ids))
+    )
+    return set(qs.values_list("scheduled_at", flat=True))
+
+
+def _next_available_slot(social_account, *, exclude_pp_ids=(), after=None):
+    """First upcoming PostingSlot datetime not already occupied, or ``None``.
+
+    ``None`` means every slot within the lookahead horizon (``_next_slot_datetimes``
+    caps at 60 days) is taken — the queue is full.
+    """
+    after = after or timezone.now()
+    occupied = _occupied_datetimes(social_account, exclude_pp_ids=exclude_pp_ids)
+    # Among the first ``len(occupied) + 1`` distinct slots at most ``len(occupied)``
+    # can be taken, so one is guaranteed free if any free slot exists at all.
+    candidates = _next_slot_datetimes(social_account, after, count=len(occupied) + 1)
+    for slot_dt in candidates:
+        if slot_dt not in occupied:
+            return slot_dt
+    return None
+
+
+def _platform_post_for(post, social_account):
+    """The post's PlatformPost child on this channel (or ``None``)."""
+    return post.platform_posts.filter(social_account=social_account).first()
+
+
+def _is_protected(pp):
+    from apps.composer.models import PlatformPost
+
+    return pp is not None and pp.status in PlatformPost.PROTECTED_STATUSES
+
+
+def _ensure_entry(post, queue):
+    """Return the post's QueueEntry, creating it (appended) if absent."""
+    from django.db.models import Max
+
+    entry = queue.entries.filter(post=post).first()
+    if entry is None:
+        max_pos = queue.entries.aggregate(m=Max("position"))["m"]
+        entry = QueueEntry.objects.create(queue=queue, post=post, position=(max_pos or 0) + 1)
+    return entry
+
+
+def _write_slot(entry, pp, slot_dt):
+    """Persist one slot assignment to the QueueEntry and its PlatformPost."""
+    from apps.composer.services import sync_post_scheduled_at
+
+    entry.assigned_slot_datetime = slot_dt
+    entry.save(update_fields=["assigned_slot_datetime"])
+    if pp is not None:
+        pp.scheduled_at = slot_dt
+        pp.save(update_fields=["scheduled_at", "updated_at"])
+        sync_post_scheduled_at(pp.post)
+
+
+def add_post_next_available(post, queue):
+    """Place ``post`` into this queue's first open slot (upsert-aware).
+
+    Comment §1 (Create · Next Available) and §4 (Edit · Next Available): if the
+    post is already queued, its own slot is vacated first and it is re-slotted to
+    the next gap; existing entries are never disturbed. Raises ``QueueFullError`` when
+    no slot is free within the horizon.
+    """
+    from django.db import transaction
+
+    with transaction.atomic():
+        # Lock the queue's rows so two concurrent adds can't grab one slot.
+        list(queue.entries.select_for_update().values_list("id", flat=True))
+
+        pp = _platform_post_for(post, queue.social_account)
+        exclude = [pp.id] if pp is not None else []
+        slot_dt = _next_available_slot(queue.social_account, exclude_pp_ids=exclude)
+        if slot_dt is None:
+            raise QueueFullError(f"Queue {queue.id} has no open slot within the scheduling horizon.")
+
+        entry = _ensure_entry(post, queue)
+        _write_slot(entry, pp, slot_dt)
+        return entry
+
+
+def prioritize(post, queue):
+    """Place ``post`` at the queue's earliest slot, laddering others up by one.
+
+    Comment §2: if the earliest upcoming slot is free, ``post`` takes it and
+    nothing moves. Otherwise every other occupied queue entry shifts one slot
+    later (``[k]→[k+1]``, preserving the gap pattern) before ``post`` takes
+    slot ``[0]``. Upsert-aware. Raises ``QueueFullError`` past the horizon.
+    """
+    from django.db import transaction
+
+    with transaction.atomic():
+        list(queue.entries.select_for_update().values_list("id", flat=True))
+
+        now = timezone.now()
+        pp = _platform_post_for(post, queue.social_account)
+
+        # This queue's movable entries (exclude `post`, exclude protected), each
+        # currently sitting on a future slot.
+        movable = []
+        for e in queue.entries.exclude(post=post).select_related("post").filter(assigned_slot_datetime__gt=now):
+            p = _platform_post_for(e.post, queue.social_account)
+            if _is_protected(p):
+                continue
+            movable.append((e, p))
+        movable_dts = {e.assigned_slot_datetime for e, _ in movable}
+
+        candidates = _next_slot_datetimes(queue.social_account, now, count=len(movable) + 2)
+        if not candidates:
+            raise QueueFullError(f"Queue {queue.id} has no posting slots within the horizon.")
+
+        entry = _ensure_entry(post, queue)
+        target = candidates[0]
+
+        # Slot 0 is free among the queue's own entries.
+        if target not in movable_dts:
+            # If a foreign/fixed post (manual schedule, clone, other queue) holds
+            # slot 0, we cannot preempt it — degrade to the next genuine gap.
+            occupied = _occupied_datetimes(queue.social_account, exclude_pp_ids=[pp.id] if pp else [])
+            if target in occupied:
+                free = _next_available_slot(queue.social_account, exclude_pp_ids=[pp.id] if pp else [])
+                if free is None:
+                    raise QueueFullError(f"Queue {queue.id} has no open slot within the scheduling horizon.")
+                _write_slot(entry, pp, free)
+                return entry
+            _write_slot(entry, pp, target)
+            return entry
+
+        # Slot 0 taken by a queue entry: ladder every movable entry up one index.
+        index_of = {dt: i for i, dt in enumerate(candidates)}
+        movers = [
+            (index_of[e.assigned_slot_datetime], e, p) for e, p in movable if e.assigned_slot_datetime in index_of
+        ]
+        max_i = max((i for i, _, _ in movers), default=0)
+        if max_i + 1 >= len(candidates):
+            candidates = _next_slot_datetimes(queue.social_account, now, count=max_i + 2)
+        # Descending so each destination slot is vacated before it is written.
+        for i, e, p in sorted(movers, key=lambda t: t[0], reverse=True):
+            _write_slot(e, p, candidates[i + 1])
+        _write_slot(entry, pp, candidates[0])
+        return entry
+
+
+def remove_from_queue(entry):
+    """Remove a single entry, leaving a gap; neighbours are untouched.
+
+    Comment §3: delete the QueueEntry and clear the matching PlatformPost's
+    schedule. The child is transitioned ``scheduled→draft`` (which nulls
+    ``scheduled_at``) rather than nulled directly, so it can't become instantly
+    due via the publisher's ``Coalesce(scheduled_at, post__scheduled_at)``
+    fallback while the parent aggregate still points at a past time.
+    """
+    from django.db import transaction
+
+    from apps.composer.services import sync_post_scheduled_at, transition_platform_post
+
+    with transaction.atomic():
+        post = entry.post
+        queue = entry.queue
+        pp = _platform_post_for(post, queue.social_account)
+        if pp is not None and pp.status == "scheduled" and pp.can_transition_to("draft"):
+            transition_platform_post(pp, "draft")
+        entry.delete()
+        sync_post_scheduled_at(post)
+
+
+def reslot_to_next_available(entry):
+    """Free this entry's slot and move it to the queue's next gap."""
+    return add_post_next_available(entry.post, entry.queue)
+
+
 def assign_queue_slots(queue):
     """Recalculate assigned_slot_datetime for all entries in a queue.
 
@@ -139,37 +344,53 @@ def assign_queue_slots(queue):
 
 
 def add_to_queue(post, queue, priority=False):
-    """Add a post to a queue and recalculate slot assignments.
+    """Add a post to a queue (back-compat dispatcher).
 
-    If *priority* is True the post is inserted at position 0 (top of the
-    queue) and all existing entries are shifted down.  Otherwise it is
-    appended at the end.
+    Routes to the stable-slot ops: ``prioritize`` (top of queue) or
+    ``add_post_next_available`` (first open gap). Kept so existing callers and
+    the composer's ``add_to_queue`` / ``add_to_queue_priority`` actions only
+    need their resolved service swapped, not their wiring.
     """
-    from django.db.models import Max
-
     if priority:
-        # Shift all existing entries down by 1
-        queue.entries.update(position=models.F("position") + 1)
-        position = 0
-    else:
-        max_pos = queue.entries.aggregate(max_pos=Max("position"))["max_pos"]
-        position = (max_pos or 0) + 1
-
-    QueueEntry.objects.update_or_create(
-        queue=queue,
-        post=post,
-        defaults={"position": position},
-    )
-
-    assign_queue_slots(queue)
+        return prioritize(post, queue)
+    return add_post_next_available(post, queue)
 
 
 def reorder_queue(queue, ordered_entry_ids):
-    """Reorder queue entries by a list of entry IDs and recalculate slots."""
-    for idx, entry_id in enumerate(ordered_entry_ids):
-        QueueEntry.objects.filter(id=entry_id, queue=queue).update(position=idx)
+    """Reassign the queue's occupied slot times to entries in a new order.
 
-    assign_queue_slots(queue)
+    Drag-reorder under the slot model: the SET of occupied datetimes is
+    preserved (gaps stay put); only which post sits in which slot changes. The
+    movable, slotted entries named in ``ordered_entry_ids`` are matched — in that
+    visual order — to their datetimes sorted ascending. Protected
+    (published/publishing) entries are immovable and skipped.
+    """
+    from django.db import transaction
+
+    with transaction.atomic():
+        list(queue.entries.select_for_update().values_list("id", flat=True))
+
+        ordered = []
+        for eid in ordered_entry_ids:
+            e = queue.entries.filter(id=eid).select_related("post").first()
+            if e is None:
+                continue
+            p = _platform_post_for(e.post, queue.social_account)
+            if _is_protected(p):
+                continue
+            ordered.append((e, p))
+
+        # Redistribute only the datetimes already held, among the entries that
+        # hold one — never invent or drop a slot during a reorder.
+        slotted = [(e, p) for e, p in ordered if e.assigned_slot_datetime is not None]
+        slots = sorted(e.assigned_slot_datetime for e, _ in slotted)
+        for idx, (e, p) in enumerate(slotted):
+            _write_slot(e, p, slots[idx])
+
+        # Keep ``position`` as a stable visual tie-break in the dragged order.
+        for idx, (e, _p) in enumerate(ordered):
+            if e.position != idx:
+                QueueEntry.objects.filter(id=e.id).update(position=idx)
 
 
 def repair_future_published_scheduled_at(*, workspace_id=None, apply=True):

--- a/apps/calendar/services.py
+++ b/apps/calendar/services.py
@@ -247,17 +247,36 @@ def prioritize(post, queue):
             _write_slot(entry, pp, target)
             return entry
 
-        # Slot 0 taken by a queue entry: ladder every movable entry up one index.
+        # Slot 0 taken by a queue entry: ladder every movable entry up to its
+        # next free slot. Each mover lands on the earliest candidate after its
+        # current index that is neither held by a post we can't move (foreign /
+        # manual / out-of-horizon) nor already claimed by another mover — so the
+        # ladder never double-books and never runs off the lookahead horizon.
         index_of = {dt: i for i, dt in enumerate(candidates)}
         movers = [
             (index_of[e.assigned_slot_datetime], e, p) for e, p in movable if e.assigned_slot_datetime in index_of
         ]
-        max_i = max((i for i, _, _ in movers), default=0)
-        if max_i + 1 >= len(candidates):
-            candidates = _next_slot_datetimes(queue.social_account, now, count=max_i + 2)
-        # Descending so each destination slot is vacated before it is written.
-        for i, e, p in sorted(movers, key=lambda t: t[0], reverse=True):
-            _write_slot(e, p, candidates[i + 1])
+        mover_old_dts = {e.assigned_slot_datetime for _, e, _ in movers}
+        # Datetimes that must stay free: everything occupied on this channel
+        # except the movers we are about to relocate (their slots are vacated).
+        avoid_dts = (
+            _occupied_datetimes(queue.social_account, exclude_pp_ids=[pp.id] if pp is not None else []) - mover_old_dts
+        )
+
+        assigned_idx = {0}  # slot 0 is reserved for the prioritized post
+        # Descending so a destination is always vacated before it is written.
+        for cur_idx, e, p in sorted(movers, key=lambda t: t[0], reverse=True):
+            j = cur_idx + 1
+            while True:
+                if j >= len(candidates):
+                    candidates = _next_slot_datetimes(queue.social_account, now, count=j + 2)
+                    if j >= len(candidates):
+                        raise QueueFullError(f"Queue {queue.id} has no open slot within the scheduling horizon.")
+                if j not in assigned_idx and candidates[j] not in avoid_dts:
+                    break
+                j += 1
+            assigned_idx.add(j)
+            _write_slot(e, p, candidates[j])
         _write_slot(entry, pp, candidates[0])
         return entry
 

--- a/apps/calendar/tests.py
+++ b/apps/calendar/tests.py
@@ -12,10 +12,15 @@ from django.utils import timezone
 from apps.accounts.models import User
 from apps.calendar.models import PostingSlot, Queue, QueueEntry, RecurrenceRule
 from apps.calendar.services import (
+    QueueFullError,
     _next_slot_datetimes,
+    add_post_next_available,
     add_to_queue,
+    prioritize,
+    remove_from_queue,
     reorder_queue,
     repair_future_published_scheduled_at,
+    reslot_to_next_available,
 )
 from apps.calendar.tasks import generate_recurring_posts
 from apps.calendar.views import _day_view_data
@@ -814,3 +819,157 @@ class PublishTabTimezoneTests(TestCase):
         url = reverse("calendar:publish_tab_drafts", kwargs={"workspace_id": self.ws.id})
         resp = self.client.get(url + "?tz=")
         self.assertEqual(resp.status_code, 200)
+
+
+class SlotOccupancyQueueTests(TestCase):
+    """Stable slot-occupancy: local ops fill/vacate one slot and preserve gaps."""
+
+    def setUp(self):
+        self.org = Organization.objects.create(name="Slot Org", default_timezone="UTC")
+        self.workspace = Workspace.objects.create(organization=self.org, name="Slot WS")
+        self.account = SocialAccount.objects.create(
+            workspace=self.workspace,
+            platform="linkedin_personal",
+            account_platform_id="li-slot",
+            account_name="Slot",
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+        # One slot every weekday at 09:00 → deterministic, dense candidate list.
+        for day in range(7):
+            PostingSlot.objects.create(social_account=self.account, day_of_week=day, time=time(9, 0))
+        self.queue = Queue.objects.create(workspace=self.workspace, name="Slot Q", social_account=self.account)
+
+    def _cands(self, n=6):
+        return _next_slot_datetimes(self.account, timezone.now(), count=n)
+
+    def _occupy(self, slot_dt, *, queued=True, caption="occupied"):
+        post = Post.objects.create(workspace=self.workspace, caption=caption)
+        pp = PlatformPost.objects.create(
+            post=post,
+            social_account=self.account,
+            status=PlatformPost.Status.SCHEDULED,
+            scheduled_at=slot_dt,
+        )
+        entry = None
+        if queued:
+            entry = QueueEntry.objects.create(queue=self.queue, post=post, position=0, assigned_slot_datetime=slot_dt)
+        return post, pp, entry
+
+    def _add(self, caption="new"):
+        post = Post.objects.create(workspace=self.workspace, caption=caption)
+        PlatformPost.objects.create(post=post, social_account=self.account, status=PlatformPost.Status.DRAFT)
+        return post
+
+    def test_next_available_fills_first_gap(self):
+        c = self._cands()
+        self._occupy(c[0])  # [0] taken
+        self._occupy(c[2])  # [2] taken, [1] is the gap
+        post = self._add()
+
+        add_post_next_available(post, self.queue)
+
+        pp = PlatformPost.objects.get(post=post, social_account=self.account)
+        self.assertEqual(pp.scheduled_at, c[1])
+
+    def test_next_available_leaves_occupied_entries_unchanged(self):
+        c = self._cands()
+        _, pp0, _ = self._occupy(c[0])
+        _, pp2, _ = self._occupy(c[2])
+
+        add_post_next_available(self._add(), self.queue)
+
+        pp0.refresh_from_db()
+        pp2.refresh_from_db()
+        self.assertEqual(pp0.scheduled_at, c[0])
+        self.assertEqual(pp2.scheduled_at, c[2])
+
+    def test_prioritize_with_slot0_taken_ladders_and_preserves_gap(self):
+        c = self._cands()
+        _, pp_a, _ = self._occupy(c[0], caption="A")
+        _, pp_b, _ = self._occupy(c[2], caption="B")  # gap at [1]
+        post = self._add()
+
+        prioritize(post, self.queue)
+
+        pp_new = PlatformPost.objects.get(post=post, social_account=self.account)
+        pp_a.refresh_from_db()
+        pp_b.refresh_from_db()
+        self.assertEqual(pp_new.scheduled_at, c[0])  # new at the top
+        self.assertEqual(pp_a.scheduled_at, c[1])  # old[0] → [1]
+        self.assertEqual(pp_b.scheduled_at, c[3])  # old[2] → [3] (gap now at [2])
+
+    def test_prioritize_with_slot0_free_moves_nothing(self):
+        c = self._cands()
+        _, pp_a, _ = self._occupy(c[1], caption="A")  # [0] free
+        post = self._add()
+
+        prioritize(post, self.queue)
+
+        pp_new = PlatformPost.objects.get(post=post, social_account=self.account)
+        pp_a.refresh_from_db()
+        self.assertEqual(pp_new.scheduled_at, c[0])
+        self.assertEqual(pp_a.scheduled_at, c[1])  # untouched
+
+    def test_remove_leaves_gap_drafts_child_and_not_due(self):
+        c = self._cands()
+        post_a, pp_a, entry_a = self._occupy(c[0], caption="A")
+        _, pp_b, _ = self._occupy(c[1], caption="B")
+
+        remove_from_queue(entry_a)
+
+        self.assertFalse(QueueEntry.objects.filter(id=entry_a.id).exists())
+        pp_a.refresh_from_db()
+        post_a.refresh_from_db()
+        self.assertEqual(pp_a.status, PlatformPost.Status.DRAFT)
+        self.assertIsNone(pp_a.scheduled_at)
+        self.assertIsNone(post_a.scheduled_at)
+        pp_b.refresh_from_db()
+        self.assertEqual(pp_b.scheduled_at, c[1])  # neighbour untouched
+
+        # Drafted child is not swept up by the publisher's due query.
+        from django.db.models.functions import Coalesce
+
+        due = set(
+            PlatformPost.objects.filter(status=PlatformPost.Status.SCHEDULED)
+            .annotate(eff=Coalesce("scheduled_at", "post__scheduled_at"))
+            .filter(eff__lte=timezone.now())
+            .values_list("id", flat=True)
+        )
+        self.assertNotIn(pp_a.id, due)
+
+    def test_reslot_moves_entry_to_first_gap(self):
+        c = self._cands()
+        post_a, pp_a, entry_a = self._occupy(c[2], caption="A")  # [0],[1] free
+
+        reslot_to_next_available(entry_a)
+
+        pp_a.refresh_from_db()
+        self.assertEqual(pp_a.scheduled_at, c[0])  # excludes itself → first gap
+        # Still a single entry (upsert, not duplicated).
+        self.assertEqual(QueueEntry.objects.filter(post=post_a, queue=self.queue).count(), 1)
+
+    def test_add_next_available_upserts_existing_entry(self):
+        c = self._cands()
+        post_a, pp_a, _ = self._occupy(c[2], caption="A")
+        self._occupy(c[0], caption="B")  # [0] taken, [1] free
+
+        add_post_next_available(post_a, self.queue)  # post_a already queued
+
+        pp_a.refresh_from_db()
+        self.assertEqual(pp_a.scheduled_at, c[1])  # moved to first gap, excluding self
+        self.assertEqual(QueueEntry.objects.filter(post=post_a, queue=self.queue).count(), 1)
+
+    def test_queue_full_raises_when_channel_has_no_slots(self):
+        slotless = SocialAccount.objects.create(
+            workspace=self.workspace,
+            platform="bluesky",
+            account_platform_id="bs-slotless",
+            account_name="Slotless",
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+        queue = Queue.objects.create(workspace=self.workspace, name="Empty Q", social_account=slotless)
+        post = Post.objects.create(workspace=self.workspace, caption="x")
+        PlatformPost.objects.create(post=post, social_account=slotless, status=PlatformPost.Status.DRAFT)
+
+        with self.assertRaises(QueueFullError):
+            add_post_next_available(post, queue)

--- a/apps/calendar/tests.py
+++ b/apps/calendar/tests.py
@@ -825,6 +825,15 @@ class SlotOccupancyQueueTests(TestCase):
     """Stable slot-occupancy: local ops fill/vacate one slot and preserve gaps."""
 
     def setUp(self):
+        # Freeze now so the candidate list the tests compute via _cands() can't
+        # drift from the list the service computes microseconds later (crossing a
+        # 09:00 slot boundary would otherwise shift the window by one).
+        self._now_patcher = patch(
+            "django.utils.timezone.now",
+            return_value=datetime(2026, 7, 1, 12, 0, tzinfo=zoneinfo.ZoneInfo("UTC")),
+        )
+        self._now_patcher.start()
+        self.addCleanup(self._now_patcher.stop)
         self.org = Organization.objects.create(name="Slot Org", default_timezone="UTC")
         self.workspace = Workspace.objects.create(organization=self.org, name="Slot WS")
         self.account = SocialAccount.objects.create(
@@ -1035,6 +1044,71 @@ class SlotOccupancyQueueTests(TestCase):
 
         with self.assertRaises(QueueFullError):
             prioritize(newp, queue)
+
+    def test_prioritize_keys_on_scheduled_at_not_stale_assigned(self):
+        # A queued post dragged on the calendar (reschedule_post) moves
+        # pp.scheduled_at but leaves QueueEntry.assigned_slot_datetime stale.
+        # prioritize must read the real (scheduled_at) slot, not the stale one.
+        c = self._cands()
+        post_a, pp_a, _ = self._occupy(c[0], caption="A")  # entry assigned=c[0]
+        pp_a.scheduled_at = c[2]  # "dragged" to c[2]; assigned stays c[0]
+        pp_a.save(update_fields=["scheduled_at"])
+
+        prioritize(self._add(caption="B"), self.queue)
+
+        pp_b = PlatformPost.objects.get(post__caption="B", social_account=self.account)
+        pp_a.refresh_from_db()
+        # Slot 0 is really free (A is at c[2]); B takes it and A is untouched —
+        # no mis-ladder off the stale assigned_slot_datetime.
+        self.assertEqual(pp_b.scheduled_at, c[0])
+        self.assertEqual(pp_a.scheduled_at, c[2])
+
+    def test_reorder_keys_on_scheduled_at_not_stale_assigned(self):
+        c = self._cands()
+        post1, pp1, e1 = self._occupy(c[0], caption="one")
+        post2, pp2, e2 = self._occupy(c[1], caption="two")
+        pp1.scheduled_at = c[2]  # drag post1 to c[2]; e1.assigned stays c[0]
+        pp1.save(update_fields=["scheduled_at"])
+
+        reorder_queue(self.queue, [str(e1.id), str(e2.id)])
+
+        pp1.refresh_from_db()
+        pp2.refresh_from_db()
+        # Real occupied instants are {c[1], c[2]} (not the stale {c[0], c[1]});
+        # redistributed in order → e1=c[1], e2=c[2]. No double-book.
+        self.assertEqual(pp1.scheduled_at, c[1])
+        self.assertEqual(pp2.scheduled_at, c[2])
+        self.assertEqual(len({pp1.scheduled_at, pp2.scheduled_at}), 2)
+
+    def test_reslot_is_noop_for_publishing_post(self):
+        # A protected (publishing) post's schedule is history — reslot must not
+        # overwrite it with a future slot (the corruption class repair exists for).
+        c = self._cands()
+        post = Post.objects.create(workspace=self.workspace, caption="pub")
+        pp = PlatformPost.objects.create(
+            post=post, social_account=self.account, status=PlatformPost.Status.PUBLISHING, scheduled_at=c[2]
+        )
+        entry = QueueEntry.objects.create(queue=self.queue, post=post, position=0, assigned_slot_datetime=c[2])
+
+        reslot_to_next_available(entry)
+
+        pp.refresh_from_db()
+        self.assertEqual(pp.scheduled_at, c[2])  # untouched
+
+    def test_remove_clears_schedule_for_failed_child(self):
+        c = self._cands()
+        post = Post.objects.create(workspace=self.workspace, caption="failed")
+        pp = PlatformPost.objects.create(
+            post=post, social_account=self.account, status=PlatformPost.Status.FAILED, scheduled_at=c[0]
+        )
+        entry = QueueEntry.objects.create(queue=self.queue, post=post, position=0, assigned_slot_datetime=c[0])
+
+        remove_from_queue(entry)
+
+        self.assertFalse(QueueEntry.objects.filter(id=entry.id).exists())
+        pp.refresh_from_db()
+        self.assertEqual(pp.status, PlatformPost.Status.DRAFT)
+        self.assertIsNone(pp.scheduled_at)  # no longer lingers on the calendar
 
 
 class QueueEntryEndpointTests(TestCase):

--- a/apps/calendar/tests.py
+++ b/apps/calendar/tests.py
@@ -959,6 +959,21 @@ class SlotOccupancyQueueTests(TestCase):
         self.assertEqual(pp_a.scheduled_at, c[1])  # moved to first gap, excluding self
         self.assertEqual(QueueEntry.objects.filter(post=post_a, queue=self.queue).count(), 1)
 
+    def test_drafting_child_removes_queue_entry(self):
+        # Cancel/unschedule parity: transitioning a queued child back to draft
+        # drops its QueueEntry (so no orphan with a stale slot lingers).
+        from apps.composer.services import transition_platform_post
+
+        c = self._cands()
+        post, pp, entry = self._occupy(c[0], caption="A")
+
+        transition_platform_post(pp, "draft")
+
+        pp.refresh_from_db()
+        self.assertEqual(pp.status, PlatformPost.Status.DRAFT)
+        self.assertIsNone(pp.scheduled_at)
+        self.assertFalse(QueueEntry.objects.filter(id=entry.id).exists())
+
     def test_queue_full_raises_when_channel_has_no_slots(self):
         slotless = SocialAccount.objects.create(
             workspace=self.workspace,

--- a/apps/calendar/tests.py
+++ b/apps/calendar/tests.py
@@ -973,3 +973,89 @@ class SlotOccupancyQueueTests(TestCase):
 
         with self.assertRaises(QueueFullError):
             add_post_next_available(post, queue)
+
+
+class QueueEntryEndpointTests(TestCase):
+    """HTTP endpoints for single-entry remove / reslot (workspace-scoped)."""
+
+    def setUp(self):
+        self.user = User.objects.create_user(email="qe@example.com", password="pw", tos_accepted_at=timezone.now())
+        self.org = Organization.objects.create(name="EP Org")
+        self.workspace = Workspace.objects.create(organization=self.org, name="EP WS")
+        OrgMembership.objects.create(user=self.user, organization=self.org, org_role=OrgMembership.OrgRole.OWNER)
+        WorkspaceMembership.objects.create(
+            user=self.user, workspace=self.workspace, workspace_role=WorkspaceMembership.WorkspaceRole.OWNER
+        )
+        self.account = SocialAccount.objects.create(
+            workspace=self.workspace,
+            platform="linkedin_personal",
+            account_platform_id="li-ep",
+            account_name="EP",
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+        for day in range(7):
+            PostingSlot.objects.create(social_account=self.account, day_of_week=day, time=time(9, 0))
+        self.queue = Queue.objects.create(workspace=self.workspace, name="EP Q", social_account=self.account)
+        self.client.force_login(self.user)
+
+    def _queue_post(self, slot_dt):
+        post = Post.objects.create(workspace=self.workspace, caption="x")
+        PlatformPost.objects.create(
+            post=post, social_account=self.account, status=PlatformPost.Status.SCHEDULED, scheduled_at=slot_dt
+        )
+        entry = QueueEntry.objects.create(queue=self.queue, post=post, position=0, assigned_slot_datetime=slot_dt)
+        return post, entry
+
+    def _remove_url(self, entry_id, queue_id=None):
+        return reverse(
+            "calendar:queue_entry_remove",
+            kwargs={"workspace_id": self.workspace.id, "queue_id": queue_id or self.queue.id, "entry_id": entry_id},
+        )
+
+    def test_remove_entry_deletes_and_drafts(self):
+        c = _next_slot_datetimes(self.account, timezone.now(), count=2)
+        post, entry = self._queue_post(c[0])
+        resp = self.client.post(self._remove_url(entry.id), HTTP_HX_REQUEST="true")
+        self.assertEqual(resp.status_code, 204)
+        self.assertIn("queueReordered", resp.headers.get("HX-Trigger", ""))
+        self.assertFalse(QueueEntry.objects.filter(id=entry.id).exists())
+        pp = PlatformPost.objects.get(post=post)
+        self.assertEqual(pp.status, PlatformPost.Status.DRAFT)
+        self.assertIsNone(pp.scheduled_at)
+
+    def test_remove_idempotent_when_already_gone(self):
+        import uuid as _uuid
+
+        resp = self.client.post(self._remove_url(_uuid.uuid4()), HTTP_HX_REQUEST="true")
+        self.assertEqual(resp.status_code, 204)
+
+    def test_remove_foreign_workspace_entry_is_noop(self):
+        other_org = Organization.objects.create(name="Other")
+        other_ws = Workspace.objects.create(organization=other_org, name="Other WS")
+        other_acct = SocialAccount.objects.create(
+            workspace=other_ws,
+            platform="linkedin_personal",
+            account_platform_id="li-other",
+            account_name="O",
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+        other_queue = Queue.objects.create(workspace=other_ws, name="OQ", social_account=other_acct)
+        other_post = Post.objects.create(workspace=other_ws, caption="o")
+        other_entry = QueueEntry.objects.create(queue=other_queue, post=other_post, position=0)
+
+        # Member of self.workspace targets their own workspace_id but a foreign entry.
+        resp = self.client.post(self._remove_url(other_entry.id, queue_id=other_queue.id), HTTP_HX_REQUEST="true")
+        self.assertEqual(resp.status_code, 204)
+        self.assertTrue(QueueEntry.objects.filter(id=other_entry.id).exists())
+
+    def test_reslot_moves_to_next_gap(self):
+        c = _next_slot_datetimes(self.account, timezone.now(), count=3)
+        post, entry = self._queue_post(c[2])  # [0],[1] free
+        url = reverse(
+            "calendar:queue_entry_reslot",
+            kwargs={"workspace_id": self.workspace.id, "queue_id": self.queue.id, "entry_id": entry.id},
+        )
+        resp = self.client.post(url, HTTP_HX_REQUEST="true")
+        self.assertEqual(resp.status_code, 204)
+        pp = PlatformPost.objects.get(post=post)
+        self.assertEqual(pp.scheduled_at, c[0])

--- a/apps/calendar/tests.py
+++ b/apps/calendar/tests.py
@@ -1074,3 +1074,25 @@ class QueueEntryEndpointTests(TestCase):
         self.assertEqual(resp.status_code, 204)
         pp = PlatformPost.objects.get(post=post)
         self.assertEqual(pp.scheduled_at, c[0])
+
+    def test_queue_detail_page_renders_chronologically(self):
+        # Smoke: the detail page renders with the new remove button and orders
+        # entries by slot datetime (an earlier slot added second still shows first).
+        c = _next_slot_datetimes(self.account, timezone.now(), count=2)
+        later = Post.objects.create(workspace=self.workspace, caption="LATER caption")
+        PlatformPost.objects.create(
+            post=later, social_account=self.account, status=PlatformPost.Status.SCHEDULED, scheduled_at=c[1]
+        )
+        QueueEntry.objects.create(queue=self.queue, post=later, position=0, assigned_slot_datetime=c[1])
+        earlier = Post.objects.create(workspace=self.workspace, caption="EARLIER caption")
+        PlatformPost.objects.create(
+            post=earlier, social_account=self.account, status=PlatformPost.Status.SCHEDULED, scheduled_at=c[0]
+        )
+        QueueEntry.objects.create(queue=self.queue, post=earlier, position=1, assigned_slot_datetime=c[0])
+
+        url = reverse("calendar:queue_detail", kwargs={"workspace_id": self.workspace.id, "queue_id": self.queue.id})
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Remove from queue")
+        body = resp.content.decode()
+        self.assertLess(body.index("EARLIER caption"), body.index("LATER caption"))

--- a/apps/calendar/tests.py
+++ b/apps/calendar/tests.py
@@ -989,6 +989,53 @@ class SlotOccupancyQueueTests(TestCase):
         with self.assertRaises(QueueFullError):
             add_post_next_available(post, queue)
 
+    def test_prioritize_ladder_skips_foreign_occupied_slot(self):
+        # A manually-scheduled post (no QueueEntry) the queue can't move must not
+        # be double-booked: the laddered mover skips its slot.
+        c = self._cands()
+        _, pp_mover, _ = self._occupy(c[0], caption="mover")  # queue entry holds slot 0
+        foreign = Post.objects.create(workspace=self.workspace, caption="manual")
+        pp_foreign = PlatformPost.objects.create(
+            post=foreign, social_account=self.account, status=PlatformPost.Status.SCHEDULED, scheduled_at=c[1]
+        )
+        post = self._add()
+
+        prioritize(post, self.queue)
+
+        pp_new = PlatformPost.objects.get(post=post, social_account=self.account)
+        pp_mover.refresh_from_db()
+        pp_foreign.refresh_from_db()
+        self.assertEqual(pp_new.scheduled_at, c[0])  # new takes the top
+        self.assertEqual(pp_foreign.scheduled_at, c[1])  # immovable, untouched
+        self.assertEqual(pp_mover.scheduled_at, c[2])  # skipped the foreign slot
+        # Three live posts hold three distinct slots — no collision.
+        self.assertEqual(len({pp_new.scheduled_at, pp_mover.scheduled_at, pp_foreign.scheduled_at}), 3)
+
+    def test_prioritize_raises_queue_full_when_ladder_exhausts_horizon(self):
+        # A channel with a single weekly slot: fill every slot in the horizon, so
+        # the prioritize ladder has nowhere to push the top mover.
+        weekly = SocialAccount.objects.create(
+            workspace=self.workspace,
+            platform="bluesky",
+            account_platform_id="bs-weekly",
+            account_name="W",
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+        PostingSlot.objects.create(social_account=weekly, day_of_week=0, time=time(9, 0))  # Mondays only
+        queue = Queue.objects.create(workspace=self.workspace, name="Weekly Q", social_account=weekly)
+        for i, dt in enumerate(_next_slot_datetimes(weekly, timezone.now(), count=200)):
+            p = Post.objects.create(workspace=self.workspace, caption=f"m{i}")
+            PlatformPost.objects.create(
+                post=p, social_account=weekly, status=PlatformPost.Status.SCHEDULED, scheduled_at=dt
+            )
+            QueueEntry.objects.create(queue=queue, post=p, position=i, assigned_slot_datetime=dt)
+
+        newp = Post.objects.create(workspace=self.workspace, caption="new")
+        PlatformPost.objects.create(post=newp, social_account=weekly, status=PlatformPost.Status.DRAFT)
+
+        with self.assertRaises(QueueFullError):
+            prioritize(newp, queue)
+
 
 class QueueEntryEndpointTests(TestCase):
     """HTTP endpoints for single-entry remove / reslot (workspace-scoped)."""

--- a/apps/calendar/urls.py
+++ b/apps/calendar/urls.py
@@ -22,6 +22,16 @@ urlpatterns = [
     path("queues/<uuid:queue_id>/", views.queue_detail, name="queue_detail"),
     path("queues/<uuid:queue_id>/delete/", views.queue_delete, name="queue_delete"),
     path("queues/<uuid:queue_id>/reorder/", views.queue_reorder, name="queue_reorder"),
+    path(
+        "queues/<uuid:queue_id>/entries/<uuid:entry_id>/remove/",
+        views.queue_entry_remove,
+        name="queue_entry_remove",
+    ),
+    path(
+        "queues/<uuid:queue_id>/entries/<uuid:entry_id>/reslot/",
+        views.queue_entry_reslot,
+        name="queue_entry_reslot",
+    ),
     # Publish page tab partials (HTMX)
     path("publish/queue/", views.publish_tab_queue, name="publish_tab_queue"),
     path("publish/drafts/", views.publish_tab_drafts, name="publish_tab_drafts"),

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -994,6 +994,12 @@ def reschedule_post(request, workspace_id):
         if pp.status == "draft" and pp.can_transition_to("scheduled"):
             pp.transition_to("scheduled")
         pp.save(update_fields=["status", "scheduled_at", "updated_at"])
+        # Keep any queue entry's slot mirror in step with the manual reschedule
+        # so the queue list shows the real time (the slot ops read scheduled_at,
+        # but the detail page still orders by assigned_slot_datetime).
+        QueueEntry.objects.filter(post=post, queue__social_account=pp.social_account).update(
+            assigned_slot_datetime=new_dt
+        )
         sync_post_scheduled_at(post)
     except (ValueError, TypeError) as e:
         return JsonResponse({"error": f"Invalid datetime: {e}"}, status=400)

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -21,7 +21,7 @@ from apps.social_accounts.models import SocialAccount
 from apps.workspaces.models import Workspace
 
 from .holidays import get_holidays_for_range
-from .models import CustomCalendarEvent, PostingSlot, Queue
+from .models import CustomCalendarEvent, PostingSlot, Queue, QueueEntry
 
 # Common timezones for the publish page timezone dropdown
 COMMON_TIMEZONES = [
@@ -1258,12 +1258,16 @@ def queue_create(request, workspace_id):
 @login_required
 def queue_detail(request, workspace_id, queue_id):
     """Show queue entries in order with drag-to-reorder."""
+    from django.db.models import F
+
     workspace = _get_workspace(request, workspace_id)
     queue = get_object_or_404(Queue, id=queue_id, workspace=workspace)
+    # Slot datetime is the source of truth for order now (positions can be sparse
+    # after gap-fills); show entries chronologically, unslotted ones last.
     entries = (
         queue.entries.select_related("post__author")
         .prefetch_related("post__platform_posts__social_account")
-        .order_by("position")
+        .order_by(F("assigned_slot_datetime").asc(nulls_last=True), "position")
     )
 
     return render(
@@ -1307,6 +1311,54 @@ def queue_reorder(request, workspace_id, queue_id):
     if request.htmx:
         return HttpResponse(status=204, headers={"HX-Trigger": "queueReordered"})
     return JsonResponse({"reordered": True})
+
+
+@login_required
+@require_POST
+def queue_entry_remove(request, workspace_id, queue_id, entry_id):
+    """Remove a single post from a queue, leaving a gap (comment §3).
+
+    Workspace-scoped and idempotent: a vanished entry (stale page, double-click)
+    still refreshes the list via the ``queueReordered`` trigger instead of 404ing.
+    """
+    workspace = _get_workspace(request, workspace_id)
+    entry = (
+        QueueEntry.objects.filter(id=entry_id, queue_id=queue_id, queue__workspace=workspace)
+        .select_related("post", "queue__social_account")
+        .first()
+    )
+    if entry is not None:
+        from .services import remove_from_queue
+
+        remove_from_queue(entry)
+
+    if request.htmx:
+        return HttpResponse(status=204, headers={"HX-Trigger": "queueReordered"})
+    return JsonResponse({"removed": entry is not None})
+
+
+@login_required
+@require_POST
+def queue_entry_reslot(request, workspace_id, queue_id, entry_id):
+    """Move a queued post to the queue's next open slot (comment §4)."""
+    workspace = _get_workspace(request, workspace_id)
+    entry = get_object_or_404(
+        QueueEntry.objects.select_related("post", "queue__social_account"),
+        id=entry_id,
+        queue_id=queue_id,
+        queue__workspace=workspace,
+    )
+
+    from .services import QueueFullError, reslot_to_next_available
+
+    try:
+        reslot_to_next_available(entry)
+    except QueueFullError:
+        return JsonResponse({"error": "No open slot within the scheduling horizon."}, status=409)
+
+    if request.htmx:
+        return HttpResponse(status=204, headers={"HX-Trigger": "queueReordered"})
+    return JsonResponse({"reslotted": True})
 
 
 # ---------------------------------------------------------------------------

--- a/apps/composer/services.py
+++ b/apps/composer/services.py
@@ -318,7 +318,7 @@ def clone_post(post, *, author=None):
                         platform_specific_title=pp.platform_specific_title,
                         platform_specific_caption=pp.platform_specific_caption,
                         platform_specific_first_comment=pp.platform_specific_first_comment,
-                        platform_specific_media=pp.platform_specific_media,
+                        platform_specific_media=copy.deepcopy(pp.platform_specific_media),
                         platform_extra=copy.deepcopy(pp.platform_extra) if pp.platform_extra else {},
                     )
                     for pp in children
@@ -333,7 +333,7 @@ def clone_post(post, *, author=None):
                         media_asset=pm.media_asset,
                         position=pm.position,
                         alt_text=pm.alt_text,
-                        platform_overrides=pm.platform_overrides,
+                        platform_overrides=copy.deepcopy(pm.platform_overrides),
                     )
                     for pm in media
                 ]

--- a/apps/composer/services.py
+++ b/apps/composer/services.py
@@ -265,6 +265,15 @@ def transition_platform_post(
             if platform_post.scheduled_at is not None:
                 platform_post.scheduled_at = None
                 update_fields.add("scheduled_at")
+            # A drafted child is no longer queued — drop its QueueEntry so the
+            # slot frees as a gap. Covers cancel / unschedule paths that would
+            # otherwise orphan the row with a stale assigned_slot_datetime.
+            from apps.calendar.models import QueueEntry
+
+            QueueEntry.objects.filter(
+                post=platform_post.post,
+                queue__social_account=platform_post.social_account,
+            ).delete()
         elif target_status == "published":
             update_fields.add("published_at")  # set by transition_to
         platform_post.save(update_fields=list(update_fields))

--- a/apps/composer/services.py
+++ b/apps/composer/services.py
@@ -12,6 +12,7 @@ status transitions so audit + idempotency live in one place.
 
 from __future__ import annotations
 
+import copy
 import datetime as dt
 import uuid
 from collections.abc import Iterable
@@ -280,6 +281,64 @@ def transition_platform_post(
 
     sync_post_scheduled_at(platform_post.post)
     return platform_post
+
+
+def clone_post(post, *, author=None):
+    """Create a fresh DRAFT duplicate of *post* (Clone / Repost).
+
+    Copies caption, title, first comment, internal notes, tags, category, every
+    per-platform override (``platform_specific_*`` + ``platform_extra``) and all
+    media attachments. The copy starts as a ``draft`` with no schedule, so a
+    published (or any) post can be re-edited and re-queued without touching the
+    original. ``author`` defaults to the source author.
+    """
+    from django.db import transaction
+
+    from apps.composer.models import PlatformPost, Post, PostMedia
+
+    with transaction.atomic():
+        new_post = Post.objects.create(
+            workspace=post.workspace,
+            author=author or post.author,
+            title=(f"Copy of {post.title}" if post.title else ""),
+            caption=post.caption,
+            first_comment=post.first_comment,
+            internal_notes=post.internal_notes,
+            tags=post.tags,
+            category=post.category,
+        )
+        children = list(post.platform_posts.all())
+        if children:
+            PlatformPost.objects.bulk_create(
+                [
+                    PlatformPost(
+                        post=new_post,
+                        social_account=pp.social_account,
+                        status="draft",
+                        platform_specific_title=pp.platform_specific_title,
+                        platform_specific_caption=pp.platform_specific_caption,
+                        platform_specific_first_comment=pp.platform_specific_first_comment,
+                        platform_specific_media=pp.platform_specific_media,
+                        platform_extra=copy.deepcopy(pp.platform_extra) if pp.platform_extra else {},
+                    )
+                    for pp in children
+                ]
+            )
+        media = list(post.media_attachments.all())
+        if media:
+            PostMedia.objects.bulk_create(
+                [
+                    PostMedia(
+                        post=new_post,
+                        media_asset=pm.media_asset,
+                        position=pm.position,
+                        alt_text=pm.alt_text,
+                        platform_overrides=pm.platform_overrides,
+                    )
+                    for pm in media
+                ]
+            )
+    return new_post
 
 
 # ---------------------------------------------------------------------------

--- a/apps/composer/tests/test_clone.py
+++ b/apps/composer/tests/test_clone.py
@@ -1,0 +1,119 @@
+"""Tests for clone_post (Clone / Repost) — service + endpoint."""
+
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from apps.accounts.models import User
+from apps.composer.models import PlatformPost, Post
+from apps.composer.services import clone_post
+from apps.members.models import OrgMembership, WorkspaceMembership
+from apps.organizations.models import Organization
+from apps.social_accounts.models import SocialAccount
+from apps.workspaces.models import Workspace
+
+
+class ClonePostServiceTest(TestCase):
+    def setUp(self):
+        self.org = Organization.objects.create(name="Clone Org")
+        self.workspace = Workspace.objects.create(organization=self.org, name="Clone WS")
+        self.author = User.objects.create_user(
+            email="author@example.com", password="pw", tos_accepted_at=timezone.now()
+        )
+        self.account = SocialAccount.objects.create(
+            workspace=self.workspace,
+            platform="tiktok",
+            account_platform_id="tt-clone",
+            account_name="TT",
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+        self.post = Post.objects.create(
+            workspace=self.workspace,
+            author=self.author,
+            title="Launch",
+            caption="hello world",
+            tags=["a", "b"],
+        )
+        self.pp = PlatformPost.objects.create(
+            post=self.post,
+            social_account=self.account,
+            status=PlatformPost.Status.PUBLISHED,
+            published_at=timezone.now(),
+            scheduled_at=timezone.now(),
+            platform_specific_caption="tiktok caption",
+            platform_extra={"privacy_level": "SELF_ONLY", "disable_duet": True},
+        )
+
+    def test_clone_creates_independent_draft_copy(self):
+        clone = clone_post(self.post, author=self.author)
+
+        self.assertNotEqual(clone.id, self.post.id)
+        self.assertEqual(clone.caption, "hello world")
+        self.assertEqual(clone.title, "Copy of Launch")
+        self.assertEqual(clone.tags, ["a", "b"])
+        self.assertIsNone(clone.scheduled_at)
+
+        child = clone.platform_posts.get()
+        self.assertEqual(child.status, PlatformPost.Status.DRAFT)
+        self.assertIsNone(child.scheduled_at)
+        self.assertIsNone(child.published_at)
+        self.assertEqual(child.social_account, self.account)
+        self.assertEqual(child.platform_specific_caption, "tiktok caption")
+        self.assertEqual(child.platform_extra, {"privacy_level": "SELF_ONLY", "disable_duet": True})
+
+        # Mutating the clone's extras must not bleed into the source (deepcopy).
+        child.platform_extra["privacy_level"] = "PUBLIC"
+        child.save(update_fields=["platform_extra"])
+        self.pp.refresh_from_db()
+        self.assertEqual(self.pp.platform_extra["privacy_level"], "SELF_ONLY")
+
+
+class ClonePostEndpointTest(TestCase):
+    def setUp(self):
+        self.org = Organization.objects.create(name="Clone EP Org")
+        self.workspace = Workspace.objects.create(organization=self.org, name="Clone EP WS")
+        self.owner = User.objects.create_user(email="owner@example.com", password="pw", tos_accepted_at=timezone.now())
+        OrgMembership.objects.create(user=self.owner, organization=self.org, org_role=OrgMembership.OrgRole.OWNER)
+        WorkspaceMembership.objects.create(
+            user=self.owner, workspace=self.workspace, workspace_role=WorkspaceMembership.WorkspaceRole.OWNER
+        )
+        self.account = SocialAccount.objects.create(
+            workspace=self.workspace,
+            platform="linkedin_personal",
+            account_platform_id="li-clone",
+            account_name="LI",
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+        self.post = Post.objects.create(workspace=self.workspace, author=self.owner, caption="published thing")
+        PlatformPost.objects.create(
+            post=self.post,
+            social_account=self.account,
+            status=PlatformPost.Status.PUBLISHED,
+            published_at=timezone.now(),
+        )
+
+    def test_clone_endpoint_creates_draft_and_redirects(self):
+        self.client.force_login(self.owner)
+        url = reverse("composer:clone_post", kwargs={"workspace_id": self.workspace.id, "post_id": self.post.id})
+        resp = self.client.post(url, HTTP_HX_REQUEST="true")
+
+        self.assertEqual(resp.status_code, 204)
+        redirect_url = resp.headers.get("HX-Redirect", "")
+        self.assertIn("/compose/", redirect_url)
+
+        clone = Post.objects.exclude(id=self.post.id).get(workspace=self.workspace)
+        self.assertEqual(clone.caption, "published thing")
+        self.assertEqual(clone.platform_posts.get().status, PlatformPost.Status.DRAFT)
+        self.assertIn(str(clone.id), redirect_url)
+
+    def test_clone_endpoint_denies_member_without_create_posts(self):
+        viewer = User.objects.create_user(email="viewer@example.com", password="pw", tos_accepted_at=timezone.now())
+        WorkspaceMembership.objects.create(
+            user=viewer, workspace=self.workspace, workspace_role=WorkspaceMembership.WorkspaceRole.VIEWER
+        )
+        self.client.force_login(viewer)
+        url = reverse("composer:clone_post", kwargs={"workspace_id": self.workspace.id, "post_id": self.post.id})
+        resp = self.client.post(url, HTTP_HX_REQUEST="true")
+
+        self.assertEqual(resp.status_code, 403)
+        self.assertEqual(Post.objects.filter(workspace=self.workspace).count(), 1)

--- a/apps/composer/tests/test_queue_rollback.py
+++ b/apps/composer/tests/test_queue_rollback.py
@@ -1,0 +1,78 @@
+"""Add-to-Queue must be atomic across queues: a full queue rolls back partials."""
+
+from datetime import time
+
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from apps.accounts.models import User
+from apps.calendar.models import PostingSlot, Queue, QueueEntry
+from apps.composer.models import PlatformPost, Post
+from apps.members.models import OrgMembership, WorkspaceMembership
+from apps.organizations.models import Organization
+from apps.social_accounts.models import SocialAccount
+from apps.workspaces.models import Workspace
+
+
+class AddToQueueRollbackTest(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(email="rb@example.com", password="pw", tos_accepted_at=timezone.now())
+        self.org = Organization.objects.create(name="RB Org")
+        self.workspace = Workspace.objects.create(organization=self.org, name="RB WS")
+        OrgMembership.objects.create(user=self.user, organization=self.org, org_role=OrgMembership.OrgRole.OWNER)
+        WorkspaceMembership.objects.create(
+            user=self.user, workspace=self.workspace, workspace_role=WorkspaceMembership.WorkspaceRole.OWNER
+        )
+        self.client.force_login(self.user)
+
+        # Account A has posting slots; account B has none, so its queue is always full.
+        self.acct_a = SocialAccount.objects.create(
+            workspace=self.workspace,
+            platform="linkedin_personal",
+            account_platform_id="li-a",
+            account_name="A",
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+        self.acct_b = SocialAccount.objects.create(
+            workspace=self.workspace,
+            platform="bluesky",
+            account_platform_id="bs-b",
+            account_name="B",
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+        for day in range(7):
+            PostingSlot.objects.create(social_account=self.acct_a, day_of_week=day, time=time(9, 0))
+        Queue.objects.create(workspace=self.workspace, name="QA", social_account=self.acct_a)
+        Queue.objects.create(workspace=self.workspace, name="QB", social_account=self.acct_b)
+
+        self.post = Post.objects.create(workspace=self.workspace, author=self.user, caption="multi")
+        self.pp_a = PlatformPost.objects.create(
+            post=self.post, social_account=self.acct_a, status=PlatformPost.Status.DRAFT
+        )
+        self.pp_b = PlatformPost.objects.create(
+            post=self.post, social_account=self.acct_b, status=PlatformPost.Status.DRAFT
+        )
+
+    def test_full_queue_rolls_back_the_other_queue_writes(self):
+        url = reverse("composer:save_post_edit", kwargs={"workspace_id": self.workspace.id, "post_id": self.post.id})
+        resp = self.client.post(
+            url,
+            data={
+                "action": "add_to_queue",
+                "title": "",
+                "caption": "multi",
+                "tags": "",
+                "selected_accounts": f"{self.acct_a.id},{self.acct_b.id}",
+            },
+        )
+
+        self.assertEqual(resp.status_code, 400)
+        # No partial state: no queue entries, both children still draft + unscheduled.
+        self.assertEqual(QueueEntry.objects.filter(post=self.post).count(), 0)
+        self.pp_a.refresh_from_db()
+        self.pp_b.refresh_from_db()
+        self.assertIsNone(self.pp_a.scheduled_at)
+        self.assertIsNone(self.pp_b.scheduled_at)
+        self.assertEqual(self.pp_a.status, PlatformPost.Status.DRAFT)
+        self.assertEqual(self.pp_b.status, PlatformPost.Status.DRAFT)

--- a/apps/composer/urls.py
+++ b/apps/composer/urls.py
@@ -58,6 +58,8 @@ urlpatterns = [
     path("drafts/", views.drafts_list, name="drafts_list"),
     # Post delete
     path("compose/<uuid:post_id>/delete/", views.post_delete, name="post_delete"),
+    # Clone / Repost
+    path("compose/<uuid:post_id>/clone/", views.clone_post_view, name="clone_post"),
     # Content Categories
     path("categories/", views.category_list, name="category_list"),
     path("categories/create/", views.category_create, name="category_create"),

--- a/apps/composer/views.py
+++ b/apps/composer/views.py
@@ -51,6 +51,9 @@ from .models import (
 
 MAX_CSV_UPLOAD_BYTES = 5 * 1024 * 1024  # 5 MB cap on CSV planner imports
 
+# Shown when every posting slot within the lookahead horizon is already taken.
+_QUEUE_FULL_MSG = "No open posting slot within the scheduling horizon — add posting slots or free one up."
+
 
 def _get_workspace(request, workspace_id):
     """Resolve workspace and enforce membership check."""
@@ -292,32 +295,33 @@ def _resolve_queues_for_post(queue_id, workspace, post_data):
 
 
 def _reassign_queue_slots_from_floor(queues, post, floor_date, workspace):
-    """Override per-platform scheduled_at for *post* with the next posting slot
-    on/after *floor_date* for each queue's social account.
+    """Re-slot *post* into each queue's first open slot on/after *floor_date*.
 
-    Used when the composer was opened from a specific calendar day - we want
-    each platform to pick its earliest available slot starting that day,
-    independently.
+    Used when the composer was opened from a specific calendar day — each
+    platform picks its earliest *free* slot (a gap, not a raw next slot, so it
+    never double-books) starting that day. Keeps the QueueEntry mirror in sync
+    with the PlatformPost the publisher fires on.
     """
-    from apps.calendar.services import _next_slot_datetimes
-    from apps.composer.services import sync_post_scheduled_at
-
-    ws_tz = workspace.effective_timezone or "UTC"
     import zoneinfo
 
-    tz = zoneinfo.ZoneInfo(ws_tz)
+    from apps.calendar.models import QueueEntry
+    from apps.calendar.services import _next_available_slot
+    from apps.composer.services import sync_post_scheduled_at
+
+    tz = zoneinfo.ZoneInfo(workspace.effective_timezone or "UTC")
     floor_dt = datetime.combine(floor_date, datetime.min.time()).replace(tzinfo=tz)
     floor_dt = max(floor_dt, timezone.now())
 
     for q in queues:
-        slots = _next_slot_datetimes(q.social_account, floor_dt, count=1)
-        if not slots:
-            continue
         pp = post.platform_posts.filter(social_account=q.social_account).first()
         if pp is None:
             continue
-        pp.scheduled_at = slots[0]
+        slot = _next_available_slot(q.social_account, exclude_pp_ids=[pp.id], after=floor_dt)
+        if slot is None:
+            continue
+        pp.scheduled_at = slot
         pp.save(update_fields=["scheduled_at", "updated_at"])
+        QueueEntry.objects.filter(post=post, queue=q).update(assigned_slot_datetime=slot)
 
     sync_post_scheduled_at(post)
 
@@ -772,7 +776,7 @@ def save_post(request, workspace_id, post_id=None):
         pending_target = "scheduled"
         initial_status = "scheduled"
     elif action == "add_to_queue":
-        from apps.calendar.services import add_to_queue
+        from apps.calendar.services import QueueFullError, add_to_queue
 
         queue_id = request.POST.get("queue_id")
         queues = _resolve_queues_for_post(queue_id, workspace, request.POST)
@@ -784,8 +788,11 @@ def save_post(request, workspace_id, post_id=None):
         # Ensure PlatformPost rows exist for every selected account before the
         # queue service writes per-platform scheduled_at values.
         _sync_platform_posts(request, post, workspace, initial_status="draft")
-        for q in queues:
-            add_to_queue(post, q)
+        try:
+            for q in queues:
+                add_to_queue(post, q)
+        except QueueFullError:
+            return JsonResponse({"errors": {"queue": _QUEUE_FULL_MSG}}, status=400)
         # If opened from a specific calendar day (month/week/day "+" CTA), each
         # queue should use that day as its floor - re-assign slots accordingly.
         floor_date = form.cleaned_data.get("scheduled_date")
@@ -804,7 +811,7 @@ def save_post(request, workspace_id, post_id=None):
             )
         return redirect("composer:compose_edit", workspace_id=workspace.id, post_id=post.id)
     elif action == "add_to_queue_priority":
-        from apps.calendar.services import add_to_queue
+        from apps.calendar.services import QueueFullError, add_to_queue
 
         queue_id = request.POST.get("queue_id")
         queues = _resolve_queues_for_post(queue_id, workspace, request.POST)
@@ -814,8 +821,11 @@ def save_post(request, workspace_id, post_id=None):
         post.proposed_publish_at = None
         post.save()
         _sync_platform_posts(request, post, workspace, initial_status="draft")
-        for q in queues:
-            add_to_queue(post, q, priority=True)
+        try:
+            for q in queues:
+                add_to_queue(post, q, priority=True)
+        except QueueFullError:
+            return JsonResponse({"errors": {"queue": _QUEUE_FULL_MSG}}, status=400)
         _transition_post_children(post, "scheduled", only=_scoped_platform_post_ids(request, post))
         _save_version(post, request.user)
         if request.htmx:

--- a/apps/composer/views.py
+++ b/apps/composer/views.py
@@ -2092,6 +2092,34 @@ def post_delete(request, workspace_id, post_id):
     )
 
 
+@login_required
+@require_POST
+def clone_post_view(request, workspace_id, post_id):
+    """Clone a post into a fresh draft (Clone / Repost) and open the copy.
+
+    The composer makes published/publishing posts read-only; this is the escape
+    hatch to repost — the duplicate starts as a draft with the same content but
+    no schedule, so it can be edited and re-queued without touching the original.
+    """
+    from django.urls import reverse
+
+    from apps.composer.services import clone_post
+
+    workspace = _get_workspace(request, workspace_id)
+    post = get_object_or_404(Post, id=post_id, workspace=workspace)
+
+    membership = request.workspace_membership
+    perms = membership.effective_permissions if membership else {}
+    if not perms.get("create_posts", False):
+        raise PermissionDenied("You do not have permission to create posts.")
+
+    new_post = clone_post(post, author=request.user)
+    target = reverse("composer:compose_edit", kwargs={"workspace_id": workspace.id, "post_id": new_post.id})
+    if request.htmx:
+        return HttpResponse(status=204, headers={"HX-Redirect": target})
+    return redirect(target)
+
+
 # ---------------------------------------------------------------------------
 # Create landing page & Idea CRUD
 # ---------------------------------------------------------------------------

--- a/apps/composer/views.py
+++ b/apps/composer/views.py
@@ -776,6 +776,8 @@ def save_post(request, workspace_id, post_id=None):
         pending_target = "scheduled"
         initial_status = "scheduled"
     elif action == "add_to_queue":
+        from django.db import transaction
+
         from apps.calendar.services import QueueFullError, add_to_queue
 
         queue_id = request.POST.get("queue_id")
@@ -788,18 +790,22 @@ def save_post(request, workspace_id, post_id=None):
         # Ensure PlatformPost rows exist for every selected account before the
         # queue service writes per-platform scheduled_at values.
         _sync_platform_posts(request, post, workspace, initial_status="draft")
+        # If opened from a specific calendar day (month/week/day "+" CTA), that
+        # day is each queue's slot floor.
+        floor_date = form.cleaned_data.get("scheduled_date")
         try:
-            for q in queues:
-                add_to_queue(post, q)
+            # One transaction across every queue: if a later queue is full, the
+            # earlier queues' slot writes roll back instead of leaving a child
+            # half-queued.
+            with transaction.atomic():
+                for q in queues:
+                    add_to_queue(post, q)
+                if floor_date:
+                    _reassign_queue_slots_from_floor(queues, post, floor_date, workspace)
+                # Transition every child whose scheduled_at was filled in.
+                _transition_post_children(post, "scheduled", only=_scoped_platform_post_ids(request, post))
         except QueueFullError:
             return JsonResponse({"errors": {"queue": _QUEUE_FULL_MSG}}, status=400)
-        # If opened from a specific calendar day (month/week/day "+" CTA), each
-        # queue should use that day as its floor - re-assign slots accordingly.
-        floor_date = form.cleaned_data.get("scheduled_date")
-        if floor_date:
-            _reassign_queue_slots_from_floor(queues, post, floor_date, workspace)
-        # Transition every child whose scheduled_at was filled in to "scheduled".
-        _transition_post_children(post, "scheduled", only=_scoped_platform_post_ids(request, post))
         _save_version(post, request.user)
         if request.htmx:
             return HttpResponse(
@@ -811,6 +817,8 @@ def save_post(request, workspace_id, post_id=None):
             )
         return redirect("composer:compose_edit", workspace_id=workspace.id, post_id=post.id)
     elif action == "add_to_queue_priority":
+        from django.db import transaction
+
         from apps.calendar.services import QueueFullError, add_to_queue
 
         queue_id = request.POST.get("queue_id")
@@ -822,11 +830,13 @@ def save_post(request, workspace_id, post_id=None):
         post.save()
         _sync_platform_posts(request, post, workspace, initial_status="draft")
         try:
-            for q in queues:
-                add_to_queue(post, q, priority=True)
+            # One transaction across every queue (see add_to_queue above).
+            with transaction.atomic():
+                for q in queues:
+                    add_to_queue(post, q, priority=True)
+                _transition_post_children(post, "scheduled", only=_scoped_platform_post_ids(request, post))
         except QueueFullError:
             return JsonResponse({"errors": {"queue": _QUEUE_FULL_MSG}}, status=400)
-        _transition_post_children(post, "scheduled", only=_scoped_platform_post_ids(request, post))
         _save_version(post, request.user)
         if request.htmx:
             return HttpResponse(

--- a/apps/publisher/engine.py
+++ b/apps/publisher/engine.py
@@ -216,6 +216,18 @@ class PublishEngine:
                 platform_post.published_at = timezone.now()
                 platform_post.save()
 
+                # A published post leaves the queue: drop the QueueEntry that
+                # held this channel's slot so the queue shows only upcoming
+                # posts and the slot frees up as a gap. Structurally prevents a
+                # published row from ever being re-slotted (the lingering-entry
+                # bug class). The PlatformPost + published_at are kept.
+                from apps.calendar.models import QueueEntry
+
+                QueueEntry.objects.filter(
+                    post_id=platform_post.post_id,
+                    queue__social_account_id=platform_post.social_account_id,
+                ).delete()
+
                 # Log success
                 PublishLog.objects.create(
                     platform_post=platform_post,

--- a/apps/publisher/engine.py
+++ b/apps/publisher/engine.py
@@ -217,16 +217,24 @@ class PublishEngine:
                 platform_post.save()
 
                 # A published post leaves the queue: drop the QueueEntry that
-                # held this channel's slot so the queue shows only upcoming
-                # posts and the slot frees up as a gap. Structurally prevents a
-                # published row from ever being re-slotted (the lingering-entry
-                # bug class). The PlatformPost + published_at are kept.
-                from apps.calendar.models import QueueEntry
+                # held this channel's slot so the queue shows only upcoming posts
+                # and the slot frees up as a gap. Best-effort and isolated: the
+                # publish has already succeeded, so a cleanup failure here must
+                # NOT fall through to the `except` below (which would schedule a
+                # retry and double-post). The PlatformPost + published_at are kept.
+                try:
+                    from apps.calendar.models import QueueEntry
 
-                QueueEntry.objects.filter(
-                    post_id=platform_post.post_id,
-                    queue__social_account_id=platform_post.social_account_id,
-                ).delete()
+                    QueueEntry.objects.filter(
+                        post_id=platform_post.post_id,
+                        queue__social_account_id=platform_post.social_account_id,
+                    ).delete()
+                except Exception:
+                    logger.warning(
+                        "Failed to drop QueueEntry for published PlatformPost %s",
+                        platform_post.id,
+                        exc_info=True,
+                    )
 
                 # Log success
                 PublishLog.objects.create(

--- a/apps/publisher/tests.py
+++ b/apps/publisher/tests.py
@@ -313,3 +313,22 @@ class PublishedPostLeavesQueueTest(TestCase):
         self.assertIsNotNone(self.pp.published_at)
         # The QueueEntry is gone (slot freed), but the PlatformPost remains.
         self.assertFalse(QueueEntry.objects.filter(id=self.entry.id).exists())
+
+    def test_publish_success_survives_queue_cleanup_failure(self):
+        from apps.composer.models import PlatformPost
+
+        engine = PublishEngine()
+        success = {"success": True, "platform_post_id": "x", "status_code": 200, "response": {}}
+        # The post is durably published; if the QueueEntry cleanup then fails it
+        # must NOT fall through to a retry (which would re-dispatch and double-post).
+        with (
+            patch.object(PublishEngine, "_dispatch_to_provider", return_value=success),
+            patch("apps.calendar.models.QueueEntry.objects") as mock_objects,
+        ):
+            mock_objects.filter.side_effect = Exception("db unavailable")
+            engine._publish_platform_post(self.pp)
+
+        self.pp.refresh_from_db()
+        self.assertEqual(self.pp.status, PlatformPost.Status.PUBLISHED)
+        self.assertEqual(self.pp.retry_count, 0)
+        self.assertIsNone(self.pp.next_retry_at)

--- a/apps/publisher/tests.py
+++ b/apps/publisher/tests.py
@@ -266,3 +266,50 @@ class NonRetryableFailureTest(TestCase):
         self.assertEqual(self.platform_post.retry_count, 1)
         self.assertIsNotNone(self.platform_post.next_retry_at)
         self.assertEqual(PublishLog.objects.filter(platform_post=self.platform_post).count(), 1)
+
+
+class PublishedPostLeavesQueueTest(TestCase):
+    """A successful publish drops the post's QueueEntry, freeing the slot."""
+
+    def setUp(self):
+        from apps.calendar.models import Queue, QueueEntry
+        from apps.composer.models import PlatformPost, Post
+        from apps.organizations.models import Organization
+        from apps.social_accounts.models import SocialAccount
+        from apps.workspaces.models import Workspace
+
+        self.org = Organization.objects.create(name="Org")
+        self.workspace = Workspace.objects.create(organization=self.org, name="WS")
+        self.account = SocialAccount.objects.create(
+            workspace=self.workspace,
+            platform="linkedin_personal",
+            account_platform_id="li-1",
+            account_name="LI",
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+        self.queue = Queue.objects.create(workspace=self.workspace, name="Q", social_account=self.account)
+        self.post = Post.objects.create(workspace=self.workspace, caption="hi")
+        self.pp = PlatformPost.objects.create(
+            post=self.post,
+            social_account=self.account,
+            status=PlatformPost.Status.PUBLISHING,
+            scheduled_at=timezone.now() + timedelta(hours=1),
+        )
+        self.entry = QueueEntry.objects.create(
+            queue=self.queue, post=self.post, position=0, assigned_slot_datetime=self.pp.scheduled_at
+        )
+
+    def test_publish_success_removes_queue_entry(self):
+        from apps.calendar.models import QueueEntry
+        from apps.composer.models import PlatformPost
+
+        engine = PublishEngine()
+        success = {"success": True, "platform_post_id": "x", "status_code": 200, "response": {}}
+        with patch.object(PublishEngine, "_dispatch_to_provider", return_value=success):
+            engine._publish_platform_post(self.pp)
+
+        self.pp.refresh_from_db()
+        self.assertEqual(self.pp.status, PlatformPost.Status.PUBLISHED)
+        self.assertIsNotNone(self.pp.published_at)
+        # The QueueEntry is gone (slot freed), but the PlatformPost remains.
+        self.assertFalse(QueueEntry.objects.filter(id=self.entry.id).exists())

--- a/templates/calendar/queue_detail.html
+++ b/templates/calendar/queue_detail.html
@@ -52,7 +52,7 @@
 
     <div id="entries-list" class="space-y-2">
         {% for entry in entries %}
-        <div class="flex items-center gap-3 p-3 bg-white rounded-lg border border-stone-200 hover:border-stone-300 transition-colors cursor-grab active:cursor-grabbing"
+        <div class="group flex items-center gap-3 p-3 bg-white rounded-lg border border-stone-200 hover:border-stone-300 transition-colors cursor-grab active:cursor-grabbing"
              draggable="true"
              data-entry-id="{{ entry.id }}"
              @dragstart="onDragStart($event, '{{ entry.id }}')"
@@ -64,9 +64,9 @@
                 <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><circle cx="9" cy="6" r="1.5"/><circle cx="15" cy="6" r="1.5"/><circle cx="9" cy="12" r="1.5"/><circle cx="15" cy="12" r="1.5"/><circle cx="9" cy="18" r="1.5"/><circle cx="15" cy="18" r="1.5"/></svg>
             </div>
 
-            <!-- Position badge -->
+            <!-- Slot order -->
             <div class="w-6 h-6 rounded-full bg-stone-100 flex items-center justify-center text-[10px] font-bold text-stone-500 flex-shrink-0">
-                {{ entry.position|add:1 }}
+                {{ forloop.counter }}
             </div>
 
             <!-- Post info -->
@@ -98,6 +98,17 @@
                 <span class="text-xs text-stone-400">No slot</span>
                 {% endif %}
             </div>
+
+            <!-- Remove from queue (leaves a gap; the slot frees up) -->
+            <button type="button"
+                    class="text-stone-300 hover:text-red-500 transition-colors flex-shrink-0 opacity-0 group-hover:opacity-100"
+                    hx-post="{% url 'calendar:queue_entry_remove' workspace_id=workspace.id queue_id=queue.id entry_id=entry.id %}"
+                    hx-confirm="Remove this post from the queue? Its slot will free up."
+                    @click.stop
+                    @dragstart.stop
+                    title="Remove from queue">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+            </button>
         </div>
         {% empty %}
         <div class="text-center py-16">

--- a/templates/composer/compose.html
+++ b/templates/composer/compose.html
@@ -365,6 +365,38 @@
                         {{ pp.publish_error }}
                     </p>
                     {% endfor %}
+                    {% if post %}
+                    <div class="pt-1 pl-5.5">
+                        <button type="button"
+                                class="text-xs font-semibold text-red-700 hover:text-red-900 underline underline-offset-2"
+                                hx-post="{% url 'composer:clone_post' workspace_id=workspace.id post_id=post.id %}"
+                                title="Open an editable draft copy to fix and re-queue">
+                            Clone to retry →
+                        </button>
+                    </div>
+                    {% endif %}
+                </div>
+                {% endif %}
+
+                {% if post and post.status == 'scheduled' %}
+                <!-- Scheduled: editable, but warn that edits affect a live schedule -->
+                <div class="border border-amber-200 bg-amber-50 rounded-xl p-3 flex items-start gap-2">
+                    <svg class="w-4 h-4 text-amber-500 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 9v3.75m9-.75a9 9 0 11-18 0 9 9 0 0118 0zm-9 3.75h.008v.008H12v-.008z"/></svg>
+                    <p class="text-xs text-amber-700">This post is <span class="font-semibold">scheduled</span>. Saving changes will affect the scheduled post.</p>
+                </div>
+                {% elif post and post.status == 'published' or post and post.status == 'partially_published' or post and post.status == 'publishing' %}
+                <!-- Published / publishing: read-only; Clone to repost an editable copy -->
+                <div class="border border-stone-200 bg-stone-50 rounded-xl p-3 flex items-start justify-between gap-3">
+                    <div class="flex items-start gap-2">
+                        <svg class="w-4 h-4 text-stone-400 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z"/></svg>
+                        <p class="text-xs text-stone-600">This post is <span class="font-semibold">{{ post.get_status_display|default:post.status }}</span> and read-only. Use <span class="font-semibold">Clone</span> to repost an editable copy.</p>
+                    </div>
+                    <button type="button"
+                            class="text-xs font-semibold px-3 py-1.5 rounded-lg bg-stone-800 text-white hover:bg-stone-900 flex-shrink-0 cursor-pointer"
+                            hx-post="{% url 'composer:clone_post' workspace_id=workspace.id post_id=post.id %}"
+                            title="Create an editable draft copy">
+                        Clone
+                    </button>
                 </div>
                 {% endif %}
 


### PR DESCRIPTION
## What does this PR do?

Reworks the content queue from "recompute every entry's datetime from `now` on each change" to a **stable slot-occupancy model** with persistent gaps, matching the flow proposed in [#96 (comment)](https://github.com/brightbeanxyz/brightbean-studio/pull/96#issuecomment-4768530506), and adds the status guard rails from that comment.

**Queue mechanics (comment §1–4)** — `apps/calendar/services.py`
- Occupancy is derived from `PlatformPost.scheduled_at` (the publisher's source of truth, excluding published/publishing) — a *gap* is an upcoming posting-slot datetime nobody holds. Operations are **local**: an entry's slot stays stable until it is explicitly moved.
- `add_post_next_available` → fill the first gap (upsert-aware, so **Edit · Next Available** reuses it). `prioritize` → take slot `[0]`; if taken, ladder each occupied entry `[k]→[k+1]` preserving the gap pattern. `remove_from_queue` → drop the entry, draft the child, leave a gap. `reslot_to_next_available`; `reorder_queue` now permutes occupied datetimes.
- `add_to_queue` stays as a thin back-compat dispatcher, so the composer's `add_to_queue` / `add_to_queue_priority` actions only needed their resolved service swapped. `QueueFullError` is surfaced as a 400 (not a 500).
- New single-entry endpoints `queue_entry_remove` / `queue_entry_reslot` + a per-entry **remove** button in `queue_detail` (now ordered by slot datetime).

**Lifecycle**
- Publisher drops the `QueueEntry` when a post publishes (`apps/publisher/engine.py`) — the queue holds only upcoming posts and a published row can never be re-slotted (the bug class from #96), making the existing guard + repair belt-and-suspenders.
- `transition_platform_post(→draft)` removes the matching `QueueEntry`, so cancel / unschedule free the slot instead of orphaning a stale row.
- Floor queueing (`_reassign_queue_slots_from_floor`) is now gap-aware and keeps the entry/PlatformPost in sync.

**Status guard rails (comment §5)** — `apps/composer/`
- `clone_post(post)` service → fresh DRAFT duplicate (overrides + `platform_extra` deepcopy + media); `/compose/<id>/clone/` endpoint (create_posts-gated).
- `compose.html`: SCHEDULED edit-warning banner; PUBLISHED/PUBLISHING read-only banner with a **Clone** CTA; FAILED block gains **Clone to retry**.

## Why?

The previous model recomputed every entry from `now` on each add/reorder, so slots drifted, gaps were impossible, two posts could collide on one time, and published entries lingered (root of #96). The proposed model makes placement local and predictable.

## How to test

```
pytest apps/calendar apps/composer apps/publisher apps/api -q   # 344 passing
```
Key new tests: `SlotOccupancyQueueTests` (first-gap, prioritize ladder + gap, remove/reslot, upsert, queue-full), `QueueEntryEndpointTests` (remove/reslot/render + cross-workspace), `PublishedPostLeavesQueueTest`, `ClonePost*Test`, plus the existing `QueueSlot*` / `Repair*` suites stay green.

Manual: from the composer publish menu, exercise **Next available** / **Prioritise**; in queue detail, remove an entry (leaves a gap) and confirm times stay stable; open a published post (read-only banner + Clone).

## Base branch

Stacked on **#96** (`fix/queue-reslot-published-scheduled-at`) — retarget to `main` once #96 merges.

## Checklist

- [x] Tests pass (`pytest`) — 344 across calendar/composer/publisher/api
- [x] Lint passes (`ruff check` / `ruff format --check`) + `manage.py check`
- [ ] Documentation updated (if applicable) — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)
