### PR TITLE
feat(composer): enforce TikTok branded-content × privacy UX rules

### DIFF
--- a/templates/composer/compose.html
+++ b/templates/composer/compose.html
@@ -806,7 +806,18 @@
                                  if (this.ttBrandOrganic) return `Your photo/video will be labeled as 'Promotional content'`;
                                  return '';
                              },
+                             get ttBrandingBlocked() {
+                                 return this.ttSelfOnlyLocked || this.ttPrivacy === 'SELF_ONLY';
+                             },
+                             enforceBrandingLock() {
+                                 if (this.ttBrandingBlocked && this.ttBrandContent) {
+                                     this.ttBrandContent = false;
+                                     if (!this.ttBrandOrganic) this.ttDisclose = false;
+                                 }
+                             },
                          }"
+                         x-init="enforceBrandingLock();
+                                 $watch('ttBrandingBlocked', () => enforceBrandingLock())"
                          x-effect="if (charLimits[accId]?.platform === 'tiktok' && !ttLoaded && !ttLoading) {
                              ttLoading = true;
                              fetch(`/workspace/{{ workspace.id }}/compose/tiktok-creator-info/${accId}/`)
@@ -839,19 +850,81 @@
                             <label class="block text-[11px] font-semibold text-stone-400 uppercase tracking-wider mb-1">
                                 Who can see this post <span class="text-red-400">*</span>
                             </label>
