### PR TITLE
[codex] Enforce platform publish settings in composer

### DIFF
--- a/apps/composer/tests/test_account_scope.py
+++ b/apps/composer/tests/test_account_scope.py
@@ -266,6 +266,52 @@ class TikTokExtrasSyncTests(AccountScopeTestsBase):
         self.assertEqual(self.tt_pp.platform_extra, {"privacy_level": "SELF_ONLY"})
 
 
+class PinterestBoardSelectionTests(AccountScopeTestsBase):
+    def setUp(self):
+        super().setUp()
+        self.pinterest = SocialAccount.objects.create(
+            workspace=self.workspace,
+            platform="pinterest",
+            account_platform_id="pin-1",
+            account_name="Pinterest",
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+        self.pin_pp = PlatformPost.objects.create(
+            post=self.post,
+            social_account=self.pinterest,
+            status=PlatformPost.Status.DRAFT,
+        )
+
+    def _pinterest_payload(self, **fields):
+        acc = str(self.pinterest.id)
+        payload = self._payload(selected_accounts=acc, account_scope=acc)
+        payload.update({f"pin_{key}_{acc}": value for key, value in fields.items()})
+        return payload
+
+    def test_selected_pinterest_account_requires_board(self):
+        response = self.client.post(self.save_url, data=self._pinterest_payload())
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("pinterest_board", response.json()["errors"])
+
+    def test_selected_pinterest_account_saves_board(self):
+        response = self.client.post(self.save_url, data=self._pinterest_payload(board_id="board-123"))
+
+        self.assertIn(response.status_code, (200, 204, 302))
+        self.pin_pp.refresh_from_db()
+        self.assertEqual(self.pin_pp.platform_extra["board_id"], "board-123")
+
+    def test_missing_board_field_preserves_existing_board(self):
+        self.pin_pp.platform_extra = {"board_id": "board-123"}
+        self.pin_pp.save(update_fields=["platform_extra"])
+
+        response = self.client.post(self.save_url, data=self._pinterest_payload())
+
+        self.assertIn(response.status_code, (200, 204, 302))
+        self.pin_pp.refresh_from_db()
+        self.assertEqual(self.pin_pp.platform_extra["board_id"], "board-123")
+
+
 class TikTokComposerDefaultsTests(AccountScopeTestsBase):
     """TikTok's audit requires the composer to ship NO default privacy level and
     NO pre-checked interaction toggles. The defaults live in the Alpine init in
@@ -284,7 +330,10 @@ class TikTokComposerDefaultsTests(AccountScopeTestsBase):
         # No pre-selected privacy level (TikTok "no default value" rule)…
         self.assertIn("privacy_level || ''", html)
         self.assertNotIn("privacy_level || 'PUBLIC_TO_EVERYONE'", html)
-        # …and the creator-info effect must not auto-select an option either.
+        # …except when creator-info says SELF_ONLY is the sole legal option for
+        # an unaudited app, in which case the form must submit the only valid
+        # value instead of falling back to PUBLIC_TO_EVERYONE server-side.
+        self.assertIn("opts.length === 1 && opts[0] === 'SELF_ONLY'", html)
         self.assertNotIn("ttPrivacy = opts[0]", html)
 
     def test_interaction_toggles_unchecked_by_default(self):

--- a/apps/composer/views.py
+++ b/apps/composer/views.py
@@ -172,8 +172,11 @@ def _sync_platform_posts(request, post, workspace, initial_status=None):
             }
 
         elif account.platform == "pinterest":
+            board_id = request.POST.get(f"pin_board_id_{acc_id}", "").strip()
+            if not board_id:
+                board_id = (pp.platform_extra or {}).get("board_id") or None
             pp.platform_extra = {
-                "board_id": request.POST.get(f"pin_board_id_{acc_id}", "").strip() or None,
+                "board_id": board_id,
                 "link_url": request.POST.get(f"pin_link_url_{acc_id}", "").strip() or None,
                 "alt_text": request.POST.get(f"pin_alt_text_{acc_id}", "").strip() or None,
                 "tag_products": request.POST.get(f"pin_tag_products_{acc_id}", "").strip() or None,
@@ -219,6 +222,31 @@ def _sync_platform_posts(request, post, workspace, initial_status=None):
             pp.platform_extra = extra
 
         pp.save()
+
+
+def _validate_pinterest_board_selection(request, post, workspace):
+    """Selected Pinterest accounts need a board before composer save/submit."""
+    selected_ids = _parse_selected_account_ids(request.POST.get("selected_accounts", ""))
+    if not selected_ids:
+        return None
+
+    accounts = SocialAccount.objects.filter(id__in=selected_ids, workspace=workspace, platform="pinterest")
+    for account in accounts:
+        acc_id = str(account.id)
+        board_id = request.POST.get(f"pin_board_id_{acc_id}", "").strip()
+        if not board_id and post.pk:
+            board_id = (
+                PlatformPost.objects.filter(post=post, social_account=account)
+                .values_list("platform_extra__board_id", flat=True)
+                .first()
+                or ""
+            )
+        if not board_id:
+            return JsonResponse(
+                {"errors": {"pinterest_board": f"Select a Pinterest board for {account.account_name}."}},
+                status=400,
+            )
+    return None
 
 
 def _save_version(post, user):
@@ -701,6 +729,10 @@ def save_post(request, workspace_id, post_id=None):
     post.workspace = workspace
     if not post_id:
         post.author = request.user
+
+    pinterest_board_error = _validate_pinterest_board_selection(request, post, workspace)
+    if pinterest_board_error is not None:
+        return pinterest_board_error
 
     # Handle action — note that Post itself no longer carries an editorial
     # status: every transition below operates on the PlatformPost children,

--- a/providers/tiktok.py
+++ b/providers/tiktok.py
@@ -277,6 +277,7 @@ class TikTokProvider(SocialProvider):
                 platform=self.platform_name,
             )
 
+        privacy_level_is_explicit = "privacy_level" in content.extra
         privacy_level = content.extra.get("privacy_level", DEFAULT_PRIVACY_LEVEL)
         if privacy_level not in VALID_PRIVACY_LEVELS:
             raise PublishError(
@@ -285,7 +286,12 @@ class TikTokProvider(SocialProvider):
                 retryable=False,
             )
 
-        self._check_creator_constraints(access_token, privacy_level, content)
+        privacy_level = self._check_creator_constraints(
+            access_token,
+            privacy_level,
+            content,
+            privacy_level_is_explicit=privacy_level_is_explicit,
+        )
 
         # Prefer FILE_UPLOAD: PULL_FROM_URL requires the source domain to be
         # verified with TikTok, which presigned S3/R2 URLs can't satisfy.
@@ -299,7 +305,14 @@ class TikTokProvider(SocialProvider):
             retryable=False,
         )
 
-    def _check_creator_constraints(self, access_token: str, privacy_level: str, content: PublishContent) -> None:
+    def _check_creator_constraints(
+        self,
+        access_token: str,
+        privacy_level: str,
+        content: PublishContent,
+        *,
+        privacy_level_is_explicit: bool,
+    ) -> str:
         """Validate privacy level and video duration against creator_info.
 
         A creator_info failure is logged and ignored — a transient outage of
@@ -310,22 +323,25 @@ class TikTokProvider(SocialProvider):
             info = self.query_creator_info(access_token)
         except Exception:
             logger.warning("TikTok creator_info query failed; proceeding with publish", exc_info=True)
-            return
+            return privacy_level
 
         options = info.get("privacy_level_options") or []
         if options and privacy_level not in options:
-            message = (
-                f"TikTok does not allow privacy level '{privacy_level}' for this "
-                f"account (allowed: {', '.join(options)})."
-            )
-            if options == ["SELF_ONLY"]:
-                message = f"{message} {UNAUDITED_CLIENT_HINT}"
-            raise PublishError(
-                message,
-                platform=self.platform_name,
-                raw_response=info,
-                retryable=False,
-            )
+            if not privacy_level_is_explicit and options == ["SELF_ONLY"]:
+                privacy_level = "SELF_ONLY"
+            else:
+                message = (
+                    f"TikTok does not allow privacy level '{privacy_level}' for this "
+                    f"account (allowed: {', '.join(options)})."
+                )
+                if options == ["SELF_ONLY"]:
+                    message = f"{message} {UNAUDITED_CLIENT_HINT}"
+                raise PublishError(
+                    message,
+                    platform=self.platform_name,
+                    raw_response=info,
+                    retryable=False,
+                )
 
         # TikTok's UX guidelines require checking the video against the
         # creator's max post duration before uploading. Skip silently when
@@ -340,6 +356,7 @@ class TikTokProvider(SocialProvider):
                 raw_response=info,
                 retryable=False,
             )
