### PR TITLE
fix(providers): publish single videos as Instagram Reels and wait for Threads containers

### DIFF
--- a/providers/instagram.py
+++ b/providers/instagram.py
@@ -288,7 +288,12 @@ class InstagramProvider(SocialProvider):
         if content.text:
             payload["caption"] = content.text
 
-        if content.post_type == PostType.REEL:
+        if content.post_type in (PostType.REEL, PostType.VIDEO):
+            # Instagram no longer supports standalone feed videos: a single
+            # video is published as a Reel. PostType.VIDEO (the engine's
+            # fallback for a lone video asset) must take the REELS path too,
+            # otherwise it falls through to the IMAGE branch and the .mp4 is
+            # sent as image_url ("The image format is not supported").
             payload["media_type"] = "REELS"
             payload["video_url"] = content.media_urls[0]
         elif content.post_type == PostType.STORY:

--- a/providers/threads.py
+++ b/providers/threads.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from urllib.parse import urlencode
 
 from .base import SocialProvider
@@ -25,6 +26,12 @@ logger = logging.getLogger(__name__)
 AUTH_URL = "https://www.threads.com/oauth/authorize"
 TOKEN_URL = "https://graph.threads.net/oauth/access_token"
 API_BASE = "https://graph.threads.net/v1.0"
+
+# Threads ingests media (esp. video) asynchronously: the container must reach
+# status FINISHED before it can be published, otherwise threads_publish fails
+# with "The requested resource does not exist" (code 24 / media not found).
+CONTAINER_POLL_INTERVAL = 3  # seconds
+CONTAINER_POLL_MAX_ATTEMPTS = 40  # up to ~2 min for video processing
 
 
 class ThreadsProvider(SocialProvider):
@@ -259,6 +266,13 @@ class ThreadsProvider(SocialProvider):
                 raw_response=create_body,
             )
 
+        # Step 1b: wait for media containers to finish processing before
+        # publishing. Text-only threads publish instantly, but image/video
+        # containers are ingested asynchronously; publishing too early fails
+        # with "media not found".
+        if container_payload["media_type"] != "TEXT":
+            self._wait_for_container(access_token, creation_id)
+
         # Step 2: Publish the container
         publish_resp = self._request(
             "POST",
@@ -271,6 +285,40 @@ class ThreadsProvider(SocialProvider):
         return PublishResult(
             platform_post_id=thread_id,
             extra=publish_body,
+        )
+
+    def _wait_for_container(self, access_token: str, creation_id: str) -> None:
+        """Poll a Threads media container until it is FINISHED.
+
+        Threads exposes the ingest state via the container's ``status`` field
+        (values: IN_PROGRESS, FINISHED, ERROR, EXPIRED, PUBLISHED). Video
+        containers stay IN_PROGRESS while Meta transcodes the upload; calling
+        threads_publish before FINISHED returns "media not found".
+        """
+        for _ in range(CONTAINER_POLL_MAX_ATTEMPTS):
+            resp = self._request(
+                "GET",
+                f"{API_BASE}/{creation_id}",
+                access_token=access_token,
+                params={"fields": "status,error_message"},
+            )
+            data = resp.json()
+            status = data.get("status", "")
+
+            if status in ("FINISHED", "PUBLISHED"):
+                return
+            if status in ("ERROR", "EXPIRED"):
+                raise PublishError(
+                    f"Threads container failed: {data.get('error_message', status)}",
+                    platform=self.platform_name,
+                    raw_response=data,
+                )
+
+            time.sleep(CONTAINER_POLL_INTERVAL)
+
+        raise PublishError(
+            "Threads container processing timed out",
+            platform=self.platform_name,
         )
 
     def _publish_carousel(
@@ -311,6 +359,10 @@ class ThreadsProvider(SocialProvider):
                     platform=self.platform_name,
                     raw_response=item_body,
                 )
+            # Video children ingest asynchronously; wait before they are
+            # referenced by the carousel container.
+            if media_type == "VIDEO":
+                self._wait_for_container(access_token, item_id)
             children_ids.append(item_id)
 
         # Step 2: Create carousel container
@@ -332,6 +384,8 @@ class ThreadsProvider(SocialProvider):
                 platform=self.platform_name,
                 raw_response=carousel_body,
             )
+
+        self._wait_for_container(access_token, creation_id)
 
         # Step 3: Publish
         publish_resp = self._request(


### PR DESCRIPTION
## Problem

Publishing a single **video** to **Instagram** and **Threads** always failed, while the same video published fine to YouTube and Facebook.

- **Instagram** → `400 The image format is not supported` (code 36001). The engine resolves a lone video asset to `PostType.VIDEO`, but `InstagramProvider._publish_single` only handled `REEL`/`STORY`; `VIDEO` fell through to the default **IMAGE** branch and the `.mp4` was sent as `image_url`. Instagram no longer supports standalone feed videos — a single video must be published as a **Reel**.
- **Threads** → `400 The requested resource does not exist` (code 24 / *media not found*). `ThreadsProvider._publish_single` created the media container and called `threads_publish` **immediately**, without waiting for asynchronous ingest. Video containers are still `IN_PROGRESS` at that point, so the publish failed. Instagram already polls container status (`_wait_for_container`); Threads did not.

## Fix

- **Instagram** (`providers/instagram.py`): route `PostType.VIDEO` through the REELS flow alongside `PostType.REEL`.
- **Threads** (`providers/threads.py`): add `_wait_for_container` polling (status `FINISHED`) before publishing, for both the single-item and carousel video paths.

## Validation

Deployed to a live Brightbean instance and re-published the same 720×1080/9:16 video:

- Instagram → published as a Reel ✅
- Threads → published ✅
- YouTube / Facebook → unaffected ✅

## Notes

The pre-existing `.endswith((".mp4", ".mov"))` heuristic in the carousel paths does not recognize presigned storage URLs (query string after the extension); not changed here since the failing case is single-media, but worth a follow-up.