### PR TITLE
[codex] Use video-only TikTok analytics scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ If you set only the Path B (Company) credentials, Brightbean Studio automaticall
    ```
    {APP_URL}/social-accounts/callback/social1/
    ```
-4. Required scopes: `user.info.basic`, `user.info.profile`, `user.info.stats`, `video.publish`, `video.upload`, `video.list`
+4. Required scopes: `user.info.basic`, `video.publish`, `video.upload`, `video.list`
 5. Note: TikTok uses **Client Key** (not Client ID). Copy the **Client Key** and **Client Secret** from your app dashboard
 6. Set the environment variables:
    ```

--- a/apps/analytics/metrics.py
+++ b/apps/analytics/metrics.py
@@ -54,13 +54,10 @@ PLATFORM_METRICS: dict[str, list[str]] = {
     # YouTube Analytics: views, watch_time, avg_view_pct, likes, comments, shares, subscribers gained.
     "youtube": ["views", "watch_time", "avg_view_pct", "likes", "comments", "shares", "subscribers"],
     # TikTok video metrics: view/like/comment/share counts from /v2/video/query/.
-    # ``followers`` (total) is account-only — TikTok's /v2/user/info/ returns
-    # cumulative counters with no daily delta, so we surface the total rather
-    # than ``follows`` (which is defined as "new follows" per day). watch_time
-    # is intentionally absent: /v2/video/query/ doesn't expose it per-video
-    # and TikTok has no public per-video Analytics-style endpoint yet — listing
-    # it would render an always-zero chart and mislead users.
-    "tiktok": ["views", "likes", "comments", "shares", "followers", "engagement"],
+    # Account-level followers require ``user.info.stats``, which we don't request.
+    # watch_time is intentionally absent: TikTok has no public per-video
+    # Analytics-style endpoint for it yet.
+    "tiktok": ["views", "likes", "comments", "shares", "engagement"],
     # Bluesky / AT Protocol post aggregates: like, repost, reply counts (no impressions/views).
     "bluesky": ["likes", "reposts", "replies", "follows"],
     # Threads insights: views, likes, replies, reposts; account follower growth.

--- a/providers/tiktok.py
+++ b/providers/tiktok.py
@@ -143,12 +143,9 @@ class TikTokProvider(SocialProvider):
 
     @property
     def analytics_only_scopes(self) -> list[str]:
-        # ``video.list`` lets us read per-video stats; ``user.info.profile`` +
-        # ``user.info.stats`` enable account-level totals via /v2/user/info/.
-        # All three are gated behind the analytics platform toggle so a
-        # publish-only TikTok app (whose review hasn't approved them yet)
-        # can still connect accounts.
-        return ["user.info.profile", "user.info.stats", "video.list"]
+        # ``video.list`` lets us read per-video stats. Keep TikTok analytics
+        # video-only so sandbox apps don't need the profile/stat scopes.
+        return ["video.list"]
 
     @property
     def rate_limits(self) -> RateLimitConfig:
@@ -583,41 +580,14 @@ class TikTokProvider(SocialProvider):
         )
 
     def get_account_metrics(self, access_token: str, date_range: tuple[datetime, datetime]) -> AccountMetrics:
-        """Account-level totals from ``/v2/user/info/``.
+        """TikTok account-level analytics are intentionally disabled.
 
-        Requires ``user.info.profile`` + ``user.info.stats``. TikTok exposes
-        only lifetime cumulative counters here (no daily delta), so the
-        ``date_range`` argument is accepted for signature parity with other
-        providers but not sent to the API; the sync layer keys snapshots by
-        the calling date.
-
-        Only ``follower_count`` is propagated — into
-        :attr:`AccountMetrics.followers`, which
-        :func:`apps.analytics.tasks._account_metrics_to_dict` writes as the
-        ``"followers"`` snapshot key for platforms whose
-        ``PLATFORM_METRICS`` lists it. The other ``/v2/user/info/`` fields
-        (``likes_count``, ``video_count``, ``following_count``) are
-        intentionally NOT mapped to ``extra``: their semantics are LIFETIME
-        TOTALS but the analytics catalog mapper's recognised extras
-        (``likes``, ``comments``, ``shares``, …) are DAILY values that
-        :func:`apps.analytics.derive.engagement_rate` sums across the
-        window — feeding a cumulative total in would inflate the rate by N
-        days. If TikTok exposes a daily-delta endpoint in the future, those
-        fields can land here under the correct keys.
+        The implemented TikTok analytics surface is video-only and relies on
+        ``video.list``. Follower totals require ``user.info.stats``, which we
+        do not request, so this returns an empty metrics object.
         """
-        del date_range  # /v2/user/info/ returns lifetime totals, no range filter.
-        resp = self._request(
-            "GET",
-            f"{API_BASE}/user/info/",
-            access_token=access_token,
-            params={"fields": "follower_count"},
-        )
-        body = resp.json()
-        user = body.get("data", {}).get("user", {}) or {}
-        followers = 0
-        with contextlib.suppress(TypeError, ValueError):
-            followers = int(user.get("follower_count", 0) or 0)
-        return AccountMetrics(followers=followers)
+        del access_token, date_range
+        return AccountMetrics(followers=None)
 
     # ------------------------------------------------------------------
     # Token management

--- a/tests/providers/test_tiktok.py
+++ b/tests/providers/test_tiktok.py
@@ -1,4 +1,4 @@
-"""Tests for TikTokProvider analytics methods (video.list + user.info.stats)."""
+"""Tests for TikTokProvider analytics methods (video.list)."""
 
 import hashlib
 from datetime import UTC, datetime
@@ -28,6 +28,13 @@ def _date_range() -> tuple[datetime, datetime]:
 class TestGetAuthUrl:
     def test_provider_declares_pkce(self):
         assert TikTokProvider({"client_key": "k", "client_secret": "s"}).uses_pkce is True
+
+    def test_scopes_are_publish_plus_video_analytics_only(self):
+        provider = TikTokProvider({"client_key": "k", "client_secret": "s"})
+        url = provider.get_auth_url("https://app.example/cb", "state-123")
+
+        query = parse_qs(urlsplit(url).query)
+        assert query["scope"] == ["user.info.basic,video.publish,video.upload,video.list"]
 
     def test_includes_pkce_challenge_when_verifier_given(self):
         provider = TikTokProvider({"client_key": "k", "client_secret": "s"})
@@ -302,92 +309,27 @@ class TestGetPostMetrics:
 
 class TestGetAccountMetrics:
     @patch.object(TikTokProvider, "_request")
-    def test_request_shape(self, mock_request):
-        mock_request.return_value = _make_response({"data": {"user": {}}})
-
+    def test_returns_empty_without_user_info_request(self, mock_request):
+        # TikTok analytics is video-only. Account follower totals require
+        # user.info.stats, which OAuth no longer requests.
         provider = TikTokProvider({"client_key": "k", "client_secret": "s"})
-        provider.get_account_metrics("token-xyz", _date_range())
+        metrics = provider.get_account_metrics("token-xyz", _date_range())
 
-        assert mock_request.call_count == 1
-        args, kwargs = mock_request.call_args
-        assert args[0] == "GET"
-        assert args[1] == "https://open.tiktokapis.com/v2/user/info/"
-        assert kwargs["access_token"] == "token-xyz"
-        # date_range is intentionally NOT sent — /v2/user/info/ returns
-        # lifetime totals with no range filter. Only follower_count is
-        # requested; the other user.info.stats fields (likes_count etc.)
-        # are lifetime cumulatives that would inflate engagement_rate if
-        # snapshotted as daily values.
-        assert kwargs["params"] == {"fields": "follower_count"}
-
-    @patch.object(TikTokProvider, "_request")
-    def test_parses_followers(self, mock_request):
-        mock_request.return_value = _make_response({"data": {"user": {"follower_count": 4200}}})
-
-        provider = TikTokProvider({"client_key": "k", "client_secret": "s"})
-        metrics = provider.get_account_metrics("token", _date_range())
-
-        assert metrics.followers == 4200
-        # No extras — TikTok's other lifetime counters would corrupt
-        # engagement_rate if treated as per-day values, so they're not
-        # surfaced until a daily-delta endpoint exists.
+        assert metrics.followers is None
         assert metrics.extra == {}
+        mock_request.assert_not_called()
 
-    @patch.object(TikTokProvider, "_request")
-    def test_zero_followers_still_returns_metrics(self, mock_request):
-        # Brand-new accounts can legitimately have 0 followers; the
-        # AccountMetrics object MUST still carry that value (not None) so
-        # `_account_metrics_to_dict` writes a baseline snapshot.
-        mock_request.return_value = _make_response({"data": {"user": {"follower_count": 0}}})
-
-        provider = TikTokProvider({"client_key": "k", "client_secret": "s"})
-        metrics = provider.get_account_metrics("token", _date_range())
-
-        assert metrics.followers == 0
-
-    @patch.object(TikTokProvider, "_request")
-    def test_missing_user_block_returns_empty(self, mock_request):
-        # Defensive: malformed response shouldn't raise — empty AccountMetrics
-        # lets the sync layer treat it as "no data".
-        mock_request.return_value = _make_response({})
-
-        provider = TikTokProvider({"client_key": "k", "client_secret": "s"})
-        metrics = provider.get_account_metrics("token", _date_range())
-
-        assert metrics.followers == 0
-        assert metrics.extra == {}
-
-    @patch.object(TikTokProvider, "_request")
-    def test_non_numeric_follower_count_does_not_raise(self, mock_request):
-        # Defensive: if TikTok ever returns a non-coercible value (legacy
-        # locales have been seen to return abbreviated strings like "4.2K"),
-        # the provider must not abort the whole sync — fall back to 0.
-        mock_request.return_value = _make_response({"data": {"user": {"follower_count": "unavailable"}}})
-
-        provider = TikTokProvider({"client_key": "k", "client_secret": "s"})
-        metrics = provider.get_account_metrics("token", _date_range())
-
-        assert metrics.followers == 0
-
-    @patch.object(TikTokProvider, "_request")
-    def test_does_not_supports_date_range(self, _mock_request):
-        # The sync layer reads this flag to skip the 3-day backfill loop
-        # for providers whose stats endpoint ignores date_range — otherwise
-        # TikTok's lifetime totals would be replayed into past dates as
-        # if they were historical observations.
+    def test_does_not_supports_date_range(self):
+        # This remains false because account metrics are not date-ranged and
+        # currently not fetched at all.
         provider = TikTokProvider({"client_key": "k", "client_secret": "s"})
         assert provider.account_metrics_supports_date_range is False
 
 
 class TestAccountMetricsPersistence:
-    """Integration check: TikTok ``AccountMetrics`` actually persist to snapshots.
+    """Integration checks for TikTok's video-only analytics catalog."""
 
-    Without these checks, the provider can silently return well-formed
-    ``AccountMetrics`` that the catalog mapper drops on the floor — exactly
-    the Codex finding for issue 2.
-    """
-
-    def test_tiktok_followers_persists(self):
+    def test_tiktok_followers_are_not_persisted(self):
         from apps.analytics.tasks import _account_metrics_to_dict
         from providers.types import AccountMetrics
 
@@ -395,53 +337,23 @@ class TestAccountMetricsPersistence:
 
         out = _account_metrics_to_dict(metrics, "tiktok")
 
-        # Total follower count snapshots under the ``followers`` key the
-        # catalog mapper persists for platforms that list it.
-        assert out["followers"] == 4200.0
-
-    def test_tiktok_zero_followers_persists(self):
-        # Brand-new TikTok account: 0 followers must still be persisted
-        # so the chart series has a baseline (not a gap that jumps to
-        # the first non-zero value).
-        from apps.analytics.tasks import _account_metrics_to_dict
-        from providers.types import AccountMetrics
-
-        metrics = AccountMetrics(followers=0)
-
-        out = _account_metrics_to_dict(metrics, "tiktok")
-
-        assert out["followers"] == 0.0
+        assert "followers" not in out
 
     def test_followers_not_persisted_for_platforms_without_catalog_entry(self):
-        # Facebook/LinkedIn surface follower *growth* via the daily-delta
-        # ``follows`` key (e.g. FB ``page_daily_follows_unique``) and their
-        # catalogs don't list ``followers``, so the lifetime total must not be
-        # persisted under the ``followers`` key. The catalog-membership gate
-        # prevents that leak; this test pins the contract. (Instagram
-        # intentionally DOES persist ``followers`` now — its catalog lists it so
-        # growth derives from the daily total, same as TikTok.)
         from apps.analytics.tasks import _account_metrics_to_dict
         from providers.types import AccountMetrics
 
         metrics = AccountMetrics(followers=42)
 
-        for platform in ("facebook", "linkedin_company"):
+        for platform in ("facebook", "linkedin_company", "tiktok"):
             out = _account_metrics_to_dict(metrics, platform)
             assert "followers" not in out, f"unexpected followers leak for {platform}"
 
-    def test_tiktok_follower_growth_metric_resolves(self):
-        # Regression guard for the catalog-swap bug: when TikTok's catalog
-        # was changed from ``follows`` to ``followers``, the existing
-        # follower_growth_metric iteration over (``subscribers``, ``follows``)
-        # returned None for TikTok, hiding the new follower data from the
-        # analytics header.
-        from apps.analytics.metrics import PLATFORM_METRICS
+    def test_tiktok_catalog_is_video_only(self):
+        from apps.analytics.metrics import PLATFORM_METRICS, post_metrics_for
 
-        platform_metrics = PLATFORM_METRICS["tiktok"]
-        assert any(m in platform_metrics for m in ("subscribers", "follows", "followers")), (
-            "TikTok must list one of the account-level growth metrics for "
-            "follower_growth_metric to surface follower data in the UI header"
-        )
+        assert PLATFORM_METRICS["tiktok"] == ["views", "likes", "comments", "shares", "engagement"]
+        assert post_metrics_for("tiktok") == ["views", "likes", "comments", "shares", "engagement"]
 
 
 CREATOR_INFO_URL = "https://open.tiktokapis.com/v2/post/publish/creator_info/query/"


### PR DESCRIPTION
## Summary

This changes TikTok analytics to rely only on the `video.list` scope.

## Why

TikTok sandbox apps can connect successfully with `user.info.basic`, `video.publish`, `video.upload`, and `video.list`, but requesting `user.info.profile` and `user.info.stats` causes `invalid_scope` unless those profile/stat scopes are enabled. The current analytics implementation can derive TikTok video performance from video metrics, so the extra profile/stat scopes are not required.

## Changes

- Request only `video.list` as the TikTok analytics scope.
- Stop fetching TikTok account-level follower metrics from `/v2/user/info/`.
- Remove TikTok `followers` from the analytics metric catalog.
- Update TikTok setup documentation and provider tests for the new video-only behavior.

## Validation

- `.venv/bin/python -m pytest tests/providers/test_tiktok.py tests/providers/test_base.py apps/social_accounts/tests/test_views.py apps/analytics/tests/test_tasks.py`
- `.venv/bin/python -m ruff check providers/tiktok.py apps/analytics/metrics.py tests/providers/test_tiktok.py`