### PR TITLE
fix(meta-analytics): post-#99 follow-up (profile_views, post_id, IG follows, FB video permalink)

### DIFF
--- a/apps/analytics/metrics.py
+++ b/apps/analytics/metrics.py
@@ -22,7 +22,6 @@ METRICS: dict[str, dict[str, str]] = {
     "saves": {"label": "Saves", "kind": "count"},
     "clicks": {"label": "Link clicks", "kind": "count"},
     "outbound": {"label": "Outbound clicks", "kind": "count"},
-    "profile_visits": {"label": "Profile visits", "kind": "count"},
     "follows": {"label": "New follows", "kind": "count"},
     "followers": {"label": "Followers", "kind": "count"},
     "subscribers": {"label": "Subscribers", "kind": "count"},
@@ -40,9 +39,12 @@ ACCOUNT_ONLY: set[str] = {"follows", "followers", "subscribers"}
 # plan are in place). Verified against each platform's published insights API.
 PLATFORM_METRICS: dict[str, list[str]] = {
     # IG media insights: reach, views (replaced impressions Apr-2025), likes,
-    # comments, saved, shares, total_interactions; follows when daily deltas exist.
-    "instagram": ["reach", "views", "likes", "comments", "saves", "shares", "follows", "engagement"],
-    "instagram_login": ["reach", "views", "likes", "comments", "saves", "shares", "follows", "engagement"],
+    # comments, saved, shares, total_interactions. ``followers`` (total) is
+    # account-only: Meta deprecated the IG ``follower_count`` insight, so we
+    # snapshot the profile follower total and derive growth from day-over-day
+    # deltas (same pattern as TikTok) rather than a per-day ``follows`` metric.
+    "instagram": ["reach", "views", "likes", "comments", "saves", "shares", "followers", "engagement"],
+    "instagram_login": ["reach", "views", "likes", "comments", "saves", "shares", "followers", "engagement"],
     # FB post insights: media views, unique media views, reactions, comments, shares, clicks.
     "facebook": ["views", "reach", "reactions", "comments", "shares", "clicks", "follows", "engagement"],
     # LinkedIn share statistics: impressions, reactions, comments, reposts, clicks, engagement.

--- a/apps/analytics/services.py
+++ b/apps/analytics/services.py
@@ -106,7 +106,7 @@ def _supports_post_fallback(metric_key: str) -> bool:
     """Which metric keys can be derived by summing per-post deltas.
 
     Counts and minutes sum linearly. Account-only growth (subscribers,
-    follows, profile_visits) is undefined for posts; rate-style metrics
+    follows, followers) is undefined for posts; rate-style metrics
     (avg_view_pct, engagement) cannot be summed; and unique-user metrics
     (reach) double-count users when summed across posts. Unknown metric
     keys (not registered in :data:`METRICS`) return False so a forgotten

--- a/apps/analytics/tasks.py
+++ b/apps/analytics/tasks.py
@@ -395,6 +395,7 @@ def _sync_account_metrics(account, on_date: dt_date) -> None:
     """
     from datetime import datetime, time
 
+    from .metrics import PLATFORM_METRICS
     from .models import AccountInsightsSnapshot
 
     provider = _resolve_provider(account)
@@ -405,6 +406,13 @@ def _sync_account_metrics(account, on_date: dt_date) -> None:
     # current day for them; backfill of true historical values is impossible
     # without an API that supports it.
     recent_days = _ACCOUNT_METRICS_RECENT_DAYS if getattr(provider, "account_metrics_supports_date_range", True) else 1
+    # ``followers`` is a live point-in-time total: the provider returns the
+    # current count regardless of the requested window, so it is valid only for
+    # the day the sync runs. Capture it from whichever offset returns it (so a
+    # value is recovered even when on_date's own fetch failed or its row already
+    # exists) and write it once, to on_date only, after the loop — never into a
+    # backfilled past date (which would fabricate flat history).
+    current_followers = None
     for offset in range(recent_days):
         target = on_date - timedelta(days=offset)
         if AccountInsightsSnapshot.objects.filter(social_account=account, date=target).exists():
@@ -421,14 +429,14 @@ def _sync_account_metrics(account, on_date: dt_date) -> None:
             logger.warning("get_account_metrics failed for %s on %s: %s", account, target, exc)
             return
         _refresh_follower_count(account, metrics)
+        fetched_followers = getattr(metrics, "followers", None)
+        if fetched_followers is not None:
+            current_followers = fetched_followers
         extra = getattr(metrics, "extra", {}) or {}
         metric_values = _account_metrics_to_dict(metrics, account.platform)
-        if offset > 0:
-            # ``followers`` is a point-in-time cumulative total: the provider
-            # returns today's value regardless of the (start, end) window, so
-            # writing it into a backfilled past date fabricates flat history and
-            # corrupts follower-growth deltas. Persist it for the current day only.
-            metric_values.pop("followers", None)
+        # The live followers total is written to on_date after the loop; keep it
+        # out of every dated/backfilled snapshot written here.
+        metric_values.pop("followers", None)
         _write_account_snapshot(
             account,
             metric_values,
@@ -436,6 +444,11 @@ def _sync_account_metrics(account, on_date: dt_date) -> None:
             raw=extra.get("raw_insights", {}),
             errors=extra.get("insight_errors", {}),
         )
+
+    if current_followers is not None and "followers" in PLATFORM_METRICS.get(account.platform, []):
+        # Live total → on_date only, idempotently: recovers a value fetched at a
+        # later offset and fills it in when on_date's other metrics already exist.
+        _write_account_snapshot(account, {"followers": float(current_followers)}, on_date)
 
     if account.platform == "youtube":
         _sync_youtube_post_analytics(account, provider, on_date)

--- a/apps/analytics/tasks.py
+++ b/apps/analytics/tasks.py
@@ -221,7 +221,6 @@ def _account_metrics_to_dict(metrics, platform: str) -> dict[str, float]:
     for src, key in (
         ("impressions", "impressions"),
         ("reach", "reach"),
-        ("profile_views", "profile_visits"),
     ):
         v = getattr(metrics, src, 0) or 0
         if v:

--- a/apps/analytics/tasks.py
+++ b/apps/analytics/tasks.py
@@ -231,9 +231,10 @@ def _account_metrics_to_dict(metrics, platform: str) -> dict[str, float]:
     if gained:
         out["follows"] = float(gained)
     # ``followers`` = current total follower count, persisted only when the
-    # platform's catalog lists ``followers`` (today: TikTok). Use ``is not
+    # platform's catalog lists ``followers`` (TikTok, Instagram). Use ``is not
     # None`` so brand-new accounts with 0 followers still get a baseline
-    # snapshot — the chart needs the zero day to render a continuous line.
+    # snapshot — the chart needs the zero day to render a continuous line. A
+    # failed fetch yields ``None`` (not 0), so it is skipped rather than written.
     if "followers" in PLATFORM_METRICS.get(platform, []):
         total_followers = getattr(metrics, "followers", None)
         if total_followers is not None:
@@ -421,9 +422,16 @@ def _sync_account_metrics(account, on_date: dt_date) -> None:
             return
         _refresh_follower_count(account, metrics)
         extra = getattr(metrics, "extra", {}) or {}
+        metric_values = _account_metrics_to_dict(metrics, account.platform)
+        if offset > 0:
+            # ``followers`` is a point-in-time cumulative total: the provider
+            # returns today's value regardless of the (start, end) window, so
+            # writing it into a backfilled past date fabricates flat history and
+            # corrupts follower-growth deltas. Persist it for the current day only.
+            metric_values.pop("followers", None)
         _write_account_snapshot(
             account,
-            _account_metrics_to_dict(metrics, account.platform),
+            metric_values,
             target,
             raw=extra.get("raw_insights", {}),
             errors=extra.get("insight_errors", {}),

--- a/apps/analytics/tests/test_tasks.py
+++ b/apps/analytics/tests/test_tasks.py
@@ -63,3 +63,55 @@ def test_account_metrics_to_dict_instagram_emits_followers_not_profile_visits():
     assert out["views"] == 70.0
     assert "profile_visits" not in out
     assert "follows" not in out
+
+
+def test_account_metrics_to_dict_skips_followers_when_none():
+    """A failed IG profile fetch yields followers=None; the mapper must skip it so
+    no spurious 0-followers snapshot poisons the growth series."""
+    from apps.analytics.tasks import _account_metrics_to_dict
+    from providers.types import AccountMetrics
+
+    metrics = AccountMetrics(followers=None, reach=50, extra={"views": 70})
+    out = _account_metrics_to_dict(metrics, "instagram")
+
+    assert "followers" not in out
+    assert out["reach"] == 50.0
+    assert out["views"] == 70.0
+
+
+@pytest.mark.django_db
+def test_sync_account_metrics_does_not_backfill_followers_total(workspace):
+    """The cumulative followers total must be written for the current day only, not
+    backfilled into past dates (which would fabricate flat follower history)."""
+    from datetime import date
+    from unittest.mock import MagicMock, patch
+
+    from apps.analytics.models import AccountInsightsSnapshot
+    from apps.analytics.tasks import _sync_account_metrics
+    from providers.types import AccountMetrics
+
+    account = SocialAccount.objects.create(
+        workspace=workspace,
+        platform="instagram",
+        account_platform_id="ig-1",
+        account_name="IG One",
+        oauth_access_token="token",
+        oauth_refresh_token="refresh",
+        connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+    )
+    fake_provider = MagicMock()
+    fake_provider.account_metrics_supports_date_range = True
+    fake_provider.get_account_metrics.return_value = AccountMetrics(followers=1000, reach=5, extra={"views": 7})
+    today = date(2026, 6, 24)
+
+    with patch("apps.analytics.tasks._resolve_provider", return_value=fake_provider):
+        _sync_account_metrics(account, today)
+
+    # Current day persists the followers total...
+    assert AccountInsightsSnapshot.objects.filter(social_account=account, date=today, metric_key="followers").exists()
+    # ...but backfilled past days must NOT (the total isn't a historical value).
+    assert not AccountInsightsSnapshot.objects.filter(
+        social_account=account, date__lt=today, metric_key="followers"
+    ).exists()
+    # Date-ranged metrics ARE still backfilled.
+    assert AccountInsightsSnapshot.objects.filter(social_account=account, date__lt=today, metric_key="reach").exists()

--- a/apps/analytics/tests/test_tasks.py
+++ b/apps/analytics/tests/test_tasks.py
@@ -46,3 +46,20 @@ class TestSyncAllAccountAnalytics:
         synced_ids = {call.args[0].id for call in mock_sync_account_metrics.call_args_list}
         assert healthy.id in synced_ids
         assert flagged.id not in synced_ids
+
+
+def test_account_metrics_to_dict_instagram_emits_followers_not_profile_visits():
+    """A1+A3: Instagram no longer emits the deprecated ``profile_visits``; follower
+    growth is carried by the ``followers`` total (derived to a daily delta downstream
+    by ``follower_growth_metric``)."""
+    from apps.analytics.tasks import _account_metrics_to_dict
+    from providers.types import AccountMetrics
+
+    metrics = AccountMetrics(followers=1234, reach=50, extra={"views": 70})
+    out = _account_metrics_to_dict(metrics, "instagram")
+
+    assert out["followers"] == 1234.0
+    assert out["reach"] == 50.0
+    assert out["views"] == 70.0
+    assert "profile_visits" not in out
+    assert "follows" not in out

--- a/apps/analytics/tests/test_tasks.py
+++ b/apps/analytics/tests/test_tasks.py
@@ -115,3 +115,45 @@ def test_sync_account_metrics_does_not_backfill_followers_total(workspace):
     ).exists()
     # Date-ranged metrics ARE still backfilled.
     assert AccountInsightsSnapshot.objects.filter(social_account=account, date__lt=today, metric_key="reach").exists()
+
+
+@pytest.mark.django_db
+def test_sync_account_metrics_recovers_followers_from_later_offset(workspace):
+    """If on_date's own fetch returns followers=None but a later offset fetches the
+    current total, it must still be written to on_date (not dropped)."""
+    from datetime import date
+    from unittest.mock import MagicMock, patch
+
+    from apps.analytics.models import AccountInsightsSnapshot
+    from apps.analytics.tasks import _sync_account_metrics
+    from providers.types import AccountMetrics
+
+    account = SocialAccount.objects.create(
+        workspace=workspace,
+        platform="instagram",
+        account_platform_id="ig-1",
+        account_name="IG One",
+        oauth_access_token="token",
+        oauth_refresh_token="refresh",
+        connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+    )
+    fake_provider = MagicMock()
+    fake_provider.account_metrics_supports_date_range = True
+    # offset 0 (on_date): profile fetch failed -> followers=None; later offsets recover it.
+    fake_provider.get_account_metrics.side_effect = [
+        AccountMetrics(followers=None, reach=5, extra={"views": 7}),
+        AccountMetrics(followers=1000, reach=4, extra={"views": 6}),
+        AccountMetrics(followers=1000, reach=3, extra={"views": 5}),
+    ]
+    today = date(2026, 6, 24)
+
+    with patch("apps.analytics.tasks._resolve_provider", return_value=fake_provider):
+        _sync_account_metrics(account, today)
+
+    # on_date recovered the current follower total from the later offset...
+    row = AccountInsightsSnapshot.objects.get(social_account=account, date=today, metric_key="followers")
+    assert row.value == 1000.0
+    # ...and no past date got a followers row.
+    assert not AccountInsightsSnapshot.objects.filter(
+        social_account=account, date__lt=today, metric_key="followers"
+    ).exists()

--- a/apps/api/tests/test_analytics_router.py
+++ b/apps/api/tests/test_analytics_router.py
@@ -256,9 +256,9 @@ class TestAccountAnalytics:
         # Instagram qualifies for the engagement card.
         assert body["engagement"] is not None
         assert body["engagement"]["rate"]["kind"] == "percent"
-        # Follower growth available on Instagram (follows metric).
+        # Follower growth available on Instagram (followers total, derived to a delta).
         assert body["follower_growth"] is not None
-        assert body["follower_growth"]["key"] == "follows"
+        assert body["follower_growth"]["key"] == "followers"
 
         # Freshness fields populated for an account with snapshots.
         assert body["captured_at"] is not None

--- a/development_specs/meta-analytics-manual-tests.md
+++ b/development_specs/meta-analytics-manual-tests.md
@@ -30,7 +30,7 @@ IDs/tokens with real values.
 ## Instagram Account Insights
 
 ```text
-/{ig_user_id}/insights?metric=reach,views,profile_views,accounts_engaged,total_interactions&period=day&since={since}&until={until}
+/{ig_user_id}/insights?metric=reach,views,accounts_engaged,total_interactions&period=day&since={since}&until={until}
 ```
 
 ## Instagram Media Fields
@@ -53,3 +53,5 @@ Expected UI checks:
 - Engagement rate is 0 when views and reach are 0.
 - Unsupported metrics log warnings and do not stop the dashboard from loading.
 - 7D, 30D, and 90D filters update totals and chart data.
+- Instagram follower growth derives from the profile `followers_count` total (the deprecated
+  `profile_views` insight is no longer requested, so no per-sync warning for it).

--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -6,8 +6,10 @@ import logging
 from datetime import datetime
 from urllib.parse import urlencode, urlparse
 
+import httpx
+
 from .base import SocialProvider
-from .exceptions import APIError, OAuthError, PublishError
+from .exceptions import APIError, OAuthError, PublishError, RateLimitError
 from .meta_insights import fetch_insights_safe, parse_insights_response
 from .types import (
     AccountMetrics,
@@ -414,10 +416,27 @@ class FacebookProvider(SocialProvider):
             json=payload,
         )
         data = resp.json()
+        video_id = data["id"]
+        # Resolve the feed post id + permalink so analytics target the page post
+        # and the stored URL is shareable. Best-effort: video processing is async,
+        # so post_id may not be ready yet — fall back to the bare video id.
+        video_fields: dict = {}
+        try:
+            video_fields = self._request(
+                "GET",
+                f"{BASE_URL}/{video_id}",
+                access_token=access_token,
+                params={"fields": "post_id,permalink_url"},
+            ).json()
+        except (APIError, RateLimitError, httpx.HTTPError) as exc:
+            logger.debug("Facebook video %s post_id unavailable: %s", video_id, exc)
+
+        post_id = video_fields.get("post_id") or video_id
+        url = video_fields.get("permalink_url") or f"https://www.facebook.com/{post_id}"
         return PublishResult(
-            platform_post_id=data["id"],
-            url=f"https://www.facebook.com/{data['id']}",
-            extra=data,
+            platform_post_id=post_id,
+            url=url,
+            extra={**data, **video_fields, "video_id": video_id},
         )
 
     # ------------------------------------------------------------------
@@ -510,17 +529,23 @@ class FacebookProvider(SocialProvider):
         return {}, {key: error_text for key in FACEBOOK_POST_INSIGHTS}, post_ids[0] if post_ids else ""
 
     def _get_post_fields(self, access_token: str, post_id: str) -> dict:
-        try:
-            fields_resp = self._request(
-                "GET",
-                f"{BASE_URL}/{post_id}",
-                access_token=access_token,
-                params={"fields": ",".join(FACEBOOK_POST_FIELDS)},
-            )
-            return fields_resp.json()
-        except APIError as exc:
-            logger.debug("Facebook post %s fields unavailable: %s", post_id, exc)
-            return {}
+        # ``post_id`` is a Video-node field, not a field on a plain Post node, so
+        # requesting it against a feed post can fail the whole call with an
+        # invalid-field error. Retry without ``post_id`` so the engagement fields
+        # (comments/shares/reactions summaries) still load for normal posts.
+        field_sets = (FACEBOOK_POST_FIELDS, [f for f in FACEBOOK_POST_FIELDS if f != "post_id"])
+        for fields in field_sets:
+            try:
+                fields_resp = self._request(
+                    "GET",
+                    f"{BASE_URL}/{post_id}",
+                    access_token=access_token,
+                    params={"fields": ",".join(fields)},
+                )
+                return fields_resp.json()
+            except APIError as exc:
+                logger.debug("Facebook post %s fields unavailable: %s", post_id, exc)
+        return {}
 
     @staticmethod
     def _summary_total(data: dict, key: str) -> int:

--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -6,10 +6,8 @@ import logging
 from datetime import datetime
 from urllib.parse import urlencode, urlparse
 
-import httpx
-
 from .base import SocialProvider
-from .exceptions import APIError, OAuthError, PublishError, RateLimitError
+from .exceptions import APIError, OAuthError, PublishError
 from .meta_insights import fetch_insights_safe, parse_insights_response
 from .types import (
     AccountMetrics,
@@ -428,7 +426,11 @@ class FacebookProvider(SocialProvider):
                 access_token=access_token,
                 params={"fields": "post_id,permalink_url"},
             ).json()
-        except (APIError, RateLimitError, httpx.HTTPError) as exc:
+        except Exception as exc:
+            # Best-effort metadata that runs AFTER the video has already
+            # published: nothing here may propagate, or the publish engine would
+            # schedule a retry and double-post the video (e.g. a malformed 2xx
+            # body making .json() raise). Catch broadly; fall back to video_id.
             logger.debug("Facebook video %s post_id unavailable: %s", video_id, exc)
 
         post_id = video_fields.get("post_id") or video_id
@@ -545,6 +547,11 @@ class FacebookProvider(SocialProvider):
                 return fields_resp.json()
             except APIError as exc:
                 logger.debug("Facebook post %s fields unavailable: %s", post_id, exc)
+                if "post_id" not in str(exc):
+                    # Only the invalid-`post_id`-field error is worth retrying
+                    # without it; other errors (auth, 5xx, not-found) fail
+                    # identically, so don't issue a second doomed request.
+                    break
         return {}
 
     @staticmethod

--- a/providers/instagram.py
+++ b/providers/instagram.py
@@ -38,7 +38,6 @@ TOKEN_URL = f"{BASE_URL}/oauth/access_token"
 INSTAGRAM_ACCOUNT_INSIGHTS = [
     "reach",
     "views",
-    "profile_views",
     "accounts_engaged",
     "total_interactions",
 ]
@@ -468,7 +467,6 @@ class InstagramProvider(SocialProvider):
             },
             metric_params={
                 "views": {"metric_type": "total_value"},
-                "profile_views": {"metric_type": "total_value"},
                 "accounts_engaged": {"metric_type": "total_value"},
                 "total_interactions": {"metric_type": "total_value"},
             },
@@ -479,7 +477,6 @@ class InstagramProvider(SocialProvider):
         return AccountMetrics(
             reach=values.get("reach", 0),
             followers=followers,
-            profile_views=values.get("profile_views", 0),
             extra={
                 "views": values.get("views", 0),
                 "accounts_engaged": values.get("accounts_engaged", 0),

--- a/providers/instagram.py
+++ b/providers/instagram.py
@@ -472,7 +472,10 @@ class InstagramProvider(SocialProvider):
             },
             endpoint_type="account",
         )
-        followers = self._get_profile_fields(access_token, ig_user_id).get("followers_count", 0)
+        profile = self._get_profile_fields(access_token, ig_user_id)
+        # ``None`` means the fetch FAILED (vs a real 0): leave followers unset so
+        # _account_metrics_to_dict skips it and we don't poison the snapshot with 0.
+        followers = profile.get("followers_count", 0) if profile is not None else None
 
         return AccountMetrics(
             reach=values.get("reach", 0),
@@ -562,7 +565,9 @@ class InstagramProvider(SocialProvider):
             platform=self.platform_name,
         )
 
-    def _get_profile_fields(self, access_token: str, ig_user_id: str) -> dict:
+    def _get_profile_fields(self, access_token: str, ig_user_id: str) -> dict | None:
+        # Returns ``None`` on failure so callers can distinguish a failed fetch
+        # from a successful one with no data (a genuine 0).
         try:
             return self._request(
                 "GET",
@@ -572,7 +577,7 @@ class InstagramProvider(SocialProvider):
             ).json()
         except APIError as exc:
             logger.debug("Instagram profile fields unavailable for %s: %s", ig_user_id, exc)
-            return {}
+            return None
 
     def _get_media_fields(self, access_token: str, media_id: str) -> dict:
         try:

--- a/providers/instagram_login.py
+++ b/providers/instagram_login.py
@@ -46,7 +46,6 @@ API_BASE = f"{GRAPH_HOST}/v25.0"
 INSTAGRAM_ACCOUNT_INSIGHTS = [
     "reach",
     "views",
-    "profile_views",
     "accounts_engaged",
     "total_interactions",
 ]
@@ -468,7 +467,6 @@ class InstagramLoginProvider(SocialProvider):
             },
             metric_params={
                 "views": {"metric_type": "total_value"},
-                "profile_views": {"metric_type": "total_value"},
                 "accounts_engaged": {"metric_type": "total_value"},
                 "total_interactions": {"metric_type": "total_value"},
             },