-                            <select :name="'tiktok_privacy_level_' + accId"
-                                    x-model="ttPrivacy"
-                                    class="bb-select w-full text-sm px-3 py-2 rounded-lg border border-stone-200 bg-white outline-none focus:border-orange-500 focus:ring-2 focus:ring-orange-100 transition-all"
-                                    :required="charLimits[accId]?.platform === 'tiktok' && selectedAccounts.includes(accId)">
-                                <option value="" disabled :selected="!ttPrivacy">Select who can view this post</option>
-                                <template x-for="lvl in ttOptions" :key="lvl">
-                                    <option :value="lvl"
-                                            :disabled="ttBrandContent && lvl === 'SELF_ONLY'"
-                                            :title="(ttBrandContent && lvl === 'SELF_ONLY') ? 'Branded content visibility cannot be set to private.' : ''"
-                                            :selected="ttPrivacy === lvl"
-                                            x-text="ttLabel(lvl)"></option>
-                                </template>
-                            </select>
+                            <!-- Custom dropdown (not a native <select>): native <option>s never
+                                 render a hover tooltip, so the disabled "Only you" option couldn't
+                                 show TikTok's required prompt. A button + listbox lets each option
+                                 carry a real disabled state and hover tooltip. -->
+                            <div class="relative"
+                                 @focusout="if (! $el.contains($event.relatedTarget)) open = false"
+                                 x-data="{
+                                     open: false,
+                                     openMenu() {
+                                         this.open = true;
+                                         this.$nextTick(() => {
+                                             const list = this.$refs.list;
+                                             (list?.querySelector('button[role=option][aria-selected=true]:not([disabled])')
+                                               || list?.querySelector('button[role=option]:not([disabled])'))?.focus();
+                                         });
+                                     },
+                                     moveFocus(dir) {
+                                         const opts = [...(this.$refs.list?.querySelectorAll('button[role=option]:not([disabled])') || [])];
+                                         if (! opts.length) return;
+                                         const i = opts.indexOf(document.activeElement);
+                                         (opts[(i + dir + opts.length) % opts.length] || opts[0]).focus();
+                                     }
+                                 }">
+                                <button type="button"
+                                        x-ref="trigger"
+                                        @click="open ? (open = false) : openMenu()"
+                                        @keydown.arrow-down.prevent="openMenu()"
+                                        @keydown.arrow-up.prevent="openMenu()"
+                                        :aria-expanded="open"
+                                        aria-haspopup="listbox"
+                                        class="w-full text-sm px-3 py-2 rounded-lg border border-stone-200 bg-white outline-none focus:border-orange-500 focus:ring-2 focus:ring-orange-100 transition-all flex items-center justify-between gap-2 text-left cursor-pointer">
+                                    <span :class="ttPrivacy ? 'text-stone-800' : 'text-stone-400'"
+                                          x-text="ttPrivacy ? ttLabel(ttPrivacy) : 'Select who can view this post'"></span>
+                                    <svg class="w-4 h-4 text-stone-400 flex-shrink-0 transition-transform" :class="open && 'rotate-180'" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
+                                </button>
+                                <ul x-show="open" x-cloak x-transition
+                                    x-ref="list"
+                                    @click.outside="open = false"
+                                    @keydown.escape.window="if (open) { open = false; $refs.trigger.focus(); }"
+                                    @keydown.arrow-down.prevent="moveFocus(1)"
+                                    @keydown.arrow-up.prevent="moveFocus(-1)"
+                                    @keydown.home.prevent="$refs.list.querySelector('button[role=option]:not([disabled])')?.focus()"
+                                    @keydown.end.prevent="[...$refs.list.querySelectorAll('button[role=option]:not([disabled])')].pop()?.focus()"
+                                    role="listbox"
+                                    class="absolute z-50 top-full mt-1 left-0 w-full bg-white rounded-lg shadow-lg ring-1 ring-stone-200 py-1">
+                                    <template x-for="lvl in ttOptions" :key="lvl">
+                                        <li class="relative group">
+                                            <button type="button"
+                                                    role="option"
+                                                    tabindex="-1"
+                                                    :aria-selected="ttPrivacy === lvl"
+                                                    :aria-disabled="ttBrandContent && lvl === 'SELF_ONLY'"
+                                                    :disabled="ttBrandContent && lvl === 'SELF_ONLY'"
+                                                    @click="ttPrivacy = lvl; open = false; $refs.trigger.focus()"
+                                                    class="w-full text-left text-sm px-3 py-2 flex items-center justify-between gap-2 transition-colors"
+                                                    :class="(ttBrandContent && lvl === 'SELF_ONLY') ? 'opacity-40 cursor-not-allowed' : 'hover:bg-stone-50 cursor-pointer'">
+                                                <span x-text="ttLabel(lvl)"></span>
+                                                <svg x-show="ttPrivacy === lvl" class="w-4 h-4 text-orange-500 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2.5"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+                                            </button>
+                                            <!-- Required hover prompt for the disabled private option (mouse); the
+                                                 always-visible note below the dropdown covers keyboard/SR users. -->
+                                            <span x-show="ttBrandContent && lvl === 'SELF_ONLY'"
+                                                  class="pointer-events-none absolute left-3 -top-6 opacity-0 group-hover:opacity-100 transition-opacity bg-stone-800 text-white text-[11px] rounded px-2 py-1 whitespace-nowrap z-50 shadow">
+                                                Branded content visibility cannot be set to private.
+                                            </span>
+                                        </li>
+                                    </template>
+                                </ul>
+                                <!-- Mirror input carries the value to the form and enforces the
+                                     required gate now that the native <select> is gone (same
+                                     sr-only pattern as the disclosure gate further below). -->
+                                <input type="text" :name="'tiktok_privacy_level_' + accId" :value="ttPrivacy"
+                                       :required="charLimits[accId]?.platform === 'tiktok' && selectedAccounts.includes(accId)"
+                                       tabindex="-1" aria-hidden="true" class="sr-only">
+                            </div>
                             <p x-show="ttLoading" class="text-[11px] text-stone-400 mt-1">Loading account settings…</p>
                             <p x-show="ttSelfOnlyLocked" class="text-[11px] text-amber-600 mt-1">
                                 This TikTok app hasn't passed TikTok's content audit yet — only private posting ("Only you") is available until the audit is approved.
@@ -939,16 +1012,25 @@
                                         <span class="block text-[11px] text-stone-400 font-normal">You are promoting yourself or your own business.</span>
                                     </span>
                                 </label>
-                                <label class="flex items-start gap-2 cursor-pointer">
+                                <label class="flex items-start gap-2"
+                                       :class="ttBrandingBlocked ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'">
                                     <input type="checkbox" :name="'tiktok_brand_content_' + accId" value="true"
                                            x-model="ttBrandContent"
