### PR TITLE
fix(providers): escape LinkedIn reserved chars in commentary

### DIFF
--- a/apps/api/schemas.py
+++ b/apps/api/schemas.py
@@ -52,6 +52,15 @@ class AccountSummary(Schema):
         2200,
         description="Maximum caption length the platform accepts. Reject locally before calling /posts.",
     )
+    escaped_chars: str = Field(
+        "",
+        description=(
+            "Characters the platform requires escaped, each costing two against ``char_limit``. "
+            "LinkedIn escapes its reserved little-text set, so count a caption as "
+            "``len(caption) + sum(caption.count(c) for c in escaped_chars)`` before rejecting it. "
+            "Empty for platforms that publish the caption verbatim."
+        ),
+    )
     needs_title: bool = Field(
         False,
         description="True when the platform requires a title (YouTube, Pinterest). When false, the title field is ignored.",
@@ -75,6 +84,7 @@ class AccountSummary(Schema):
             account_handle=getattr(sa, "account_handle", "") or "",
             connection_status=sa.connection_status,
             char_limit=sa.char_limit,
+            escaped_chars=sa.escaped_chars,
             needs_title=bool(sa.field_config.get("needs_title", False)),
             supports_first_comment=sa.supports_first_comment(),
         )

--- a/apps/api/tests/test_account_capabilities.py
+++ b/apps/api/tests/test_account_capabilities.py
@@ -148,6 +148,13 @@ class TestPerPlatformCapabilities:
         # Facebook: also defaults to supports_first_comment=True.
         assert accs["facebook"]["supports_first_comment"] is True
 
+        # LinkedIn escapes its reserved set, so a client budgeting char_limit
+        # against the raw caption would overflow; every other platform publishes
+        # the caption verbatim.
+        assert set(accs["linkedin_company"]["escaped_chars"]) == set("\\|{}@[]()<>#*_~")
+        assert accs["youtube"]["escaped_chars"] == ""
+        assert accs["facebook"]["escaped_chars"] == ""
+
     def test_accounts_endpoint_surfaces_same_capabilities(self, client):
         body = client.get("/api/v1/accounts/").json()
         accs = self._by_platform(body["accounts"])

--- a/apps/composer/models.py
+++ b/apps/composer/models.py
@@ -529,7 +529,9 @@ class PlatformPost(models.Model):
 
     @property
     def caption_length(self):
-        return len(self.effective_caption)
+        # Not len(): platforms that escape reserved characters send more than
+        # was typed, and the limit applies to what is sent.
+        return self.social_account.caption_wire_length(self.effective_caption)
 
     @property
     def is_over_limit(self):

--- a/apps/composer/tests/__init__.py
+++ b/apps/composer/tests/__init__.py
@@ -5,6 +5,7 @@ from django.utils import timezone
 
 from apps.composer.models import PlatformPost, Post, PostVersion
 from apps.composer.status import derive_post_status
+from apps.social_accounts.models import SocialAccount
 
 
 class PlatformPostStateMachineTest(TestCase):
@@ -125,6 +126,41 @@ class PlatformPostModelTest(TestCase):
         post = Post(first_comment="Base comment")
         pp.post = post
         self.assertEqual(pp.effective_first_comment, "Base comment")
+
+
+class CaptionLengthTest(TestCase):
+    """The limit applies to what the platform receives, not what was typed.
+
+    LinkedIn escapes reserved characters in the commentary it publishes, so a
+    caption that fits as typed can still be rejected on the wire.
+    """
+
+    def _make_pp(self, platform, caption):
+        pp = PlatformPost()
+        pp.platform_specific_caption = caption
+        pp.post = Post(caption="")
+        pp.social_account = SocialAccount(platform=platform)
+        return pp
+
+    def test_linkedin_counts_the_escaped_length(self):
+        pp = self._make_pp("linkedin_personal", "Va al repo (durable)")
+        # Two parentheses, each escaped with a backslash.
+        self.assertEqual(pp.caption_length, len("Va al repo (durable)") + 2)
+
+    def test_other_platforms_count_the_typed_length(self):
+        pp = self._make_pp("bluesky", "Va al repo (durable)")
+        self.assertEqual(pp.caption_length, len("Va al repo (durable)"))
+
+    def test_escaping_can_push_a_fitting_caption_over_the_limit(self):
+        caption = "(" * 20 + "a" * 2970  # 2,990 typed, 3,010 escaped
+        pp = self._make_pp("linkedin_personal", caption)
+        self.assertLessEqual(len(caption), pp.char_limit)
+        self.assertTrue(pp.is_over_limit)
+
+    def test_a_caption_that_fits_after_escaping_is_not_flagged(self):
+        caption = "(" * 20 + "a" * 2950  # 2,970 typed, 2,990 escaped
+        pp = self._make_pp("linkedin_personal", caption)
+        self.assertFalse(pp.is_over_limit)
 
 
 class PostVersionModelTest(TestCase):