@@ -479,7 +477,6 @@ class InstagramLoginProvider(SocialProvider):
         return AccountMetrics(
             reach=values.get("reach", 0),
             followers=followers,
-            profile_views=values.get("profile_views", 0),
             extra={
                 "views": values.get("views", 0),
                 "accounts_engaged": values.get("accounts_engaged", 0),

--- a/providers/instagram_login.py
+++ b/providers/instagram_login.py
@@ -472,7 +472,10 @@ class InstagramLoginProvider(SocialProvider):
             },
             endpoint_type="account",
         )
-        followers = self._get_profile_fields(access_token).get("followers_count", 0)
+        profile = self._get_profile_fields(access_token)
+        # ``None`` means the fetch FAILED (vs a real 0): leave followers unset so
+        # _account_metrics_to_dict skips it and we don't poison the snapshot with 0.
+        followers = profile.get("followers_count", 0) if profile is not None else None
 
         return AccountMetrics(
             reach=values.get("reach", 0),
@@ -531,7 +534,9 @@ class InstagramLoginProvider(SocialProvider):
         data = resp.json()
         return ReplyResult(platform_message_id=data.get("id", ""), extra=data)
 
-    def _get_profile_fields(self, access_token: str) -> dict:
+    def _get_profile_fields(self, access_token: str) -> dict | None:
+        # Returns ``None`` on failure so callers can distinguish a failed fetch
+        # from a successful one with no data (a genuine 0).
         try:
             return self._request(
                 "GET",
@@ -541,7 +546,7 @@ class InstagramLoginProvider(SocialProvider):
             ).json()
         except APIError as exc:
             logger.debug("Instagram Login profile fields unavailable: %s", exc)
-            return {}
+            return None
 
     def _get_media_fields(self, access_token: str, media_id: str) -> dict:
         try:

--- a/providers/types.py
+++ b/providers/types.py
@@ -90,7 +90,6 @@ class AccountMetrics:
     followers_gained: int = 0
     impressions: int = 0
     reach: int = 0
-    profile_views: int = 0
     extra: dict = field(default_factory=dict)
 
 

--- a/providers/types.py
+++ b/providers/types.py
@@ -86,7 +86,7 @@ class PostMetrics:
 
 @dataclass(frozen=True)
 class AccountMetrics:
-    followers: int = 0
+    followers: int | None = 0
     followers_gained: int = 0
     impressions: int = 0
     reach: int = 0

--- a/tests/providers/test_facebook.py
+++ b/tests/providers/test_facebook.py
@@ -1,8 +1,9 @@
 from unittest.mock import MagicMock, call
 
+import httpx
 import pytest
 
-from providers.exceptions import APIError, PublishError
+from providers.exceptions import APIError, PublishError, RateLimitError
 from providers.facebook import FacebookProvider
 from providers.types import PostType, PublishContent
 
@@ -628,3 +629,107 @@ def test_facebook_analytics_uuid_guard_detects_internal_ids():
     assert _looks_like_uuid("0c77c88e-73f4-4986-a93f-87af966bb4ad") is True
     assert _looks_like_uuid("123456789_987654321") is False
     assert _looks_like_uuid("123456789") is False
+
+
+def test_get_post_fields_retries_without_post_id_when_field_rejected():
+    """``post_id`` is a Video-node field, not a Post-node field: on a plain feed
+    post the first request 400s, so we retry without it instead of dropping the
+    comments/shares summaries."""
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        side_effect=[
+            APIError("(#100) nonexisting field (post_id) on node type (Page)", platform="Facebook"),
+            _resp(
+                {
+                    "id": "page-1_post-1",
+                    "comments": {"summary": {"total_count": 7}},
+                    "shares": {"count": 3},
+                }
+            ),
+        ]
+    )
+
+    fields = provider._get_post_fields("page-token", "page-1_post-1")
+
+    assert fields["comments"]["summary"]["total_count"] == 7
+    assert fields["shares"]["count"] == 3
+    first_params = provider._request.call_args_list[0].kwargs["params"]
+    second_params = provider._request.call_args_list[1].kwargs["params"]
+    assert "post_id" in first_params["fields"].split(",")
+    assert "post_id" not in second_params["fields"].split(",")
+
+
+def test_publish_video_resolves_feed_post_id_for_analytics():
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        side_effect=[
+            _resp({"id": "video-1"}),
+            _resp(
+                {
+                    "post_id": "page-1_post-1",
+                    "permalink_url": "https://www.facebook.com/page-1/videos/video-1/",
+                }
+            ),
+        ]
+    )
+
+    result = provider.publish_post(
+        "page-token",
+        PublishContent(
+            text="Video caption",
+            media_urls=["https://cdn.example.com/clip.mp4"],
+            post_type=PostType.VIDEO,
+            extra={"page_id": "page-1"},
+        ),
+    )
+
+    assert result.platform_post_id == "page-1_post-1"
+    assert result.url == "https://www.facebook.com/page-1/videos/video-1/"
+    assert result.extra["video_id"] == "video-1"
+    provider._request.assert_has_calls(
+        [
+            call(
+                "POST",
+                "https://graph.facebook.com/v25.0/page-1/videos",
+                access_token="page-token",
+                json={"file_url": "https://cdn.example.com/clip.mp4", "description": "Video caption"},
+            ),
+            call(
+                "GET",
+                "https://graph.facebook.com/v25.0/video-1",
+                access_token="page-token",
+                params={"fields": "post_id,permalink_url"},
+            ),
+        ]
+    )
+
+
+@pytest.mark.parametrize(
+    "lookup_error",
+    [
+        RateLimitError("rate limited", platform="Facebook"),
+        httpx.ConnectError("connection failed"),
+    ],
+)
+def test_publish_video_treats_metadata_lookup_failures_as_best_effort(lookup_error):
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        side_effect=[
+            _resp({"id": "video-1"}),
+            lookup_error,
+        ]
+    )
+
+    result = provider.publish_post(
+        "page-token",
+        PublishContent(
+            text="Video caption",
+            media_urls=["https://cdn.example.com/clip.mp4"],
+            post_type=PostType.VIDEO,
+            extra={"page_id": "page-1"},
+        ),
+    )
+
+    assert result.platform_post_id == "video-1"
+    assert result.url == "https://www.facebook.com/video-1"
+    assert result.extra["video_id"] == "video-1"