-                                           @change="if (ttBrandContent && ttPrivacy === 'SELF_ONLY') ttPrivacy = ''"
+                                           :disabled="ttBrandingBlocked"
                                            class="bb-checkbox w-4 h-4 mt-0.5 rounded border-stone-300">
                                     <span class="text-sm text-stone-700">
                                         Branded content
                                         <span class="block text-[11px] text-stone-400 font-normal">You are promoting another brand or a third party.</span>
                                     </span>
                                 </label>
+                                <!-- Branded content can't be posted privately, so the option is
+                                     locked while visibility is "Only you"; explain why. -->
+                                <p x-show="ttSelfOnlyLocked" class="text-[11px] text-amber-600 -mt-1">
+                                    Branded content isn't available until your TikTok app passes TikTok's content audit, because branded content can't be posted privately.
+                                </p>
+                                <p x-show="ttPrivacy === 'SELF_ONLY' && !ttSelfOnlyLocked" class="text-[11px] text-stone-500 -mt-1">
+                                    Set visibility to public, friends, or followers to enable branded content.
+                                </p>
                                 <!-- Exact TikTok content label prompt, shown once a disclosure option is selected -->
                                 <template x-if="ttLabelPrompt">
                                     <p class="text-[11px] text-stone-600 bg-stone-50 border border-stone-200 rounded-md px-2 py-1.5" x-text="ttLabelPrompt"></p>


### PR DESCRIPTION
## What does this PR do?

Enforces TikTok's required branded-content × privacy UX in the composer's TikTok post settings — branded content can never be posted with private (**"Only you" / SELF_ONLY**) visibility:

- **Two-way mutual exclusion** — enabling *Branded content* disables the "Only you" visibility option; selecting "Only you" disables the *Branded content* checkbox (with an informing message).
- **Custom accessible dropdown** — replaces the native privacy `<select>` with an Alpine listbox so the disabled "Only you" option can show TikTok's required hover prompt (*"Branded content visibility cannot be set to private."*), which native `<option>`s never render. A hidden `sr-only` mirror input preserves the form field name and the `required` validation gate.
- **Audit-lock handling** — for an unaudited app where only `SELF_ONLY` is allowed, a `ttBrandingBlocked` getter + `enforceBrandingLock()` keep state valid so branded content can't strand the privacy field or the disclosure gate, and the impossible "branded + private-only" state can't be reached.
- **Accessibility** — arrow-key navigation, focus-on-open, Escape-to-trigger, roving `tabindex`, and close-on-focus-leave for the custom dropdown; `cursor-pointer` on the trigger.

UI-only enforcement; TikTok's API remains the publish-time backstop.

## Why?

TikTok's [Content Posting API content-sharing guidelines](https://developers.tiktok.com/doc/content-sharing-guidelines#required_ux_implementation_in_your_app) require this UX for audit approval: branded content disallows private visibility, and the disabled "only me" option must surface an explanatory prompt. The previous native `<select>` could not render a per-option hover prompt, and the branded ⇄ privacy interaction had gaps — most notably it could dead-end the privacy field on unaudited apps.

## How to test

Composer → select a TikTok account → open **Post Settings**:

1. **Branded on** — enable *Disclose post content* + *Branded content*, then open *Who can see this post*: "Only you" is greyed and hovering it shows "Branded content visibility cannot be set to private."
2. **Private selected** — choose "Only you": the *Branded content* checkbox is disabled with a helper message; *Your brand* stays enabled.
3. **Unaudited lock** — with creator-info returning only `SELF_ONLY`: "Only you" stays selectable, *Branded content* is locked off with the audit explanation, and the form remains submittable (no dead-end).
4. **Keyboard** — open with Enter/↓, navigate options with ↑/↓, Escape closes and returns focus to the trigger.

Verified in the browser (mutual exclusion, audit-lock edge case, keyboard nav, and no CSP violations) and via `pytest tests/providers/test_tiktok.py apps/composer/` (**144 passed**). This is a **template-only** change — no Python / server-contract changes.

## Checklist

- [x] Tests pass — TikTok provider + composer suites (144 passed); template-only, server contract unchanged
- [x] Lint passes — `ruff check .` and `ruff format --check .` clean (no Python touched)
- [ ] Documentation updated (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)