### PR TITLE
docs(facebook): document pages_manage_engagement scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ Facebook, Instagram, and Threads all use the same Meta app credentials.
 
    **Use case: "Manage everything on your Page"** (Facebook)
    - This use case auto-includes `business_management`, `pages_show_list`, and `public_profile`
-   - Add these optional permissions: `pages_manage_posts`, `pages_read_engagement`, `pages_read_user_content`, `pages_manage_metadata`, `read_insights`
+   - Add these optional permissions: `pages_manage_posts`, `pages_manage_engagement`, `pages_read_engagement`, `pages_read_user_content`, `pages_manage_metadata`, `read_insights`
 
    **Use case: "Messenger from Meta"** (Facebook Messaging)
    - Required to enable the `pages_messaging` permission, which is not available under the "Manage Pages" use case

--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -79,6 +79,8 @@ class FacebookProvider(SocialProvider):
         scopes = [
             "business_management",
             "pages_show_list",
+            # Required by publish_comment() — POST /{post_id}/comments is gated
+            # behind pages_manage_engagement.
             "pages_manage_engagement",
             "pages_manage_posts",
             "pages_read_engagement",


### PR DESCRIPTION
## Summary

Follow-up to #90, which added the `pages_manage_engagement` scope so connected Facebook Pages can publish first comments. That PR added the scope in code, but the self-hoster setup docs weren't updated to match.

## Changes

- **README** — add `pages_manage_engagement` to the Meta **"Manage everything on your Page"** setup checklist. Without it, a self-hoster following the README won't enable the permission in their Meta app, so first-comment publishing silently fails even though regular posting works.
- **providers/facebook.py** — add a comment explaining why `publish_comment()` requires the scope (`POST /{post_id}/comments` is gated behind `pages_manage_engagement`).

## Notes

- No functional code change — the scope itself is already on `main` from #90. This is docs + a code comment.
- **Existing connected Facebook accounts** were authorized before #90 and must reconnect to grant the new scope; until then first comments fail silently (caught + logged). The "needs reconnect" nudge is currently wired only into analytics, not the publishing path — possible follow-up.
- Confirm `pages_manage_engagement` is approved for the production Meta app (App Review) for use on Pages the app doesn't own.

## Testing

`pytest tests/providers/test_base.py -k facebook` → 9 passed (incl. `test_facebook_scopes_include_comment_permission`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