--- a/apps/composer/views.py
+++ b/apps/composer/views.py
@@ -467,6 +467,9 @@ def compose(request, workspace_id, post_id=None):
         char_limits[str(acc.id)] = {
             "platform": acc.platform,
             "limit": acc.char_limit,
+            # Each of these costs two characters once the provider escapes it,
+            # so the live counter can charge for them as the user types.
+            "escaped_chars": acc.escaped_chars,
             "name": acc.account_name or acc.account_handle,
             **cfg,
         }
@@ -1200,6 +1203,8 @@ def preview(request, workspace_id):
             effective_title = request.POST.get(override_title_key, "") or title
             effective_caption = request.POST.get(override_key, "") or caption
             char_limit = account.char_limit
+            # Counted after escaping, so the badge matches what gets published.
+            char_count = account.caption_wire_length(effective_caption)
             field_config = account.field_config
             previews.append(
                 {
@@ -1207,9 +1212,9 @@ def preview(request, workspace_id):
                     "title": effective_title,
                     "caption": effective_caption,
                     "first_comment": first_comment,
-                    "char_count": len(effective_caption),
+                    "char_count": char_count,
                     "char_limit": char_limit,
-                    "is_over_limit": len(effective_caption) > char_limit,
+                    "is_over_limit": char_count > char_limit,
                     "truncated_caption": effective_caption[:char_limit]
                     if len(effective_caption) > char_limit
                     else effective_caption,

--- a/apps/mcp/handlers.py
+++ b/apps/mcp/handlers.py
@@ -186,7 +186,7 @@ register_tool(
         description=(
             "List the social media accounts this API key is allowed to act on. "
             "Returns id, platform, account_name, account_handle, connection_status, char_limit, "
-            "needs_title, and supports_first_comment. Call this first to discover which "
+            "escaped_chars, needs_title, and supports_first_comment. Call this first to discover which "
             "social_account_id values are valid and what each platform requires."
         ),
         input_schema={"type": "object", "properties": {}, "additionalProperties": False},

--- a/apps/social_accounts/models.py
+++ b/apps/social_accounts/models.py
@@ -143,6 +143,23 @@ class SocialAccount(models.Model):
     def char_limit(self) -> int:
         return self.PLATFORM_CHAR_LIMITS.get(self.platform, 2200)
 
+    @property
+    def escaped_chars(self) -> str:
+        """Characters this platform escapes, each costing two against the limit."""
+        from providers import CAPTION_ESCAPED_CHARS
+
+        return CAPTION_ESCAPED_CHARS.get(self.platform, "")
+
+    def caption_wire_length(self, text: str) -> int:
+        """Caption length as this platform counts it, after any escaping.
+
+        LinkedIn escapes reserved characters in the commentary it publishes, so
+        the typed length is not the length that counts against ``char_limit``.
+        """
+        from providers import caption_wire_length
+
+        return caption_wire_length(self.platform, text)
+
     # Platform-specific field configuration (which platforms need extra fields)
     PLATFORM_FIELD_CONFIG: dict[str, dict[str, Any]] = {
         "youtube": {

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -14,6 +14,7 @@ from .facebook import FacebookProvider
 from .google_business import GoogleBusinessProvider
 from .instagram import InstagramProvider
 from .instagram_login import InstagramLoginProvider
+from .linkedin import LINKEDIN_RESERVED_CHARS
 from .linkedin_company import LinkedInCompanyProvider
 from .linkedin_personal import LinkedInPersonalProvider
 from .mastodon import MastodonProvider
@@ -40,6 +41,30 @@ PROVIDER_REGISTRY: dict[str, type[SocialProvider]] = {
     "mastodon": MastodonProvider,
     "devto": DevtoProvider,
 }
+
+# Characters a platform escapes in the caption it publishes. Each one costs two
+# characters on the wire, so a limit has to be counted against the escaped text
+# rather than the text the user typed.
+CAPTION_ESCAPED_CHARS: dict[str, str] = {
+    # LinkedIn's little-text commentary; the backslash escapes itself too.
+    "linkedin_personal": "\\" + LINKEDIN_RESERVED_CHARS,
+    "linkedin_company": "\\" + LINKEDIN_RESERVED_CHARS,
+}
+
+
+def caption_wire_length(platform: str, text: str) -> int:
+    """Length of ``text`` as ``platform`` counts it, after any escaping.
+
+    The composer's counter and the published payload have to agree: a LinkedIn
+    caption of 2,990 characters holding 20 parentheses arrives as 3,010 and is
+    rejected, even though the user was shown a green counter.
+    ``providers.linkedin.escape_commentary`` is the transform this mirrors;
+    ``tests/providers/test_caption_wire_length.py`` holds the two together.
+    """
+    escaped = CAPTION_ESCAPED_CHARS.get(platform)
+    if not escaped:
+        return len(text)
+    return len(text) + sum(text.count(ch) for ch in escaped)
 
 
 def get_provider(platform: str, credentials: dict | None = None) -> SocialProvider:

--- a/providers/linkedin.py
+++ b/providers/linkedin.py
@@ -59,12 +59,14 @@ def _encode_urn(urn: str) -> str:
 # Characters LinkedIn treats as reserved in the Posts API "commentary"
 # (little-text) field. If any is sent unescaped, LinkedIn silently truncates the
 # commentary at the first occurrence (e.g. a "(" drops everything after it).
-# Each must be prefixed with a backslash to render literally.
+# Each must be prefixed with a backslash to render literally. Public because the
+# escaping inflates the caption, so the composer counts against the escaped
+# length too (see providers.caption_wire_length).
 # https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/posts-api
-_LINKEDIN_RESERVED_CHARS = "|{}@[]()<>#*_~"
+LINKEDIN_RESERVED_CHARS = "|{}@[]()<>#*_~"
 
 
-def _escape_commentary(text: str) -> str:
+def escape_commentary(text: str) -> str:
     """Escape LinkedIn's reserved little-text characters in a post commentary.
 
     LinkedIn's Posts API truncates ``commentary`` at the first unescaped
@@ -78,7 +80,7 @@ def _escape_commentary(text: str) -> str:
     if not text:
         return text
     escaped = text.replace("\\", "\\\\")
-    for ch in _LINKEDIN_RESERVED_CHARS:
+    for ch in LINKEDIN_RESERVED_CHARS:
         escaped = escaped.replace(ch, "\\" + ch)
     return escaped
 
@@ -255,7 +257,7 @@ class LinkedInProvider(SocialProvider):
     def _build_post_body(self, author: str, commentary: str) -> dict:
         return {
             "author": author,
-            "commentary": _escape_commentary(commentary),
+            "commentary": escape_commentary(commentary),
             "visibility": "PUBLIC",
             "distribution": {
                 "feedDistribution": "MAIN_FEED",

--- a/providers/linkedin.py
+++ b/providers/linkedin.py
@@ -65,13 +65,15 @@ _LINKEDIN_RESERVED_CHARS = "|{}@[]()<>#*_~"
 
 
 def _escape_commentary(text: str) -> str:
-    """Escape LinkedIn's reserved little-text characters in post/comment text.
+    """Escape LinkedIn's reserved little-text characters in a post commentary.
 
     LinkedIn's Posts API truncates ``commentary`` at the first unescaped
     reserved character, so a caption like "Va al repo (durable)" would publish
     as just "Va al repo ". Prefix each reserved char with a backslash so the
     full text renders literally. The backslash itself is escaped first to avoid
     double-escaping the escapes we add.
+
+    Posts only: the Comments API takes plain text, not little-format.
     """
     if not text:
         return text
@@ -518,7 +520,10 @@ class LinkedInProvider(SocialProvider):
             headers=LINKEDIN_HEADERS,
             json={
                 "actor": actor,
-                "message": {"text": _escape_commentary(text)},
+                # Plain text on purpose: the Comments API is not little-format
+                # (mentions ride in a separate attributes[] array), so escaping
+                # would publish literal backslashes and shift mention offsets.
+                "message": {"text": text},
             },
         )
         data = resp.json()
@@ -624,7 +629,8 @@ class LinkedInProvider(SocialProvider):
             headers=LINKEDIN_HEADERS,
             json={
                 "actor": actor,
-                "message": {"text": _escape_commentary(text)},
+                # Plain text, as in publish_comment above.
+                "message": {"text": text},
                 "parentComment": message_id,
             },
         )

--- a/providers/linkedin.py
+++ b/providers/linkedin.py
@@ -56,6 +56,31 @@ def _encode_urn(urn: str) -> str:
     return quote(urn, safe="")
 
 
+# Characters LinkedIn treats as reserved in the Posts API "commentary"
+# (little-text) field. If any is sent unescaped, LinkedIn silently truncates the
+# commentary at the first occurrence (e.g. a "(" drops everything after it).
+# Each must be prefixed with a backslash to render literally.
+# https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/posts-api
+_LINKEDIN_RESERVED_CHARS = "|{}@[]()<>#*_~"
+
+
+def _escape_commentary(text: str) -> str:
+    """Escape LinkedIn's reserved little-text characters in post/comment text.
+
+    LinkedIn's Posts API truncates ``commentary`` at the first unescaped
+    reserved character, so a caption like "Va al repo (durable)" would publish
+    as just "Va al repo ". Prefix each reserved char with a backslash so the
+    full text renders literally. The backslash itself is escaped first to avoid
+    double-escaping the escapes we add.
+    """
+    if not text:
+        return text
+    escaped = text.replace("\\", "\\\\")
+    for ch in _LINKEDIN_RESERVED_CHARS:
+        escaped = escaped.replace(ch, "\\" + ch)
+    return escaped
+
+
 class LinkedInProvider(SocialProvider):
     """LinkedIn Marketing API v2 provider."""
 
@@ -228,7 +253,7 @@ class LinkedInProvider(SocialProvider):
     def _build_post_body(self, author: str, commentary: str) -> dict:
         return {
             "author": author,
-            "commentary": commentary,
+            "commentary": _escape_commentary(commentary),
             "visibility": "PUBLIC",
             "distribution": {
                 "feedDistribution": "MAIN_FEED",
@@ -493,7 +518,7 @@ class LinkedInProvider(SocialProvider):
             headers=LINKEDIN_HEADERS,
             json={
                 "actor": actor,
-                "message": {"text": text},
+                "message": {"text": _escape_commentary(text)},
             },
         )
         data = resp.json()
@@ -599,7 +624,7 @@ class LinkedInProvider(SocialProvider):
             headers=LINKEDIN_HEADERS,
             json={
                 "actor": actor,
-                "message": {"text": text},
+                "message": {"text": _escape_commentary(text)},
                 "parentComment": message_id,
             },
         )

--- a/templates/composer/compose.html
+++ b/templates/composer/compose.html
@@ -2025,19 +2025,32 @@ function composerApp() {
             }
             return text.length + extra;
         },
-        // Worst case across the selected accounts, so the counter never reads
-        // green on a caption that one of them will reject.
+        // The counter shows one account: the one with the least headroom. Both
+        // numbers have to come from the same account or the pair lies — 200 '#'
+        // on LinkedIn and Bluesky would read as 400 / 300 (LinkedIn's escaped
+        // count against Bluesky's limit) with nothing actually over.
+        captionBinding() {
+            let binding = null;
+            for (const id of this.selectedAccounts) {
+                const limit = this.charLimits[id]?.limit;
+                if (!limit) continue;
+                const count = this.wireLength(this.caption, id);
+                if (binding === null || limit - count < binding.limit - binding.count) {
+                    binding = { count, limit };
+                }
+            }
+            return binding;
+        },
         captionCount() {
-            const lengths = this.selectedAccounts.map(id => this.wireLength(this.caption, id));
-            return lengths.length ? Math.max(...lengths) : this.caption.length;
+            return this.captionBinding()?.count ?? this.caption.length;
         },
         captionLimit() {
-            const limits = this.selectedAccounts.map(id => this.charLimits[id]?.limit).filter(Boolean);
-            return limits.length ? Math.min(...limits) : null;
+            return this.captionBinding()?.limit ?? null;
         },
+        // The least-headroom account is over exactly when any account is.
         captionOverLimit() {
-            return this.selectedAccounts.some(
-                id => this.wireLength(this.caption, id) > (this.charLimits[id]?.limit || 9999));
+            const binding = this.captionBinding();
+            return binding !== null && binding.count > binding.limit;
         },
 
         // Computed-like getters for title field visibility

--- a/templates/composer/compose.html
+++ b/templates/composer/compose.html
@@ -522,8 +522,8 @@
                                 Media Library
                             </button>
                             <span class="text-xs tabular-nums font-medium"
-                                  :class="(() => { const min = Math.min(...selectedAccounts.map(id => charLimits[id]?.limit || 9999)); return caption.length > min ? 'text-red-500' : 'text-stone-400'; })()"
-                                  x-text="(() => { const limits = selectedAccounts.map(id => charLimits[id]?.limit).filter(Boolean); const min = limits.length ? Math.min(...limits) : null; return min ? caption.length + ' / ' + min : caption.length; })()">
+                                  :class="captionOverLimit() ? 'text-red-500' : 'text-stone-400'"
+                                  x-text="captionLimit() ? captionCount() + ' / ' + captionLimit() : captionCount()">
                             </span>
                         </div>
                     </div>
@@ -2012,6 +2012,33 @@ function composerApp() {
         // Declared here so scoped writes (inside x-for panels) hit this
         // component instead of the iteration scope.
         _filmstripRun: 0,
+
+        // Caption length as a platform counts it. LinkedIn escapes reserved
+        // characters in what it publishes, so each one costs two against the
+        // limit — mirrors providers.caption_wire_length on the server.
+        wireLength(text, accId) {
+            const escaped = this.charLimits[accId]?.escaped_chars || '';
+            if (!escaped) return text.length;
+            let extra = 0;
+            for (const ch of text) {
+                if (escaped.includes(ch)) extra++;
+            }
+            return text.length + extra;
+        },
+        // Worst case across the selected accounts, so the counter never reads
+        // green on a caption that one of them will reject.
+        captionCount() {
+            const lengths = this.selectedAccounts.map(id => this.wireLength(this.caption, id));
+            return lengths.length ? Math.max(...lengths) : this.caption.length;
+        },
+        captionLimit() {
+            const limits = this.selectedAccounts.map(id => this.charLimits[id]?.limit).filter(Boolean);
+            return limits.length ? Math.min(...limits) : null;
+        },
+        captionOverLimit() {
+            return this.selectedAccounts.some(
+                id => this.wireLength(this.caption, id) > (this.charLimits[id]?.limit || 9999));
+        },
 
         // Computed-like getters for title field visibility
         get anyPlatformNeedsTitle() {

--- a/tests/providers/test_caption_wire_length.py
+++ b/tests/providers/test_caption_wire_length.py
@@ -1,0 +1,62 @@
+"""A caption is measured against the limit as the platform will receive it.
+
+LinkedIn escapes reserved characters in the commentary it publishes, so a
+2,990-character caption holding 20 parentheses arrives as 3,010 and is rejected
+by the 3,000 limit. ``caption_wire_length`` is what the composer counts with, so
+these tests hold it to what ``escape_commentary`` actually produces.
+"""
+
+from providers import CAPTION_ESCAPED_CHARS, caption_wire_length
+from providers.linkedin import LINKEDIN_RESERVED_CHARS, escape_commentary
+
+
+class TestMatchesTheEscapedPayload:
+    """The counter and the payload must never disagree."""
+
+    def test_agrees_with_escape_commentary(self):
+        for platform in ("linkedin_personal", "linkedin_company"):
+            for caption in (
+                "",
+                "plain text with no reserved characters",
+                "Va al repo (contexto durable):\n- item",
+                "#AI #Agents @someone [link](https://ex.com/a_b~c)",
+                "a\\b",  # the backslash is escaped too
+                LINKEDIN_RESERVED_CHARS,
+                "\\" + LINKEDIN_RESERVED_CHARS * 3,
+            ):
+                assert caption_wire_length(platform, caption) == len(escape_commentary(caption)), (
+                    f"{platform}: {caption!r}"
+                )
+
+    def test_every_escaped_char_costs_two(self):
+        for ch in CAPTION_ESCAPED_CHARS["linkedin_personal"]:
+            assert caption_wire_length("linkedin_personal", ch) == 2, ch
+
+    def test_the_backslash_is_charged_for(self):
+        # Absent from LINKEDIN_RESERVED_CHARS (escape_commentary handles it
+        # separately), so it is easy to leave out of the wire cost.
+        assert "\\" in CAPTION_ESCAPED_CHARS["linkedin_personal"]
+        assert caption_wire_length("linkedin_personal", "a\\b") == 4
+
+
+class TestPlatformsWithoutEscaping:
+    def test_plain_platforms_count_the_typed_length(self):
+        caption = "Look (here) #now"
+        for platform in ("bluesky", "facebook", "instagram", "threads"):
+            assert caption_wire_length(platform, caption) == len(caption)
+
+    def test_unknown_platform_falls_back_to_len(self):
+        assert caption_wire_length("some_new_platform", "Look (here)") == len("Look (here)")
+
+    def test_empty_caption_is_zero_everywhere(self):
+        assert caption_wire_length("linkedin_personal", "") == 0
+        assert caption_wire_length("bluesky", "") == 0
+
+
+class TestTheLimitItBuys:
+    def test_a_caption_that_fits_unescaped_can_still_overflow(self):
+        # The regression this exists to prevent: 2,990 typed characters, 20 of
+        # them reserved, lands at 3,010 on the wire against a 3,000 limit.
+        caption = "(" * 20 + "a" * 2970
+        assert len(caption) == 2990
+        assert caption_wire_length("linkedin_personal", caption) == 3010

--- a/tests/providers/test_linkedin_escape.py
+++ b/tests/providers/test_linkedin_escape.py
@@ -1,0 +1,50 @@
+"""Tests for LinkedIn commentary escaping (reserved little-text characters).
+
+LinkedIn's Posts API silently truncates ``commentary`` at the first unescaped
+reserved character (e.g. a ``(`` drops everything after it), which published
+posts as just their first sentence. ``_escape_commentary`` prefixes each
+reserved char with a backslash so the full text renders.
+"""
+
+from providers.linkedin import LinkedInProvider, _escape_commentary
+
+RESERVED = set("|{}@[]()<>#*_~")
+
+
+class TestEscapeCommentary:
+    def test_escapes_reserved_characters(self):
+        assert _escape_commentary("(a)") == "\\(a\\)"
+        assert _escape_commentary("pre_commands") == "pre\\_commands"
+        assert _escape_commentary("#AI #Agents") == "\\#AI \\#Agents"
+        assert _escape_commentary("{{x}}") == "\\{\\{x\\}\\}"
+        assert _escape_commentary("a*b~c<d>e|f@g[h]i") == "a\\*b\\~c\\<d\\>e\\|f\\@g\\[h\\]i"
+
+    def test_escapes_backslash_first(self):
+        # A literal backslash is doubled exactly once (not compounded with the
+        # escapes we add afterwards).
+        assert _escape_commentary("a\\b") == "a\\\\b"
+
+    def test_leaves_plain_text_and_urls_untouched(self):
+        assert _escape_commentary("Hola mundo, ¿qué tal?") == "Hola mundo, ¿qué tal?"
+        url = "https://dev.to/agentprojectcontext/mcp-scopes-are-trust-boundaries-not-settings-2i18"
+        assert _escape_commentary(url) == url
+
+    def test_empty_and_none_are_safe(self):
+        assert _escape_commentary("") == ""
+        assert _escape_commentary(None) is None
+
+    def test_no_unescaped_reserved_char_remains(self):
+        # Regression: this caption published on LinkedIn as only "Va al repo ".
+        caption = "Va al repo (contexto durable y portable):\n- item"
+        out = _escape_commentary(caption)
+        for i, ch in enumerate(out):
+            if ch in RESERVED:
+                assert i > 0 and out[i - 1] == "\\", f"unescaped {ch!r} at index {i}"
+
+
+class TestBuildPostBodyEscapes:
+    def test_commentary_in_body_is_escaped(self):
+        provider = LinkedInProvider.__new__(LinkedInProvider)
+        body = provider._build_post_body("urn:li:person:abc", "Va al repo (durable)")
+        assert body["commentary"] == "Va al repo \\(durable\\)"
+        assert body["author"] == "urn:li:person:abc"

--- a/tests/providers/test_linkedin_escape.py
+++ b/tests/providers/test_linkedin_escape.py
@@ -4,7 +4,12 @@ LinkedIn's Posts API silently truncates ``commentary`` at the first unescaped
 reserved character (e.g. a ``(`` drops everything after it), which published
 posts as just their first sentence. ``_escape_commentary`` prefixes each
 reserved char with a backslash so the full text renders.
+
+Comments are a different API with a different model — plain text plus a separate
+``attributes[]`` array for mentions — so they are deliberately *not* escaped.
 """
+
+from unittest.mock import MagicMock
 
 from providers.linkedin import LinkedInProvider, _escape_commentary
 
@@ -48,3 +53,48 @@ class TestBuildPostBodyEscapes:
         body = provider._build_post_body("urn:li:person:abc", "Va al repo (durable)")
         assert body["commentary"] == "Va al repo \\(durable\\)"
         assert body["author"] == "urn:li:person:abc"
+
+
+class TestCommentsAreNotEscaped:
+    """The Comments API is plain text; escaping there is a regression.
+
+    A reply like "Thanks (really)!" would publish with visible backslashes, and
+    any mention in ``attributes[]`` would land on the wrong start/length offset.
+    """
+
+    def _provider(self):
+        provider = LinkedInProvider.__new__(LinkedInProvider)
+        provider.get_profile = MagicMock(return_value=MagicMock(platform_id="abc"))
+        provider._request = MagicMock(
+            return_value=MagicMock(
+                json=MagicMock(return_value={"id": "urn:li:comment:1"}),
+                headers={"x-restli-id": "urn:li:comment:1"},
+            )
+        )
+        return provider
+
+    def test_publish_comment_sends_the_text_verbatim(self):
+        provider = self._provider()
+
+        provider.publish_comment("token", "urn:li:share:1", "Thanks (really)! #wow")
+
+        assert provider._request.call_args.kwargs["json"] == {
+            "actor": "urn:li:person:abc",
+            "message": {"text": "Thanks (really)! #wow"},
+        }
+
+    def test_reply_to_message_sends_the_text_verbatim(self):
+        provider = self._provider()
+
+        provider.reply_to_message(
+            "token",
+            "urn:li:comment:parent",
+            "Thanks (really)! #wow",
+            extra={"post_urn": "urn:li:share:1"},
+        )
+
+        assert provider._request.call_args.kwargs["json"] == {
+            "actor": "urn:li:person:abc",
+            "message": {"text": "Thanks (really)! #wow"},
+            "parentComment": "urn:li:comment:parent",
+        }

--- a/tests/providers/test_linkedin_escape.py
+++ b/tests/providers/test_linkedin_escape.py
@@ -2,7 +2,7 @@
 
 LinkedIn's Posts API silently truncates ``commentary`` at the first unescaped
 reserved character (e.g. a ``(`` drops everything after it), which published
-posts as just their first sentence. ``_escape_commentary`` prefixes each
+posts as just their first sentence. ``escape_commentary`` prefixes each
 reserved char with a backslash so the full text renders.
 
 Comments are a different API with a different model — plain text plus a separate
@@ -11,37 +11,39 @@ Comments are a different API with a different model — plain text plus a separa
 
 from unittest.mock import MagicMock
 
-from providers.linkedin import LinkedInProvider, _escape_commentary
+from providers.linkedin import LINKEDIN_RESERVED_CHARS, LinkedInProvider, escape_commentary
 
-RESERVED = set("|{}@[]()<>#*_~")
+# Read from the module under test, so adding a reserved char there extends the
+# coverage below instead of silently leaving the new char unchecked.
+RESERVED = set(LINKEDIN_RESERVED_CHARS)
 
 
 class TestEscapeCommentary:
     def test_escapes_reserved_characters(self):
-        assert _escape_commentary("(a)") == "\\(a\\)"
-        assert _escape_commentary("pre_commands") == "pre\\_commands"
-        assert _escape_commentary("#AI #Agents") == "\\#AI \\#Agents"
-        assert _escape_commentary("{{x}}") == "\\{\\{x\\}\\}"
-        assert _escape_commentary("a*b~c<d>e|f@g[h]i") == "a\\*b\\~c\\<d\\>e\\|f\\@g\\[h\\]i"
+        assert escape_commentary("(a)") == "\\(a\\)"
+        assert escape_commentary("pre_commands") == "pre\\_commands"
+        assert escape_commentary("#AI #Agents") == "\\#AI \\#Agents"
+        assert escape_commentary("{{x}}") == "\\{\\{x\\}\\}"
+        assert escape_commentary("a*b~c<d>e|f@g[h]i") == "a\\*b\\~c\\<d\\>e\\|f\\@g\\[h\\]i"
 
     def test_escapes_backslash_first(self):
         # A literal backslash is doubled exactly once (not compounded with the
         # escapes we add afterwards).
-        assert _escape_commentary("a\\b") == "a\\\\b"
+        assert escape_commentary("a\\b") == "a\\\\b"
 
     def test_leaves_plain_text_and_urls_untouched(self):
-        assert _escape_commentary("Hola mundo, ¿qué tal?") == "Hola mundo, ¿qué tal?"
+        assert escape_commentary("Hola mundo, ¿qué tal?") == "Hola mundo, ¿qué tal?"
         url = "https://dev.to/agentprojectcontext/mcp-scopes-are-trust-boundaries-not-settings-2i18"
-        assert _escape_commentary(url) == url
+        assert escape_commentary(url) == url
 
     def test_empty_and_none_are_safe(self):
-        assert _escape_commentary("") == ""
-        assert _escape_commentary(None) is None
+        assert escape_commentary("") == ""
+        assert escape_commentary(None) is None
 
     def test_no_unescaped_reserved_char_remains(self):
         # Regression: this caption published on LinkedIn as only "Va al repo ".
         caption = "Va al repo (contexto durable y portable):\n- item"
-        out = _escape_commentary(caption)
+        out = escape_commentary(caption)
         for i, ch in enumerate(out):
             if ch in RESERVED:
                 assert i > 0 and out[i - 1] == "\\", f"unescaped {ch!r} at index {i}"


### PR DESCRIPTION
## Problem

LinkedIn's Posts API treats `|{}@[]()<>#*_~` as reserved characters in the
`commentary` (little-text) field. If any is sent **unescaped**, LinkedIn
**silently truncates** the commentary at the first occurrence — so a caption
like `Va al repo (durable)` publishes as just `Va al repo `, dropping the rest
of the body, the link and the hashtags. No error is returned.

## Fix

Add `_escape_commentary()` which backslash-escapes each reserved character
(escaping the backslash itself first to avoid double-escaping), and route the
post `commentary` and both comment `message.text` fields through it.

Ref: https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/posts-api

## Testing

Unit test covering the reserved set, backslash pre-escaping, and empty input.
Verified live: LinkedIn posts with `(`, `_`, `#` in the caption now publish the
full body + link + hashtags.