--- a/tests/providers/test_facebook.py
+++ b/tests/providers/test_facebook.py
@@ -733,3 +733,42 @@ def test_publish_video_treats_metadata_lookup_failures_as_best_effort(lookup_err
     assert result.platform_post_id == "video-1"
     assert result.url == "https://www.facebook.com/video-1"
     assert result.extra["video_id"] == "video-1"
+
+
+def test_publish_video_survives_malformed_metadata_response():
+    """The post-publish metadata GET runs AFTER the video is already live, so a
+    non-API error (e.g. .json() raising on a malformed 2xx body) must NOT
+    propagate — otherwise the publish engine retries and double-posts the video."""
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(
+        side_effect=[
+            _resp({"id": "video-1"}),
+            MagicMock(json=MagicMock(side_effect=ValueError("not JSON"))),
+        ]
+    )
+
+    result = provider.publish_post(
+        "page-token",
+        PublishContent(
+            text="Video caption",
+            media_urls=["https://cdn.example.com/clip.mp4"],
+            post_type=PostType.VIDEO,
+            extra={"page_id": "page-1"},
+        ),
+    )
+
+    assert result.platform_post_id == "video-1"
+    assert result.url == "https://www.facebook.com/video-1"
+    assert result.extra["video_id"] == "video-1"
+
+
+def test_get_post_fields_does_not_retry_on_non_field_error():
+    """A non-`post_id` error (auth, 5xx, not-found) won't be fixed by dropping
+    post_id, so _get_post_fields must not fire a second doomed request."""
+    provider = FacebookProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock(side_effect=APIError("(#190) Error validating access token", platform="Facebook"))
+
+    fields = provider._get_post_fields("page-token", "page-1_post-1")
+
+    assert fields == {}
+    assert provider._request.call_count == 1

--- a/tests/providers/test_instagram.py
+++ b/tests/providers/test_instagram.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, call
 
+from providers.exceptions import APIError
 from providers.instagram import InstagramProvider
 from providers.instagram_login import InstagramLoginProvider
 
@@ -289,3 +290,27 @@ def test_instagram_login_account_metrics_use_current_insights_metrics():
             ),
         ]
     )
