### PR TITLE
fix(docker): run migrations before app/worker in Quick Start (#112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,9 +136,11 @@ Then start everything:
 
 ```bash
 docker compose up -d --build
-docker compose exec app python manage.py migrate
 docker compose exec app python manage.py createsuperuser
 ```
+
+Database migrations run automatically via the `migrate` Compose service before
+the `app` and `worker` services start, so there is no separate migrate step.
 
 Tailwind compiles automatically via the `tailwind` Compose service. First build
 takes ~60–90 seconds (running `npm install` in a fresh container); subsequent

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,4 +1,11 @@
 services:
+  migrate:
+    volumes:
+      - .:/app
+    environment:
+      - DJANGO_SETTINGS_MODULE=config.settings.development
+      - DATABASE_URL=postgres://postgres:postgres@postgres:5432/brightbean
+
   app:
     command: python manage.py runserver 0.0.0.0:8000
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,13 @@
 services:
+  migrate:
+    build: .
+    command: python manage.py migrate --noinput
+    env_file:
+      - .env
+    depends_on:
+      postgres:
+        condition: service_healthy
+
   app:
     build: .
     volumes:
@@ -8,8 +17,9 @@ services:
     env_file:
       - .env
     depends_on:
-      postgres:
-        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    restart: unless-stopped
 
   worker:
     build: .
@@ -19,8 +29,9 @@ services:
     env_file:
       - .env
     depends_on:
-      postgres:
-        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    restart: unless-stopped
 
   postgres:
     image: postgres:16-alpine


### PR DESCRIPTION
## What

Fixes the Docker **Quick Start** so a fresh `docker compose up` can publish posts.

- Add a one-shot `migrate` service to `docker-compose.yml`, gated on `postgres: service_healthy`.
- Gate `app` and `worker` on `migrate: service_completed_successfully` (previously they only waited on Postgres being healthy).
- Add `restart: unless-stopped` to `app`/`worker` so a transient early race self-heals.
- Give the dev override's `migrate` the same `DJANGO_SETTINGS_MODULE`/`DATABASE_URL` as `app`/`worker`, so all three target the same database.
- Drop the now-redundant manual `migrate` step from the README Quick Start.

## Why

Reported in #112: following the Quick Start, posts stayed unpublished. Root cause:

- The `worker` ran `process_tasks` as soon as Postgres was healthy, but the Quick Start had the user run `migrate` **manually after** `docker compose up`. So the worker started against an empty schema and crashed with `psycopg.errors.UndefinedTable: relation "background_task" does not exist`.
- With no restart policy, the worker stayed dead — so even after the user ran `migrate` (which created the table), the publish background task never ran and the post stayed unpublished.

The repo already solved this correctly for production in `docker-compose.prod.yml` (dedicated `migrate` service + `service_completed_successfully` gating + `restart: unless-stopped`). This brings the dev Quick Start in line.

## Reviewer notes

- No application/Python code changes — purely Compose orchestration + docs.
- The `run_publish_cycle` recurring task (registered via `post_migrate` in `apps/publisher/apps.py`) now fires reliably inside the `migrate` container against created tables; the worker reads it from the DB.
- Verified `docker compose config` resolves cleanly and `docker compose -f docker-compose.yml -f docker-compose.prod.yml config` still merges (the prod `migrate` override merges with the new base service).
- I did **not** run the destructive `down -v` → `up` → publish reproduction locally, because it would wipe the existing `brightbean-studio_postgres_data` volume and the publish step needs real Mastodon credentials.

Fixes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)