+        return privacy_level
 
     def _init_video_publish(self, access_token: str, payload: dict) -> dict:
         """POST to /post/publish/video/init/ and return the parsed body.

--- a/templates/composer/compose.html
+++ b/templates/composer/compose.html
@@ -818,6 +818,7 @@
                                          if (data.duet_disabled) ttAllowDuet = false;
                                          if (data.stitch_disabled) ttAllowStitch = false;
                                          const opts = data.privacy_level_options || [];
+                                         if (!ttPrivacy && opts.length === 1 && opts[0] === 'SELF_ONLY') ttPrivacy = 'SELF_ONLY';
                                          if (ttPrivacy && opts.length && !opts.includes(ttPrivacy)) ttPrivacy = '';
                                      }
                                      ttLoaded = true;

--- a/tests/providers/test_tiktok.py
+++ b/tests/providers/test_tiktok.py
@@ -404,20 +404,34 @@ class TestPublishPost:
         assert result.platform_post_id == "v_pub_url~123"
 
     @patch.object(TikTokProvider, "_request")
-    def test_unaudited_options_block_public_post_before_init(self, mock_request):
-        # Unaudited apps only get SELF_ONLY back — a public post must fail
-        # fast with retryable=False, without ever hitting video/init.
+    def test_unaudited_options_block_explicit_public_post_before_init(self, mock_request):
+        # Unaudited apps only get SELF_ONLY back — an explicitly public post
+        # must fail fast with retryable=False, without ever hitting video/init.
         mock_request.return_value = _creator_info_response(["SELF_ONLY"])
 
         provider = TikTokProvider({"client_key": "k", "client_secret": "s"})
         with pytest.raises(PublishError) as excinfo:
-            provider.publish_post("tok", _video_content())
+            provider.publish_post("tok", _video_content(privacy_level="PUBLIC_TO_EVERYONE"))
 
         assert excinfo.value.retryable is False
         assert "audit" in str(excinfo.value)
         assert "SELF_ONLY" in str(excinfo.value)
         urls = [call.args[1] for call in mock_request.call_args_list]
         assert VIDEO_INIT_URL not in urls
+
+    @patch.object(TikTokProvider, "_request")
+    def test_unaudited_options_use_self_only_for_implicit_default(self, mock_request):
+        mock_request.side_effect = [
+            _creator_info_response(["SELF_ONLY"]),
+            _init_response(),
+        ]
+
+        provider = TikTokProvider({"client_key": "k", "client_secret": "s"})
+        result = provider.publish_post("tok", _video_content())
+
+        assert result.platform_post_id == "v_pub_url~123"
+        init_call = mock_request.call_args_list[1]
+        assert init_call.kwargs["json"]["post_info"]["privacy_level"] == "SELF_ONLY"
 
     @patch.object(TikTokProvider, "_request")
     def test_self_only_post_allowed_when_unaudited(self, mock_request):


### PR DESCRIPTION
## Summary

This tightens composer/provider handling for platform-specific publish settings.

## Why

TikTok unaudited apps can only publish with `SELF_ONLY` visibility. The composer could show that state, but if the saved publish extras omitted `privacy_level`, the provider fell back to `PUBLIC_TO_EVERYONE` and TikTok rejected the post. Pinterest also requires a board selection; the browser field was marked required, but server-side saves could still persist a selected Pinterest account without a board.

## Changes

- Auto-select TikTok `SELF_ONLY` in the composer only when creator-info says it is the sole allowed privacy option.
- Have the TikTok provider convert only an implicit missing privacy default to `SELF_ONLY` when creator-info permits only that value.
- Keep explicit public TikTok choices failing fast for unaudited apps.
- Enforce Pinterest board selection in the composer save endpoint.
- Preserve an existing Pinterest board if a later scoped save omits the board field.
- Add focused tests for TikTok unaudited privacy handling and Pinterest board validation.

## Validation

- `.venv/bin/python -m pytest apps/composer/tests/test_account_scope.py tests/providers/test_tiktok.py apps/publisher/tests.py`
- `.venv/bin/python -m ruff check apps/composer/views.py apps/composer/tests/test_account_scope.py providers/tiktok.py tests/providers/test_tiktok.py`