### PR TITLE
fix(publisher): refresh session tokens (Bluesky) before publishing

### DIFF
--- a/apps/publisher/engine.py
+++ b/apps/publisher/engine.py
@@ -30,7 +30,7 @@ from django.utils import timezone
 from apps.composer.models import PlatformPost
 from apps.credentials.models import resolve_platform_credentials
 from providers import get_provider
-from providers.types import AuthType, PostType, PublishContent
+from providers.types import PostType, PublishContent
 
 from .models import PublishLog, RateLimitState
 
@@ -321,11 +321,14 @@ class PublishEngine:
         credentials = _resolve_publish_credentials(account)
         provider = get_provider(platform, credentials)
 
-        # Refresh token if expired or expiring soon (OAuth2 providers only).
+        # Refresh token if expired or expiring soon, for any provider that has
+        # a refresh token stored. This covers OAuth2 providers *and* session
+        # providers like Bluesky, whose accessJwt expires after only a few
+        # hours and must be renewed via refreshSession before each publish.
         # Best-effort: on refresh failure we keep the old token and let the
         # publish attempt surface the real error.
         access_token = account.oauth_access_token
-        if account.token_expires_at and account.is_token_expiring_soon and provider.auth_type == AuthType.OAUTH2:
+        if account.token_expires_at and account.is_token_expiring_soon and account.oauth_refresh_token:
             try:
                 access_token = account.refresh_oauth_token(provider)
                 logger.info("Refreshed token for %s", account)


### PR DESCRIPTION
## Problem

Scheduled Bluesky posts intermittently fail with:

```
Bluesky API error 400: {"error":"ExpiredToken","message":"Token has expired"}
```

The publish engine only refreshes access tokens for **OAuth2** providers. The gate in `PublishEngine._dispatch_to_provider` is:

```python
if account.token_expires_at and account.is_token_expiring_soon and provider.auth_type == AuthType.OAUTH2:
    access_token = account.refresh_oauth_token(provider)
```

Bluesky uses AT Protocol **session** auth (`AuthType.SESSION`), so this branch is never taken for it. Its `accessJwt` expires after only a few hours, so any scheduled post that waits past the token's TTL publishes with a stale token and gets `ExpiredToken`. OAuth2 platforms (Meta, Google, LinkedIn) are unaffected because their tokens are long-lived and already covered.

## Fix

Gate the refresh on the presence of a stored refresh token instead of the auth type:

```python
if account.token_expires_at and account.is_token_expiring_soon and account.oauth_refresh_token:
    access_token = account.refresh_oauth_token(provider)
```

This makes session providers that store a refresh token (Bluesky stores the `refreshJwt` in `oauth_refresh_token`) renew via `com.atproto.server.refreshSession` before each publish. The whole mechanism already existed — `SocialAccount.refresh_oauth_token()` → `provider.refresh_token()` → `refreshSession`, persisting the rotated `refreshJwt` — only the engine gate was excluding it. `BlueskyProvider.create_session` already populates `token_expires_at` from the JWT's `exp` claim, so `is_token_expiring_soon` fires correctly.

The refresh stays best-effort (wrapped in try/except): on failure the old token is kept and the publish attempt surfaces the real error, so this is safe for any provider whose `refresh_token()` may raise. The now-unused `AuthType` import is dropped.

## Testing

Verified end-to-end against a live self-hosted deployment: a Bluesky post that had been failing with `ExpiredToken` published successfully after this change.