### PR TITLE
fix(tiktok): add PKCE to all OAuth flows (connect, reconnect, connection-link)

### DIFF
--- a/apps/onboarding/tests.py
+++ b/apps/onboarding/tests.py
@@ -1,0 +1,86 @@
+"""Tests for the connection-link OAuth flow — PKCE round-trip for TikTok.
+
+The connection-link flow is a second, public OAuth entry point (separate from
+social_accounts.connect_platform). It must apply PKCE for providers that need
+it (TikTok), otherwise the authorize URL lacks code_challenge and TikTok
+rejects it with errCode=10007.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from apps.onboarding.models import ConnectionLink
+from apps.onboarding.views import CONNECTION_LINK_OAUTH_SESSION_KEY, _sign_connection_link_state
+from providers.types import AccountProfile, OAuthTokens
+
+
+@pytest.fixture
+def workspace(db, organization):
+    from apps.workspaces.models import Workspace
+
+    return Workspace.objects.create(name="Test WS", organization=organization)
+
+
+@pytest.fixture
+def connection_link(db, workspace):
+    return ConnectionLink.objects.create(
+        workspace=workspace,
+        expires_at=timezone.now() + timezone.timedelta(days=1),
+    )
+
+
+@pytest.mark.django_db
+class TestConnectionLinkPkce:
+    def test_oauth_start_generates_and_forwards_verifier(self, client, workspace, connection_link):
+        from apps.credentials.models import PlatformCredential
+
+        PlatformCredential.objects.create(
+            organization=workspace.organization,
+            platform="tiktok",
+            credentials={"client_key": "k", "client_secret": "s"},
+            is_configured=True,
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.uses_pkce = True
+        mock_provider.get_auth_url.return_value = "https://www.tiktok.com/v2/auth/authorize/?ok=1"
+
+        url = reverse("onboarding:connection_oauth_start", kwargs={"token": connection_link.token})
+        with patch("apps.onboarding.views._get_provider_for_platform", return_value=mock_provider):
+            response = client.post(url, {"platform": "tiktok"})
+
+        assert response.status_code == 302
+        verifier = client.session[CONNECTION_LINK_OAUTH_SESSION_KEY]["code_verifier"]
+        assert verifier  # non-empty
+        _, kwargs = mock_provider.get_auth_url.call_args
+        assert kwargs["code_verifier"] == verifier
+
+    def test_oauth_callback_replays_verifier(self, client, workspace, connection_link):
+        nonce = "nonce-xyz"
+        verifier = "stored-connection-verifier"
+        state = _sign_connection_link_state(workspace.id, "tiktok", connection_link.token, nonce)
+        session = client.session
+        session[CONNECTION_LINK_OAUTH_SESSION_KEY] = {
+            "nonce": nonce,
+            "workspace_id": str(workspace.id),
+            "platform": "tiktok",
+            "token": connection_link.token,
+            "code_verifier": verifier,
+        }
+        session.save()
+
+        mock_provider = MagicMock()
+        mock_provider.exchange_code.return_value = OAuthTokens(access_token="tok", refresh_token="r", expires_in=3600)
+        mock_provider.get_profile.return_value = AccountProfile(platform_id="open-1", name="TT")
+
+        url = reverse("onboarding:oauth_callback", kwargs={"platform": "social1"})
+        with patch("apps.onboarding.views._get_provider_for_platform", return_value=mock_provider):
+            response = client.get(url, {"code": "auth-code", "state": state})
+
+        assert response.status_code == 302
+        mock_provider.exchange_code.assert_called_once()
+        _, kwargs = mock_provider.exchange_code.call_args
+        assert kwargs["code_verifier"] == verifier

--- a/apps/onboarding/views.py
+++ b/apps/onboarding/views.py
@@ -28,6 +28,7 @@ from apps.members.models import WorkspaceMembership
 from apps.notifications.engine import notify
 from apps.notifications.models import EventType
 from apps.social_accounts.oauth_aliases import from_url_slug, redirect_uri_from_request, to_url_slug
+from apps.social_accounts.oauth_pkce import issue_pkce_verifier, pkce_kwargs
 from apps.social_accounts.views import (
     _create_or_update_account,
     _get_configured_platforms,
@@ -311,6 +312,7 @@ def connection_oauth_start(request, token):
     provider = _get_provider_for_platform(platform, org.id)
     nonce = secrets.token_urlsafe(32)
     state = _sign_connection_link_state(link.workspace_id, platform, token, nonce)
+    code_verifier = issue_pkce_verifier(provider)
 
     # Store in session
     request.session[CONNECTION_LINK_OAUTH_SESSION_KEY] = {
@@ -318,10 +320,11 @@ def connection_oauth_start(request, token):
         "workspace_id": str(link.workspace_id),
         "platform": platform,
         "token": token,
+        "code_verifier": code_verifier,
     }
 
     redirect_uri = _build_connection_redirect_uri(request, platform)
-    auth_url = provider.get_auth_url(redirect_uri, state)
+    auth_url = provider.get_auth_url(redirect_uri, state, **pkce_kwargs(code_verifier))
     return redirect(auth_url)
 
 
@@ -409,7 +412,7 @@ def connection_oauth_callback(request, platform):
 
         provider = _get_provider_for_platform(platform, org.id, **extra_creds)
         redirect_uri = redirect_uri_from_request(request)
-        tokens = provider.exchange_code(code, redirect_uri)
+        tokens = provider.exchange_code(code, redirect_uri, **pkce_kwargs(session_data.get("code_verifier")))
         profile = provider.get_profile(tokens.access_token)
 
         # Handle Facebook/Instagram multi-page: auto-connect first page

--- a/apps/social_accounts/oauth_pkce.py
+++ b/apps/social_accounts/oauth_pkce.py
@@ -1,0 +1,43 @@
+"""Client-side PKCE helpers for outbound OAuth flows.
+
+Some providers (currently TikTok) require PKCE on the authorization request.
+These helpers centralise the verifier lifecycle so every OAuth-initiation
+site — connect, reconnect, and the connection-link onboarding flow — stays
+consistent: generate a verifier when the provider needs one, stash it in the
+flow's session payload, then splat it into ``get_auth_url`` / ``exchange_code``.
+
+The ``code_challenge`` derivation itself is provider-specific (TikTok uses a
+hex SHA256 digest, not the RFC 7636 base64url encoding) and lives in the
+provider, not here.
+"""
+
+from __future__ import annotations
+
+import secrets
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from providers.base import SocialProvider
+
+# RFC 7636 allows a 43-128 char verifier; token_urlsafe(64) yields ~86 chars
+# from the URL-safe alphabet, which is a subset of the unreserved set.
+_VERIFIER_NBYTES = 64
+
+
+def issue_pkce_verifier(provider: SocialProvider) -> str | None:
+    """Return a fresh PKCE ``code_verifier`` when ``provider`` requires PKCE, else None.
+
+    Callers store the result in the flow's OAuth session payload and pass it to
+    ``get_auth_url`` (via :func:`pkce_kwargs`) so the provider can derive the
+    ``code_challenge``; the matching callback replays it on token exchange.
+    """
+    return secrets.token_urlsafe(_VERIFIER_NBYTES) if provider.uses_pkce else None
+
+
+def pkce_kwargs(code_verifier: str | None) -> dict[str, str]:
+    """kwargs to splat into ``get_auth_url`` / ``exchange_code`` for a PKCE verifier.
+
+    Empty when there is no verifier, so non-PKCE providers are invoked with
+    exactly their original argument list.
+    """
+    return {"code_verifier": code_verifier} if code_verifier else {}

--- a/apps/social_accounts/tests/test_views.py
+++ b/apps/social_accounts/tests/test_views.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 
 from apps.social_accounts.models import SocialAccount
 from apps.social_accounts.views import OAUTH_SESSION_KEY, _sign_state, _unsign_state
-from providers.types import OAuthTokens
+from providers.types import AccountProfile, OAuthTokens
 
 
 @pytest.fixture
@@ -113,6 +113,58 @@ class TestConnectPlatformView:
         assert response.status_code == 302
         assert "bluesky" in response.url
 
+    def test_pkce_connect_generates_and_forwards_verifier(self, authenticated_client, workspace):
+        """A PKCE provider (TikTok) gets a code_verifier stashed in the session
+        and forwarded to get_auth_url so it can derive the code_challenge."""
+        from apps.credentials.models import PlatformCredential
+
+        PlatformCredential.objects.create(
+            organization=workspace.organization,
+            platform="tiktok",
+            credentials={"client_key": "k", "client_secret": "s"},
+            is_configured=True,
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.uses_pkce = True
+        mock_provider.get_auth_url.return_value = "https://www.tiktok.com/v2/auth/authorize/?ok=1"
+
+        url = reverse("social_accounts:connect", kwargs={"workspace_id": workspace.id})
+        with patch("apps.social_accounts.views._get_provider_for_platform", return_value=mock_provider):
+            response = authenticated_client.post(url, {"platform": "tiktok"})
+
+        assert response.status_code == 302
+        assert response.url == "https://www.tiktok.com/v2/auth/authorize/?ok=1"
+
+        verifier = authenticated_client.session[OAUTH_SESSION_KEY]["code_verifier"]
+        assert verifier  # non-empty
+        _, kwargs = mock_provider.get_auth_url.call_args
+        assert kwargs["code_verifier"] == verifier
+
+    def test_non_pkce_connect_omits_verifier(self, authenticated_client, workspace):
+        """A non-PKCE provider stores code_verifier=None and is called without it."""
+        from apps.credentials.models import PlatformCredential
+
+        PlatformCredential.objects.create(
+            organization=workspace.organization,
+            platform="facebook",
+            credentials={"client_id": "i", "client_secret": "s"},
+            is_configured=True,
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.uses_pkce = False
+        mock_provider.get_auth_url.return_value = "https://facebook.example/auth"
+
+        url = reverse("social_accounts:connect", kwargs={"workspace_id": workspace.id})
+        with patch("apps.social_accounts.views._get_provider_for_platform", return_value=mock_provider):
+            response = authenticated_client.post(url, {"platform": "facebook"})
+
+        assert response.status_code == 302
+        assert authenticated_client.session[OAUTH_SESSION_KEY]["code_verifier"] is None
+        _, kwargs = mock_provider.get_auth_url.call_args
+        assert "code_verifier" not in kwargs
+
 
 @pytest.mark.django_db
 class TestOAuthCallbackView:
@@ -159,6 +211,29 @@ class TestOAuthCallbackView:
         page_data = authenticated_client.session["oauth_page_select"]
         assert page_data["platform"] == "instagram"
         assert page_data["pages"][0]["id"] == "17841400000000000"
+
+    def test_tiktok_callback_replays_pkce_verifier(self, authenticated_client, workspace, user):
+        """The verifier stashed at connect is read from the session and replayed
+        on the TikTok token exchange (callback arrives at the ``social1`` slug)."""
+        nonce = "nonce-tiktok"
+        verifier = "stored-code-verifier"
+        state = _sign_state(workspace.id, "tiktok", user.id, nonce)
+        session = authenticated_client.session
+        session[OAUTH_SESSION_KEY] = {"nonce": nonce, "code_verifier": verifier}
+        session.save()
+
+        mock_provider = MagicMock()
+        mock_provider.exchange_code.return_value = OAuthTokens(access_token="tok", refresh_token="r", expires_in=3600)
+        mock_provider.get_profile.return_value = AccountProfile(platform_id="open-id-1", name="Test TikTok")
+
+        url = reverse("social_accounts:oauth_callback", kwargs={"platform": "social1"})
+        with patch("apps.social_accounts.views._get_provider_for_platform", return_value=mock_provider):
+            response = authenticated_client.get(url, {"code": "auth-code", "state": state})
+
+        assert response.status_code == 302
+        mock_provider.exchange_code.assert_called_once()
+        _, kwargs = mock_provider.exchange_code.call_args
+        assert kwargs["code_verifier"] == verifier
 
 
 @pytest.mark.django_db

--- a/apps/social_accounts/tests/test_views.py
+++ b/apps/social_accounts/tests/test_views.py
@@ -167,6 +167,36 @@ class TestConnectPlatformView:
 
 
 @pytest.mark.django_db
+class TestReconnectView:
+    def test_pkce_reconnect_generates_and_forwards_verifier(self, authenticated_client, workspace):
+        """Reconnecting a TikTok account must regenerate + forward a PKCE verifier;
+        reconnect previously sent no code_challenge -> TikTok errCode 10007."""
+        account = SocialAccount.objects.create(
+            workspace=workspace,
+            platform="tiktok",
+            account_platform_id="open-1",
+            account_name="My TikTok",
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.uses_pkce = True
+        mock_provider.get_auth_url.return_value = "https://www.tiktok.com/v2/auth/authorize/?ok=1"
+
+        url = reverse(
+            "social_accounts:reconnect",
+            kwargs={"workspace_id": workspace.id, "account_id": account.id},
+        )
+        with patch("apps.social_accounts.views._get_provider_for_platform", return_value=mock_provider):
+            response = authenticated_client.post(url)
+
+        assert response.status_code == 302
+        verifier = authenticated_client.session[OAUTH_SESSION_KEY]["code_verifier"]
+        assert verifier  # non-empty
+        _, kwargs = mock_provider.get_auth_url.call_args
+        assert kwargs["code_verifier"] == verifier
+
+
+@pytest.mark.django_db
 class TestOAuthCallbackView:
     def test_error_parameter_shows_message(self, authenticated_client):
         url = reverse("social_accounts:oauth_callback", kwargs={"platform": "facebook"})

--- a/apps/social_accounts/views.py
+++ b/apps/social_accounts/views.py
@@ -261,15 +261,20 @@ def connect_platform(request, workspace_id):
     nonce = secrets.token_urlsafe(32)
     state = _sign_state(workspace_id, platform, request.user.id, nonce)
 
+    # PKCE verifier (e.g. TikTok); round-trips via the session alongside the nonce.
+    code_verifier = secrets.token_urlsafe(64) if provider.uses_pkce else None
+
     # Store nonce in session to prevent replay
     request.session[OAUTH_SESSION_KEY] = {
         "nonce": nonce,
         "workspace_id": str(workspace_id),
         "platform": platform,
+        "code_verifier": code_verifier,
     }
 
     redirect_uri = _build_redirect_uri(request, platform)
-    auth_url = provider.get_auth_url(redirect_uri, state)
+    auth_kwargs = {"code_verifier": code_verifier} if code_verifier else {}
+    auth_url = provider.get_auth_url(redirect_uri, state, **auth_kwargs)
     return redirect(auth_url)
 
 
@@ -348,7 +353,9 @@ def oauth_callback(request, platform):
 
         provider = _get_provider_for_platform(platform, request.org.id, **extra_creds)
         redirect_uri = redirect_uri_from_request(request)
-        tokens = provider.exchange_code(code, redirect_uri)
+        code_verifier = session_data.get("code_verifier")
+        exchange_kwargs = {"code_verifier": code_verifier} if code_verifier else {}
+        tokens = provider.exchange_code(code, redirect_uri, **exchange_kwargs)
 
         # Facebook/Instagram/LinkedIn Company: connect Pages, not personal profiles
         if platform in (

--- a/apps/social_accounts/views.py
+++ b/apps/social_accounts/views.py
@@ -25,6 +25,7 @@ from apps.members.decorators import require_permission
 
 from .models import MastodonAppRegistration, PlatformVisibility, SocialAccount
 from .oauth_aliases import from_url_slug, redirect_uri_from_request, to_url_slug
+from .oauth_pkce import issue_pkce_verifier, pkce_kwargs
 
 logger = logging.getLogger(__name__)
 
@@ -262,7 +263,7 @@ def connect_platform(request, workspace_id):
     state = _sign_state(workspace_id, platform, request.user.id, nonce)
 
     # PKCE verifier (e.g. TikTok); round-trips via the session alongside the nonce.
-    code_verifier = secrets.token_urlsafe(64) if provider.uses_pkce else None
+    code_verifier = issue_pkce_verifier(provider)
 
     # Store nonce in session to prevent replay
     request.session[OAUTH_SESSION_KEY] = {
@@ -273,8 +274,7 @@ def connect_platform(request, workspace_id):
     }
 
     redirect_uri = _build_redirect_uri(request, platform)
-    auth_kwargs = {"code_verifier": code_verifier} if code_verifier else {}
-    auth_url = provider.get_auth_url(redirect_uri, state, **auth_kwargs)
+    auth_url = provider.get_auth_url(redirect_uri, state, **pkce_kwargs(code_verifier))
     return redirect(auth_url)
 
 
@@ -353,9 +353,7 @@ def oauth_callback(request, platform):
 
         provider = _get_provider_for_platform(platform, request.org.id, **extra_creds)
         redirect_uri = redirect_uri_from_request(request)
-        code_verifier = session_data.get("code_verifier")
-        exchange_kwargs = {"code_verifier": code_verifier} if code_verifier else {}
-        tokens = provider.exchange_code(code, redirect_uri, **exchange_kwargs)
+        tokens = provider.exchange_code(code, redirect_uri, **pkce_kwargs(session_data.get("code_verifier")))
 
         # Facebook/Instagram/LinkedIn Company: connect Pages, not personal profiles
         if platform in (
@@ -694,15 +692,17 @@ def reconnect(request, workspace_id, account_id):
     _apply_analytics_scope_flag(provider, platform)
     nonce = secrets.token_urlsafe(32)
     state = _sign_state(workspace_id, platform, request.user.id, nonce)
+    code_verifier = issue_pkce_verifier(provider)
 
     request.session[OAUTH_SESSION_KEY] = {
         "nonce": nonce,
         "workspace_id": str(workspace_id),
         "platform": platform,
+        "code_verifier": code_verifier,
     }
 
     redirect_uri = _build_redirect_uri(request, platform)
-    auth_url = provider.get_auth_url(redirect_uri, state)
+    auth_url = provider.get_auth_url(redirect_uri, state, **pkce_kwargs(code_verifier))
     return redirect(auth_url)
 
 

--- a/providers/base.py
+++ b/providers/base.py
@@ -93,6 +93,12 @@ class SocialProvider(ABC):
     # from the requested scope list. Default True keeps backward compat.
     include_analytics_scopes: bool = True
 
+    # OAuth providers that require PKCE flip this to True. The connect view then
+    # generates a code_verifier, stashes it in the session, sends the derived
+    # code_challenge on the authorize URL, and replays the verifier on token
+    # exchange. Providers that don't set this are never passed a code_verifier.
+    uses_pkce: bool = False
+
     # True when ``get_account_metrics`` actually filters by the ``date_range``
     # argument. Providers whose stats endpoint returns only lifetime totals
     # (TikTok ``/v2/user/info/``) should set this to False so the sync layer
@@ -109,12 +115,20 @@ class SocialProvider(ABC):
     # OAuth methods (override for OAuth providers)
     # ------------------------------------------------------------------
 
-    def get_auth_url(self, redirect_uri: str, state: str) -> str:
-        """Generate the OAuth authorization URL."""
+    def get_auth_url(self, redirect_uri: str, state: str, code_verifier: str | None = None) -> str:
+        """Generate the OAuth authorization URL.
+
+        ``code_verifier`` is only supplied for providers that set
+        ``uses_pkce = True``; PKCE providers derive the ``code_challenge`` from it.
+        """
         raise NotImplementedError(f"{self.platform_name} does not implement get_auth_url")
 
-    def exchange_code(self, code: str, redirect_uri: str) -> OAuthTokens:
-        """Exchange an authorization code for access tokens."""
+    def exchange_code(self, code: str, redirect_uri: str, code_verifier: str | None = None) -> OAuthTokens:
+        """Exchange an authorization code for access tokens.
+
+        ``code_verifier`` is only supplied for providers that set
+        ``uses_pkce = True``; it must be replayed on the PKCE token exchange.
+        """
         raise NotImplementedError(f"{self.platform_name} does not implement exchange_code")
 
     def refresh_token(self, refresh_token: str) -> OAuthTokens:

--- a/providers/bluesky.py
+++ b/providers/bluesky.py
@@ -97,10 +97,10 @@ class BlueskyProvider(SocialProvider):
     # OAuth stubs (not applicable for session auth)
     # ------------------------------------------------------------------
 
-    def get_auth_url(self, redirect_uri: str, state: str) -> str:
+    def get_auth_url(self, redirect_uri: str, state: str, code_verifier: str | None = None) -> str:
         raise NotImplementedError("Bluesky uses session-based auth, not OAuth. Use create_session() instead.")
 
-    def exchange_code(self, code: str, redirect_uri: str) -> OAuthTokens:
+    def exchange_code(self, code: str, redirect_uri: str, code_verifier: str | None = None) -> OAuthTokens:
         raise NotImplementedError("Bluesky uses session-based auth, not OAuth. Use create_session() instead.")
 
     # ------------------------------------------------------------------

--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -109,7 +109,7 @@ class FacebookProvider(SocialProvider):
     # OAuth
     # ------------------------------------------------------------------
 
-    def get_auth_url(self, redirect_uri: str, state: str) -> str:
+    def get_auth_url(self, redirect_uri: str, state: str, code_verifier: str | None = None) -> str:
         params = {
             "client_id": self.credentials["client_id"],
             "redirect_uri": redirect_uri,
@@ -119,7 +119,7 @@ class FacebookProvider(SocialProvider):
         }
         return f"{OAUTH_URL}?{urlencode(params)}"
 
-    def exchange_code(self, code: str, redirect_uri: str) -> OAuthTokens:
+    def exchange_code(self, code: str, redirect_uri: str, code_verifier: str | None = None) -> OAuthTokens:
         resp = self._request(
             "POST",
             TOKEN_URL,

--- a/providers/google_business.py
+++ b/providers/google_business.py
@@ -73,7 +73,7 @@ class GoogleBusinessProvider(SocialProvider):
     # OAuth
     # ------------------------------------------------------------------
 
-    def get_auth_url(self, redirect_uri: str, state: str) -> str:
+    def get_auth_url(self, redirect_uri: str, state: str, code_verifier: str | None = None) -> str:
         """Build the Google OAuth 2.0 authorization URL."""
         params = {
             "client_id": self.credentials["client_id"],
@@ -86,7 +86,7 @@ class GoogleBusinessProvider(SocialProvider):
         }
         return f"{AUTH_URL}?{urlencode(params)}"
 
-    def exchange_code(self, code: str, redirect_uri: str) -> OAuthTokens:
+    def exchange_code(self, code: str, redirect_uri: str, code_verifier: str | None = None) -> OAuthTokens:
         """Exchange an authorization code for Google access/refresh tokens."""
         resp = self._request(
             "POST",

--- a/providers/instagram.py
+++ b/providers/instagram.py
@@ -98,7 +98,7 @@ class InstagramProvider(SocialProvider):
     # OAuth (uses Facebook OAuth flow)
     # ------------------------------------------------------------------
 
-    def get_auth_url(self, redirect_uri: str, state: str) -> str:
+    def get_auth_url(self, redirect_uri: str, state: str, code_verifier: str | None = None) -> str:
         params = {
             "client_id": self.credentials["client_id"],
             "redirect_uri": redirect_uri,
@@ -108,7 +108,7 @@ class InstagramProvider(SocialProvider):
         }
         return f"{OAUTH_URL}?{urlencode(params)}"
 
-    def exchange_code(self, code: str, redirect_uri: str) -> OAuthTokens:
+    def exchange_code(self, code: str, redirect_uri: str, code_verifier: str | None = None) -> OAuthTokens:
         resp = self._request(
             "POST",
             TOKEN_URL,

--- a/providers/instagram_login.py
+++ b/providers/instagram_login.py
@@ -118,7 +118,7 @@ class InstagramLoginProvider(SocialProvider):
     # OAuth
     # ------------------------------------------------------------------
 
-    def get_auth_url(self, redirect_uri: str, state: str) -> str:
+    def get_auth_url(self, redirect_uri: str, state: str, code_verifier: str | None = None) -> str:
         params = {
             "client_id": self.credentials["client_id"],
             "redirect_uri": redirect_uri,
@@ -130,7 +130,7 @@ class InstagramLoginProvider(SocialProvider):
         }
         return f"{AUTH_URL}?{urlencode(params)}"
 
-    def exchange_code(self, code: str, redirect_uri: str) -> OAuthTokens:
+    def exchange_code(self, code: str, redirect_uri: str, code_verifier: str | None = None) -> OAuthTokens:
         # Instagram Login requires multipart/form-data, not urlencoded.
         fields = {
             "client_id": self.credentials["client_id"],

--- a/providers/linkedin.py
+++ b/providers/linkedin.py
@@ -115,7 +115,7 @@ class LinkedInProvider(SocialProvider):
     # OAuth
     # ------------------------------------------------------------------
 
-    def get_auth_url(self, redirect_uri: str, state: str) -> str:
+    def get_auth_url(self, redirect_uri: str, state: str, code_verifier: str | None = None) -> str:
         params = {
             "response_type": "code",
             "client_id": self.credentials["client_id"],
@@ -125,7 +125,7 @@ class LinkedInProvider(SocialProvider):
         }
         return f"{AUTH_URL}?{urlencode(params)}"
 
-    def exchange_code(self, code: str, redirect_uri: str) -> OAuthTokens:
+    def exchange_code(self, code: str, redirect_uri: str, code_verifier: str | None = None) -> OAuthTokens:
         resp = self._request(
             "POST",
             TOKEN_URL,

--- a/providers/mastodon.py
+++ b/providers/mastodon.py
@@ -119,7 +119,7 @@ class MastodonProvider(SocialProvider):
     # OAuth
     # ------------------------------------------------------------------
 
-    def get_auth_url(self, redirect_uri: str, state: str) -> str:
+    def get_auth_url(self, redirect_uri: str, state: str, code_verifier: str | None = None) -> str:
         """Build the instance-specific OAuth authorization URL."""
         params = {
             "client_id": self.credentials["client_id"],
@@ -130,7 +130,7 @@ class MastodonProvider(SocialProvider):
         }
         return f"{self.instance_url}/oauth/authorize?{urlencode(params)}"
 
-    def exchange_code(self, code: str, redirect_uri: str) -> OAuthTokens:
+    def exchange_code(self, code: str, redirect_uri: str, code_verifier: str | None = None) -> OAuthTokens:
         """Exchange an authorization code for a Mastodon access token."""
         resp = self._request(
             "POST",

--- a/providers/pinterest.py
+++ b/providers/pinterest.py
@@ -91,7 +91,7 @@ class PinterestProvider(SocialProvider):
     # OAuth
     # ------------------------------------------------------------------
 
-    def get_auth_url(self, redirect_uri: str, state: str) -> str:
+    def get_auth_url(self, redirect_uri: str, state: str, code_verifier: str | None = None) -> str:
         params = {
             "client_id": self.credentials["client_id"],
             "redirect_uri": redirect_uri,
@@ -101,7 +101,7 @@ class PinterestProvider(SocialProvider):
         }
         return f"{AUTH_URL}?{urlencode(params)}"
 
-    def exchange_code(self, code: str, redirect_uri: str) -> OAuthTokens:
+    def exchange_code(self, code: str, redirect_uri: str, code_verifier: str | None = None) -> OAuthTokens:
         resp = self._request(
             "POST",
             TOKEN_URL,

--- a/providers/threads.py
+++ b/providers/threads.py
@@ -84,7 +84,7 @@ class ThreadsProvider(SocialProvider):
     # OAuth
     # ------------------------------------------------------------------
 
-    def get_auth_url(self, redirect_uri: str, state: str) -> str:
+    def get_auth_url(self, redirect_uri: str, state: str, code_verifier: str | None = None) -> str:
         params = {
             "client_id": self.credentials["client_id"],
             "redirect_uri": redirect_uri,
@@ -94,7 +94,7 @@ class ThreadsProvider(SocialProvider):
         }
         return f"{AUTH_URL}?{urlencode(params)}"
 
-    def exchange_code(self, code: str, redirect_uri: str) -> OAuthTokens:
+    def exchange_code(self, code: str, redirect_uri: str, code_verifier: str | None = None) -> OAuthTokens:
         resp = self._request(
             "POST",
             TOKEN_URL,

--- a/providers/tiktok.py
+++ b/providers/tiktok.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import contextlib
+import hashlib
 import logging
 import os
 from datetime import datetime
@@ -82,8 +83,23 @@ CONTENT_TYPE_BY_EXT = {
 }
 
 
+def _pkce_code_challenge(code_verifier: str) -> str:
+    """Derive TikTok's PKCE ``code_challenge`` from a ``code_verifier``.
+
+    TikTok deviates from RFC 7636: the challenge is the HEX-encoded SHA256 of
+    the verifier (a 64-char hex string), NOT the base64url encoding that
+    standard PKCE clients use. TikTok only supports the ``S256`` method.
+    See https://developers.tiktok.com/doc/login-kit-desktop/
+    """
+    return hashlib.sha256(code_verifier.encode("ascii")).hexdigest()
+
+
 class TikTokProvider(SocialProvider):
     """TikTok Content Posting API provider using OAuth 2.0."""
+
+    # TikTok requires PKCE on the authorization request (for desktop/native
+    # apps and localhost redirect URIs); see ``_pkce_code_challenge``.
+    uses_pkce = True
 
     # ------------------------------------------------------------------
     # Metadata
@@ -146,7 +162,7 @@ class TikTokProvider(SocialProvider):
     # OAuth
     # ------------------------------------------------------------------
 
-    def get_auth_url(self, redirect_uri: str, state: str) -> str:
+    def get_auth_url(self, redirect_uri: str, state: str, code_verifier: str | None = None) -> str:
         params = {
             "client_key": self.credentials["client_key"],
             "redirect_uri": redirect_uri,
@@ -154,20 +170,22 @@ class TikTokProvider(SocialProvider):
             "scope": ",".join(self.required_scopes),
             "response_type": "code",
         }
+        if code_verifier:
+            params["code_challenge"] = _pkce_code_challenge(code_verifier)
+            params["code_challenge_method"] = "S256"
         return f"{AUTH_URL}?{urlencode(params)}"
 
-    def exchange_code(self, code: str, redirect_uri: str) -> OAuthTokens:
-        resp = self._request(
-            "POST",
-            TOKEN_URL,
-            data={
-                "client_key": self.credentials["client_key"],
-                "client_secret": self.credentials["client_secret"],
-                "code": code,
-                "grant_type": "authorization_code",
-                "redirect_uri": redirect_uri,
-            },
-        )
+    def exchange_code(self, code: str, redirect_uri: str, code_verifier: str | None = None) -> OAuthTokens:
+        data = {
+            "client_key": self.credentials["client_key"],
+            "client_secret": self.credentials["client_secret"],
+            "code": code,
+            "grant_type": "authorization_code",
+            "redirect_uri": redirect_uri,
+        }
+        if code_verifier:
+            data["code_verifier"] = code_verifier
+        resp = self._request("POST", TOKEN_URL, data=data)
         body = resp.json()
         if "access_token" not in body:
             raise OAuthError(

--- a/providers/youtube.py
+++ b/providers/youtube.py
@@ -97,7 +97,7 @@ class YouTubeProvider(SocialProvider):
     # OAuth
     # ------------------------------------------------------------------
 
-    def get_auth_url(self, redirect_uri: str, state: str) -> str:
+    def get_auth_url(self, redirect_uri: str, state: str, code_verifier: str | None = None) -> str:
         params = {
             "client_id": self.credentials["client_id"],
             "redirect_uri": redirect_uri,
@@ -109,7 +109,7 @@ class YouTubeProvider(SocialProvider):
         }
         return f"{AUTH_URL}?{urlencode(params)}"
 
-    def exchange_code(self, code: str, redirect_uri: str) -> OAuthTokens:
+    def exchange_code(self, code: str, redirect_uri: str, code_verifier: str | None = None) -> OAuthTokens:
         resp = self._request(
             "POST",
             TOKEN_URL,

--- a/tests/providers/test_tiktok.py
+++ b/tests/providers/test_tiktok.py
@@ -1,7 +1,9 @@
 """Tests for TikTokProvider analytics methods (video.list + user.info.stats)."""
 
+import hashlib
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlsplit
 
 import pytest
 
@@ -21,6 +23,52 @@ def _date_range() -> tuple[datetime, datetime]:
         datetime(2026, 6, 1, 0, 0, 0, tzinfo=UTC),
         datetime(2026, 6, 4, 23, 59, 59, tzinfo=UTC),
     )
+
+
+class TestGetAuthUrl:
+    def test_provider_declares_pkce(self):
+        assert TikTokProvider({"client_key": "k", "client_secret": "s"}).uses_pkce is True
+
+    def test_includes_pkce_challenge_when_verifier_given(self):
+        provider = TikTokProvider({"client_key": "k", "client_secret": "s"})
+        url = provider.get_auth_url("https://app.example/cb", "state-123", code_verifier="verifier-xyz")
+
+        query = parse_qs(urlsplit(url).query)
+        # TikTok quirk: code_challenge is the HEX sha256 digest, not base64url.
+        expected = hashlib.sha256(b"verifier-xyz").hexdigest()
+        assert query["code_challenge"] == [expected]
+        assert len(expected) == 64  # hex digest length — guards against base64url (~43 chars)
+        assert query["code_challenge_method"] == ["S256"]
+
+    def test_omits_pkce_when_no_verifier(self):
+        provider = TikTokProvider({"client_key": "k", "client_secret": "s"})
+        url = provider.get_auth_url("https://app.example/cb", "state-123")
+
+        assert "code_challenge" not in url
+        assert "code_challenge_method" not in url
+
+
+class TestExchangeCode:
+    @patch.object(TikTokProvider, "_request")
+    def test_sends_code_verifier_when_given(self, mock_request):
+        mock_request.return_value = _make_response({"access_token": "tok", "expires_in": 3600})
+
+        provider = TikTokProvider({"client_key": "k", "client_secret": "s"})
+        provider.exchange_code("auth-code", "https://app.example/cb", code_verifier="verifier-xyz")
+
+        _, kwargs = mock_request.call_args
+        assert kwargs["data"]["code_verifier"] == "verifier-xyz"
+        assert kwargs["data"]["grant_type"] == "authorization_code"
+
+    @patch.object(TikTokProvider, "_request")
+    def test_omits_code_verifier_when_absent(self, mock_request):
+        mock_request.return_value = _make_response({"access_token": "tok", "expires_in": 3600})
+
+        provider = TikTokProvider({"client_key": "k", "client_secret": "s"})
+        provider.exchange_code("auth-code", "https://app.example/cb")
+
+        _, kwargs = mock_request.call_args
+        assert "code_verifier" not in kwargs["data"]
 
 
 class TestGetPostMetrics:

--- a/tests/test_oauth_pkce.py
+++ b/tests/test_oauth_pkce.py
@@ -1,0 +1,32 @@
+"""Tests for client-side PKCE helpers (apps/social_accounts/oauth_pkce.py)."""
+
+from types import SimpleNamespace
+
+from apps.social_accounts.oauth_pkce import issue_pkce_verifier, pkce_kwargs
+
+
+class TestIssuePkceVerifier:
+    def test_returns_verifier_for_pkce_provider(self):
+        verifier = issue_pkce_verifier(SimpleNamespace(uses_pkce=True))
+        assert isinstance(verifier, str)
+        # RFC 7636 allows 43-128 chars; token_urlsafe(64) yields ~86.
+        assert 43 <= len(verifier) <= 128
+
+    def test_returns_none_for_non_pkce_provider(self):
+        assert issue_pkce_verifier(SimpleNamespace(uses_pkce=False)) is None
+
+    def test_fresh_verifier_each_call(self):
+        provider = SimpleNamespace(uses_pkce=True)
+        assert issue_pkce_verifier(provider) != issue_pkce_verifier(provider)
+
+
+class TestPkceKwargs:
+    def test_includes_verifier_when_present(self):
+        assert pkce_kwargs("abc") == {"code_verifier": "abc"}
+
+    def test_empty_when_none(self):
+        # Non-PKCE providers are invoked with exactly their original arg list.
+        assert pkce_kwargs(None) == {}
+
+    def test_empty_when_empty_string(self):
+        assert pkce_kwargs("") == {}


### PR DESCRIPTION
## What does this PR do?

Adds PKCE (Proof Key for Code Exchange) to **every** outbound OAuth flow that can reach TikTok, and keeps the OAuth provider override signatures type-consistent.

- New `SocialProvider.uses_pkce` flag (default `False`); `TikTokProvider` sets it `True` and derives the challenge as a **hex** SHA256 digest (TikTok's deviation from RFC 7636), method `S256`.
- New shared helper `apps/social_accounts/oauth_pkce.py` (`issue_pkce_verifier` + `pkce_kwargs`) centralises the verifier lifecycle so all init/callback sites stay consistent.
- Wired through **all three** OAuth entry points (generate verifier → stash in that flow's session → forward to `get_auth_url` → replay on `exchange_code`):
  - `social_accounts.connect_platform` / `oauth_callback`
  - `social_accounts.reconnect`
  - onboarding `connection_oauth_start` / `connection_oauth_callback` (public connection-link flow)
- All 11 OAuth providers' `get_auth_url`/`exchange_code` overrides accept the optional `code_verifier` so they stay Liskov-compatible with the base (fixes mypy `[override]`); non-PKCE providers ignore it.

## Why?

TikTok now **requires PKCE** on the authorization request (mandatory for localhost / `127.0.0.1` redirect URIs). Without `code_challenge`, TikTok rejects the request before the consent screen with `error=param_error & errCode=10007 & error_type=code_challenge`. A code review found the first cut only fixed the primary connect flow, leaving reconnect and the connection-link flow still broken with the identical error — this PR closes all of them.

> **TikTok gotcha:** `code_challenge` must be the **hex-encoded** SHA256 of the verifier (64 chars), *not* base64url. Using base64url passes authorize but fails token exchange.

## How to test

`pytest tests/test_oauth_pkce.py tests/providers/test_tiktok.py apps/social_accounts/tests/ apps/onboarding/tests.py`

Covers: the shared helper (verifier generation + kwargs), the provider's hex challenge + verifier replay, and PKCE round-trips through connect, reconnect, and the connection-link start/callback. Full suite: 234 passed; mypy clean (440 files); ruff clean.

In-app: clicking Connect/Reconnect on a TikTok account now produces a `tiktok.com/v2/auth/authorize/` URL containing `code_challenge=<64 hex>` and `code_challenge_method=S256`.

> ⚠️ TikTok requires the registered redirect URI to match **exactly** — register the single-slash form (`http://127.0.0.1:8001/social-accounts/callback/social1/`), not a double slash.

## Checklist

- [x] Tests pass (`pytest`) — 234 passed
- [x] Lint passes (`ruff check .` and `ruff format --check .`)
- [x] Type check passes (`mypy`)
- [ ] Documentation updated (if applicable) — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)