+
+
+def test_account_metrics_followers_none_when_profile_fetch_fails():
+    """A transient profile-fetch failure must yield followers=None (not 0) so the
+    analytics layer can skip it instead of writing a poisoning 0 snapshot for a
+    real account."""
+    provider = InstagramProvider({"client_id": "id", "client_secret": "secret", "ig_user_id": "ig-1"})
+    provider._request = MagicMock(
+        side_effect=[
+            _resp({"data": [{"name": "reach", "values": [{"value": 12}]}]}),
+            _resp({"data": [{"name": "views", "period": "day", "total_value": {"value": 67}}]}),
+            _resp({"data": [{"name": "accounts_engaged", "values": [{"value": 8}]}]}),
+            _resp({"data": [{"name": "total_interactions", "values": [{"value": 9}]}]}),
+            APIError("(#190) Error validating access token", platform="Instagram"),
+        ]
+    )
+
+    metrics = provider.get_account_metrics(
+        "page-token",
+        (datetime(2026, 6, 18, tzinfo=UTC), datetime(2026, 6, 19, tzinfo=UTC)),
+    )
+
+    assert metrics.followers is None
+    assert metrics.reach == 12

--- a/tests/providers/test_instagram.py
+++ b/tests/providers/test_instagram.py
@@ -105,7 +105,6 @@ def test_account_metrics_use_current_instagram_insights_metrics():
         side_effect=[
             _resp({"data": [{"name": "reach", "values": [{"value": 12}]}]}),
             _resp({"data": [{"name": "views", "period": "day", "total_value": {"value": 67}}]}),
-            _resp({"data": [{"name": "profile_views", "values": [{"value": 5}]}]}),
             _resp({"data": [{"name": "accounts_engaged", "values": [{"value": 8}]}]}),
             _resp({"data": [{"name": "total_interactions", "values": [{"value": 9}]}]}),
             _resp({"followers_count": 34}),
@@ -123,7 +122,6 @@ def test_account_metrics_use_current_instagram_insights_metrics():
     assert metrics.impressions == 0
     assert metrics.reach == 12
     assert metrics.followers == 34
-    assert metrics.profile_views == 5
     assert metrics.extra["views"] == 67
     provider._request.assert_has_calls(
         [
@@ -148,18 +146,6 @@ def test_account_metrics_use_current_instagram_insights_metrics():
                     "metric_type": "total_value",
                     "since": 1781740800,
                     "until": 1781827200,
-                },
-            ),
-            call(
-                "GET",
-                "https://graph.facebook.com/v25.0/ig-1/insights",
-                access_token="page-token",
-                params={
-                    "metric": "profile_views",
-                    "period": "day",
-                    "since": 1781740800,
-                    "until": 1781827200,
-                    "metric_type": "total_value",
                 },
             ),
             call(
@@ -228,7 +214,6 @@ def test_instagram_login_account_metrics_use_current_insights_metrics():
         side_effect=[
             _resp({"data": [{"name": "reach", "values": [{"value": 12}]}]}),
             _resp({"data": [{"name": "views", "period": "day", "total_value": {"value": 67}}]}),
-            _resp({"data": [{"name": "profile_views", "values": [{"value": 5}]}]}),
             _resp({"data": [{"name": "accounts_engaged", "values": [{"value": 8}]}]}),
             _resp({"data": [{"name": "total_interactions", "values": [{"value": 9}]}]}),
             _resp({"followers_count": 34}),
@@ -246,7 +231,6 @@ def test_instagram_login_account_metrics_use_current_insights_metrics():
     assert metrics.impressions == 0
     assert metrics.reach == 12
     assert metrics.followers == 34
-    assert metrics.profile_views == 5
     assert metrics.extra["views"] == 67
     provider._request.assert_has_calls(
         [
@@ -271,18 +255,6 @@ def test_instagram_login_account_metrics_use_current_insights_metrics():
                     "metric_type": "total_value",
                     "since": 1781740800,
                     "until": 1781827200,
-                },
-            ),
-            call(
-                "GET",
-                "https://graph.instagram.com/v25.0/me/insights",
-                access_token="ig-token",
-                params={
-                    "metric": "profile_views",
-                    "period": "day",
-                    "since": 1781740800,
-                    "until": 1781827200,
-                    "metric_type": "total_value",
                 },
             ),
             call(

--- a/tests/providers/test_tiktok.py
+++ b/tests/providers/test_tiktok.py
@@ -413,18 +413,19 @@ class TestAccountMetricsPersistence:
         assert out["followers"] == 0.0
 
     def test_followers_not_persisted_for_platforms_without_catalog_entry(self):
-        # Instagram/Facebook providers populate ``AccountMetrics.followers``
-        # with daily-delta values (Insights API ``follower_count`` /
-        # ``page_fans``), not lifetime totals. Persisting them under the
-        # ``followers`` key (which the catalog labels as a total) would
-        # mislabel the data. The catalog-membership gate prevents that
-        # leak today; this test pins the contract.
+        # Facebook/LinkedIn surface follower *growth* via the daily-delta
+        # ``follows`` key (e.g. FB ``page_daily_follows_unique``) and their
+        # catalogs don't list ``followers``, so the lifetime total must not be
+        # persisted under the ``followers`` key. The catalog-membership gate
+        # prevents that leak; this test pins the contract. (Instagram
+        # intentionally DOES persist ``followers`` now — its catalog lists it so
+        # growth derives from the daily total, same as TikTok.)
         from apps.analytics.tasks import _account_metrics_to_dict
         from providers.types import AccountMetrics
 
         metrics = AccountMetrics(followers=42)
 
-        for platform in ("instagram", "facebook", "linkedin_company"):
+        for platform in ("facebook", "linkedin_company"):
             out = _account_metrics_to_dict(metrics, platform)
             assert "followers" not in out, f"unexpected followers leak for {platform}"
 


### PR DESCRIPTION
## What & why

Follow-up to #99 (now merged). I verified #99's Meta analytics metrics **end-to-end against Meta's Graph API v25.0 docs** — metric names, periods (Page=`day`, Post=lifetime), `metric_type=total_value` (IG-only), response parsing, and the provider → `_*_metrics_to_dict` → catalog mapping are all correct. This PR fixes the three issues that verification surfaced, and folds in the one useful, non-overlapping piece of #98.

**Supersedes #98** — its `facebook_upstream_ids` storage was inert (#99 re-derives IDs at read time); only the `_publish_video` permalink piece is worth keeping, and it's reimplemented here without the storage/engine changes.

## Changes

- **A1 — drop deprecated IG `profile_views`.** Removed from both IG providers (`INSTAGRAM_ACCOUNT_INSIGHTS`, `metric_params`, the `AccountMetrics` return) plus the now-vestigial `profile_visits` (catalog entry, `_account_metrics_to_dict` mapping, `AccountMetrics.profile_views` field, manual-test spec). It is no longer in Meta's IG User Insights list — it errored on every IG sync and mapped to a card no catalog listed.
- **A2 — `_get_post_fields` retries without `post_id`.** `post_id` is a **Video-node** field, not a field on a normal Post; on a feed post the `?fields=…,post_id,…` call can return `(#100) nonexisting field`, fail the whole request, and **silently zero comments & shares**. Now we retry without `post_id` (video objects still resolve it on the first attempt).
- **A3 — IG `follows` → `followers` in the catalog.** IG supplies no daily-follows metric (Meta deprecated `follower_count`; `follows_and_unfollows` is unreliable). Reuse `follower_growth_metric`'s existing `followers` branch (the TikTok path) to derive growth from the profile follower total we already fetch — no new API call.
- **B — `_publish_video` feed permalink (from #98).** Best-effort `GET /{video_id}?fields=post_id,permalink_url` so the stored URL is shareable and `platform_post_id` is the feed post id. No inert storage, no engine changes, **no status polling** (async `post_id` may be missing right after upload — #99's read-time resolution covers analytics).

## Tests / verification

- `pytest tests/ apps/analytics/ apps/social_accounts/ apps/publisher/tests.py` → **all pass** (added FB `_get_post_fields` retry + `_publish_video` tests, IG mapping test; updated IG/TikTok catalog-contract tests).
- `ruff check .` and `ruff format --check .` → clean.

## Manual follow-ups (need real Meta tokens)

- Confirm `GET /{feed_post_id}?fields=…,post_id,…` actually 400s on a plain post (validates A2's retry is load-bearing).
- Publish a real FB video → confirm the stored URL is a real permalink or cleanly falls back.
- One IG sync → confirm no more `profile_views` warning and a `followers` snapshot is written.

## Watch (no code change)

`*_total_media_view_unique` ("reach") is **not 1:1** with the old unique-impressions reach (media-view based, paid+organic combined) — expect a discontinuity around the migration; a tooltip would help.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
