### PR TITLE
feat(publish): calendar drag-and-drop, multi-select filters, ui_select, bulk actions

### DIFF
--- a/apps/calendar/test_bulk_actions.py
+++ b/apps/calendar/test_bulk_actions.py
@@ -1,0 +1,345 @@
+"""Tests for the Publish page's bulk selection bar and drag-and-drop reschedule.
+
+Both endpoints promote rows into ``scheduled``, which hands them to the
+publisher's poll loop — the privilege ``publish_directly`` gates on every other
+scheduling surface (the composer's chip transition, ``save_post``'s publish-now
+branch, REST ``/schedule``). These tests pin that gate plus the protected-status
+skips and the orphan-Post cleanup.
+"""
+
+from datetime import timedelta
+
+from django.test import TestCase
+from django.urls import reverse
+from django.utils import timezone
+
+from apps.accounts.models import User
+from apps.composer.models import PlatformPost, Post
+from apps.members.models import OrgMembership, WorkspaceMembership
+from apps.organizations.models import Organization
+from apps.social_accounts.models import SocialAccount
+from apps.workspaces.models import Workspace
+
+
+def _make_user(email):
+    user = User.objects.create_user(
+        email=email,
+        password="testpass123",
+        tos_accepted_at=timezone.now(),
+    )
+    # The accounts post_save signal auto-provisions a default Organization +
+    # Workspace + OrgMembership for every new User. Tests that want to attach
+    # the user to a specific org must start from a clean slate, otherwise the
+    # RBAC middleware (which does OrgMembership.objects.filter(...).first())
+    # may pick the auto-org instead of the test org.
+    auto_org_ids = list(OrgMembership.objects.filter(user=user).values_list("organization_id", flat=True))
+    WorkspaceMembership.objects.filter(user=user).delete()
+    OrgMembership.objects.filter(user=user).delete()
+    Organization.objects.filter(id__in=auto_org_ids).delete()
+    return user
+
+
+class BulkActionBase(TestCase):
+    """One workspace, two channels, and the three roles that matter here.
+
+    ``owner`` holds publish_directly + edit_others_posts, ``editor`` holds only
+    edit_others_posts, ``contributor`` holds neither.
+    """
+
+    def setUp(self):
+        self.org = Organization.objects.create(name="Bulk Org")
+        self.workspace = Workspace.objects.create(organization=self.org, name="Bulk WS")
+
+        self.owner = _make_user("owner@example.com")
+        OrgMembership.objects.create(user=self.owner, organization=self.org, org_role="owner")
+        WorkspaceMembership.objects.create(user=self.owner, workspace=self.workspace, workspace_role="owner")
+
+        self.editor = _make_user("editor@example.com")
+        OrgMembership.objects.create(user=self.editor, organization=self.org, org_role="member")
+        WorkspaceMembership.objects.create(user=self.editor, workspace=self.workspace, workspace_role="editor")
+
+        self.contributor = _make_user("contributor@example.com")
+        OrgMembership.objects.create(user=self.contributor, organization=self.org, org_role="member")
+        WorkspaceMembership.objects.create(
+            user=self.contributor, workspace=self.workspace, workspace_role="contributor"
+        )
+
+        self.account = SocialAccount.objects.create(
+            workspace=self.workspace,
+            platform="bluesky",
+            account_platform_id="did:plc:bulk-1",
+            account_name="bsky",
+            connection_status="connected",
+        )
+        self.other_account = SocialAccount.objects.create(
+            workspace=self.workspace,
+            platform="linkedin_personal",
+            account_platform_id="li-bulk-1",
+            account_name="LI",
+            connection_status="connected",
+        )
+
+    def _pp(self, status, scheduled_at=None, author=None, account=None, post=None):
+        """Create (or extend) a Post and return one of its PlatformPost rows."""
+        if post is None:
+            post = Post.objects.create(
+                workspace=self.workspace,
+                author=author or self.owner,
+                caption="bulk test",
+                scheduled_at=scheduled_at,
+            )
+        return PlatformPost.objects.create(
+            post=post,
+            social_account=account or self.account,
+            status=status,
+            scheduled_at=scheduled_at,
+        )
+
+    def _bulk(self, action, *pps):
+        return self.client.post(
+            reverse("calendar:bulk_platform_action", kwargs={"workspace_id": self.workspace.id}),
+            data={"action": action, "platform_post_ids": [str(pp.id) for pp in pps]},
+        )
+
+
+class BulkPlatformActionPermissionTests(BulkActionBase):
+    """``publish`` is a scheduling action and needs ``publish_directly``."""
+
+    def test_editor_cannot_bulk_publish(self):
+        pp = self._pp("draft")
+        self.client.force_login(self.editor)
+
+        response = self._bulk("publish", pp)
+
+        self.assertEqual(response.status_code, 403)
+        # Load-bearing invariant (not the status code): an editor holds
+        # edit_others_posts, so without this gate the row would have gone
+        # straight into the publisher's queue and skipped approval entirely.
+        pp.refresh_from_db()
+        self.assertEqual(pp.status, "draft")
+        self.assertIsNone(pp.scheduled_at)
+
+    def test_editor_can_still_bulk_draft(self):
+        pp = self._pp("scheduled", scheduled_at=timezone.now() + timedelta(days=1))
+        self.client.force_login(self.editor)
+
+        response = self._bulk("draft", pp)
+
+        self.assertEqual(response.status_code, 200)
+        pp.refresh_from_db()
+        self.assertEqual(pp.status, "draft")
+        self.assertIsNone(pp.scheduled_at)
+
+    def test_contributor_cannot_touch_another_authors_post(self):
+        pp = self._pp("scheduled", scheduled_at=timezone.now() + timedelta(days=1), author=self.owner)
+        self.client.force_login(self.contributor)
+
+        response = self._bulk("draft", pp)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["count"], 0)
+        pp.refresh_from_db()
+        self.assertEqual(pp.status, "scheduled")
+
+    def test_contributor_can_draft_their_own_post(self):
+        pp = self._pp("scheduled", scheduled_at=timezone.now() + timedelta(days=1), author=self.contributor)
+        self.client.force_login(self.contributor)
+
+        response = self._bulk("draft", pp)
+
+        self.assertEqual(response.json()["count"], 1)
+        pp.refresh_from_db()
+        self.assertEqual(pp.status, "draft")
+
+
+class BulkPlatformActionPublishTests(BulkActionBase):
+    def setUp(self):
+        super().setUp()
+        self.client.force_login(self.owner)
+
+    def test_publish_schedules_a_draft_at_now(self):
+        pp = self._pp("draft")
+        before = timezone.now()
+
+        response = self._bulk("publish", pp)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["count"], 1)
+        pp.refresh_from_db()
+        self.assertEqual(pp.status, "scheduled")
+        self.assertGreaterEqual(pp.scheduled_at, before)
+        self.assertLessEqual(pp.scheduled_at, timezone.now())
+
+    def test_publish_pulls_an_already_scheduled_row_forward(self):
+        """The Queue tab is entirely ``scheduled`` rows.
+
+        ``scheduled → scheduled`` is not a valid transition, so gating the branch
+        on ``can_transition_to`` skipped every row in the tab with no feedback.
+        """
+        future = timezone.now() + timedelta(days=3)
+        pp = self._pp("scheduled", scheduled_at=future)
+        before = timezone.now()
+
+        response = self._bulk("publish", pp)
+
+        self.assertEqual(response.json()["count"], 1)
+        pp.refresh_from_db()
+        self.assertEqual(pp.status, "scheduled")
+        self.assertGreaterEqual(pp.scheduled_at, before)
+        self.assertLessEqual(pp.scheduled_at, timezone.now())
+
+    def test_publish_skips_protected_rows(self):
+        published = self._pp("published")
+        publishing = self._pp("publishing")
+
+        response = self._bulk("publish", published, publishing)
+
+        self.assertEqual(response.json()["count"], 0)
+        published.refresh_from_db()
+        publishing.refresh_from_db()
+        self.assertEqual(published.status, "published")
+        self.assertEqual(publishing.status, "publishing")
+
+    def test_publish_skips_rows_with_no_route_to_scheduled(self):
+        # on_hold deliberately has no edge to scheduled — un-hold first.
+        on_hold = self._pp("on_hold")
+
+        response = self._bulk("publish", on_hold)
+
+        self.assertEqual(response.json()["count"], 0)
+        on_hold.refresh_from_db()
+        self.assertEqual(on_hold.status, "on_hold")
+
+
+class BulkPlatformActionDeleteTests(BulkActionBase):
+    def setUp(self):
+        super().setUp()
+        self.client.force_login(self.owner)
+
+    def test_delete_removes_draft_and_skips_published(self):
+        draft = self._pp("draft")
+        published = self._pp("published")
+
+        response = self._bulk("delete", draft, published)
+
+        self.assertEqual(response.json()["count"], 1)
+        self.assertFalse(PlatformPost.objects.filter(id=draft.id).exists())
+        # Load-bearing invariant: a published row is history and cascades away
+        # its PublishLog records if deleted.
+        self.assertTrue(PlatformPost.objects.filter(id=published.id).exists())
+
+    def test_deleting_the_last_row_deletes_the_orphaned_post(self):
+        pp = self._pp("draft")
+        post_id = pp.post_id
+
+        self._bulk("delete", pp)
+
+        self.assertFalse(Post.objects.filter(id=post_id).exists())
+
+    def test_post_with_a_surviving_sibling_is_kept_and_resynced(self):
+        soon = timezone.now() + timedelta(days=1)
+        later = timezone.now() + timedelta(days=5)
+        first = self._pp("scheduled", scheduled_at=soon)
+        second = self._pp("scheduled", scheduled_at=later, account=self.other_account, post=first.post)
+
+        self._bulk("delete", first)
+
+        post = Post.objects.get(id=second.post_id)
+        # The parent aggregate follows the earliest surviving child.
+        self.assertEqual(post.scheduled_at, later)
+
+
+class SentTabCheckboxTests(BulkActionBase):
+    """The Sent tab mixes ``published`` (protected) and ``failed`` rows."""
+
+    def setUp(self):
+        super().setUp()
+        self.client.force_login(self.owner)
+
+    def _sent_html(self):
+        response = self.client.get(
+            reverse("calendar:publish_tab_sent", kwargs={"workspace_id": self.workspace.id}),
+            HTTP_HX_REQUEST="true",
+        )
+        self.assertEqual(response.status_code, 200)
+        return response.content.decode()
+
+    def test_published_row_has_no_checkbox(self):
+        pp = self._pp("published")
+        html = self._sent_html()
+
+        # The row is listed...
+        self.assertIn(str(pp.post_id), html)
+        # ...but every bulk action skips protected rows, so a checkbox here
+        # could only ever be a no-op.
+        self.assertNotIn(f"$store.sel.toggle('{pp.id}')", html)
+
+    def test_failed_row_keeps_its_checkbox(self):
+        pp = self._pp("failed")
+
+        # `failed` is not protected — bulk retry (publish) and delete both work.
+        self.assertIn(f"$store.sel.toggle('{pp.id}')", self._sent_html())
+
+
+class ReschedulePermissionTests(BulkActionBase):
+    """Drag-and-drop promotes draft/failed chips to ``scheduled``."""
+
+    def _reschedule(self, pp, when):
+        return self.client.post(
+            reverse("calendar:reschedule", kwargs={"workspace_id": self.workspace.id}),
+            data={"platform_post_id": str(pp.id), "new_datetime": when.strftime("%Y-%m-%dT%H:%M:%S")},
+        )
+
+    def test_editor_cannot_drag_a_draft_chip(self):
+        pp = self._pp("draft")
+        self.client.force_login(self.editor)
+
+        response = self._reschedule(pp, timezone.now() + timedelta(days=2))
+
+        self.assertEqual(response.status_code, 403)
+        pp.refresh_from_db()
+        self.assertEqual(pp.status, "draft")
+        self.assertIsNone(pp.scheduled_at)
+
+    def test_editor_cannot_drag_a_failed_chip(self):
+        pp = self._pp("failed")
+        self.client.force_login(self.editor)
+
+        response = self._reschedule(pp, timezone.now() + timedelta(days=2))
+
+        self.assertEqual(response.status_code, 403)
+        pp.refresh_from_db()
+        self.assertEqual(pp.status, "failed")
+
+    def test_editor_can_still_move_an_approved_chip(self):
+        """The gate is narrow: statuses that only re-time are unaffected."""
+        pp = self._pp("approved", scheduled_at=timezone.now() + timedelta(days=1))
+        self.client.force_login(self.editor)
+
+        response = self._reschedule(pp, timezone.now() + timedelta(days=4))
+
+        self.assertEqual(response.status_code, 204)
+        pp.refresh_from_db()
+        self.assertEqual(pp.status, "approved")
+        self.assertGreater(pp.scheduled_at, timezone.now() + timedelta(days=3))
+
+    def test_owner_dragging_a_draft_schedules_it(self):
+        pp = self._pp("draft")
+        self.client.force_login(self.owner)
+
+        response = self._reschedule(pp, timezone.now() + timedelta(days=2))
+
+        self.assertEqual(response.status_code, 204)
+        pp.refresh_from_db()
+        self.assertEqual(pp.status, "scheduled")
+        self.assertGreater(pp.scheduled_at, timezone.now() + timedelta(days=1))
+
+    def test_published_chip_cannot_be_rescheduled(self):
+        pp = self._pp("published")
+        self.client.force_login(self.owner)
+
+        response = self._reschedule(pp, timezone.now() + timedelta(days=2))
+
+        self.assertEqual(response.status_code, 400)
+        pp.refresh_from_db()
+        self.assertEqual(pp.status, "published")

--- a/apps/calendar/urls.py
+++ b/apps/calendar/urls.py
@@ -9,6 +9,8 @@ urlpatterns = [
     path("", views.calendar_view, name="calendar"),
     # Drag-and-drop reschedule
     path("reschedule/", views.reschedule_post, name="reschedule"),
+    # Bulk selection actions (floating bar): draft / delete / publish
+    path("bulk-action/", views.bulk_platform_action, name="bulk_platform_action"),
     # Posting slots
     path("posting-slots/", views.posting_slots, name="posting_slots"),
     path("posting-slots/save/", views.save_posting_slot, name="save_posting_slot"),

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -1142,9 +1142,7 @@ def bulk_platform_action(request, workspace_id):
     if action not in ("draft", "delete", "publish") or not pp_ids:
         return JsonResponse({"error": "action and platform_post_ids required"}, status=400)
 
-    pps = list(
-        PlatformPost.objects.filter(id__in=pp_ids, post__workspace=workspace).select_related("post")
-    )
+    pps = list(PlatformPost.objects.filter(id__in=pp_ids, post__workspace=workspace).select_related("post"))
     membership = getattr(request, "workspace_membership", None)
     perms = membership.effective_permissions if membership else {}
     can_edit_others = perms.get("edit_others_posts")
@@ -1187,7 +1185,9 @@ def bulk_platform_action(request, workspace_id):
 
     return HttpResponse(
         status=204,
-        headers={"HX-Trigger": json.dumps({"bulkActionDone": {"action": action, "count": count}, "calendarRefresh": True})},
+        headers={
+            "HX-Trigger": json.dumps({"bulkActionDone": {"action": action, "count": count}, "calendarRefresh": True})
+        },
     )
 
 

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -386,11 +386,21 @@ def _get_publish_context(workspace, request):
         if tz not in tz_list:
             tz_list.append(tz)
 
+    # Pre-format options for the ui_select component: short label + workspace hint
+    tz_options = [
+        {
+            "value": tz,
+            "label": tz.split("/")[-1] + (" (workspace)" if tz == ws_tz else ""),
+        }
+        for tz in tz_list
+    ]
+
     return {
         "channels_with_posts": channels_with_posts,
         "all_tags": sorted(all_tags),
         "display_timezone": display_timezone,
         "timezone_choices": tz_list,
+        "timezone_options": tz_options,
         "workspace_timezone": ws_tz,
         **_publish_tab_counts(workspace),
     }

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -97,15 +97,22 @@ def _parse_date(date_str, default=None):
     return default or date.today()
 
 
-def _get_valid_channel_filter(request):
-    """Return a UUID-safe channel filter value, or blank when malformed."""
-    channel = request.GET.get("channel", "").strip()
-    if not channel:
-        return ""
-    try:
-        return str(uuid.UUID(channel))
-    except (TypeError, ValueError, AttributeError):
-        return ""
+def _get_channel_filters(request):
+    """Return the list of UUID-safe channel (SocialAccount id) filter values.
+
+    The channels toolbar is a multi-select, so several ``channel`` params may be
+    present; malformed values are dropped. An empty list means "all channels".
+    """
+    out = []
+    for raw in request.GET.getlist("channel"):
+        raw = (raw or "").strip()
+        if not raw:
+            continue
+        try:
+            out.append(str(uuid.UUID(raw)))
+        except (TypeError, ValueError, AttributeError):
+            continue
+    return out
 
 
 def _get_filtered_posts(workspace, request):
@@ -184,9 +191,9 @@ def _get_filtered_platform_posts(workspace, request):
         qs = qs.filter(social_account__platform__in=platforms)
 
     # Channel filter (calendar toolbar sends the selected SocialAccount id).
-    channel = _get_valid_channel_filter(request)
-    if channel:
-        qs = qs.filter(social_account_id=channel)
+    channels = _get_channel_filters(request)
+    if channels:
+        qs = qs.filter(social_account_id__in=channels)
 
     # Author filter
     authors = request.GET.getlist("author")
@@ -237,9 +244,9 @@ def _get_calendar_slot_occurrences(workspace, request, display_tz, visible_dates
         social_account__connection_status=SocialAccount.ConnectionStatus.CONNECTED,
         is_active=True,
     )
-    channel = _get_valid_channel_filter(request)
-    if channel:
-        slots = slots.filter(social_account_id=channel)
+    channels = _get_channel_filters(request)
+    if channels:
+        slots = slots.filter(social_account_id__in=channels)
 
     slots = slots.select_related("social_account").order_by(
         "time",
@@ -387,9 +394,9 @@ def _get_publish_context(workspace, request):
 
 def _apply_pp_publish_filters(qs, request):
     """Apply channel and tag filters to a PlatformPost queryset."""
-    channel = request.GET.get("channel")
-    if channel:
-        qs = qs.filter(social_account_id=channel)
+    channels = _get_channel_filters(request)
+    if channels:
+        qs = qs.filter(social_account_id__in=channels)
 
     tag = request.GET.get("tag")
     if tag:
@@ -510,9 +517,9 @@ def _get_tab_context(request, workspace, tab: str) -> dict:
         pp_match = pp_match.filter(status=status_filter)
     else:
         pp_match = pp_match.filter(status__in=approval_statuses)
-    channel = request.GET.get("channel")
-    if channel:
-        pp_match = pp_match.filter(social_account_id=channel)
+    channels = _get_channel_filters(request)
+    if channels:
+        pp_match = pp_match.filter(social_account_id__in=channels)
 
     posts_qs = (
         Post.objects.for_workspace(workspace.id)
@@ -573,7 +580,9 @@ def _get_tab_context(request, workspace, tab: str) -> dict:
 
     # Preserve the active channel/tag/timezone filters across status pills and the
     # post-action self-refresh (otherwise acting on a post drops the filter).
-    filter_qs = urlencode({k: request.GET[k] for k in ("channel", "tag", "tz") if request.GET.get(k)})
+    _filter_params = [("channel", c) for c in _get_channel_filters(request)]
+    _filter_params += [(k, request.GET[k]) for k in ("tag", "tz") if request.GET.get(k)]
+    filter_qs = urlencode(_filter_params)
 
     return {
         **base_ctx,

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -1078,8 +1078,8 @@ def reschedule_post(request, workspace_id):
     )
     post = pp.post
 
-    # Check permissions - only editable statuses can be rescheduled
-    if pp.status not in ("draft", "approved", "scheduled"):
+    # Only draggable statuses can be rescheduled (published/publishing can't).
+    if not pp.is_reschedulable:
         return JsonResponse({"error": "Post cannot be rescheduled in its current status."}, status=400)
 
     # Check RBAC
@@ -1099,9 +1099,11 @@ def reschedule_post(request, workspace_id):
         if new_dt.tzinfo is None:
             new_dt = new_dt.replace(tzinfo=tz)
         pp.scheduled_at = new_dt
-        # Drop into "scheduled" so the publisher picks it up. Drag-drop on a
-        # draft chip is treated as an implicit schedule action.
-        if pp.status == "draft" and pp.can_transition_to("scheduled"):
+        # Dropping a draft or a failed chip onto the calendar is an implicit
+        # (re)schedule / retry: move it into "scheduled" so the publisher picks
+        # it up. Other statuses (approved, scheduled, pending_*) just change
+        # time and keep their editorial status.
+        if pp.status in ("draft", "failed") and pp.can_transition_to("scheduled"):
             pp.transition_to("scheduled")
         pp.save(update_fields=["status", "scheduled_at", "updated_at"])
         # Keep any queue entry's slot mirror in step with the manual reschedule

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -1123,6 +1123,75 @@ def reschedule_post(request, workspace_id):
 
 
 @login_required
+@require_POST
+def bulk_platform_action(request, workspace_id):
+    """Bulk draft / delete / publish on the checkbox-selected PlatformPosts.
+
+    Powers the Publish page's floating selection bar (list + calendar). Only
+    rows the user may edit are touched, and ``published``/``publishing`` rows
+    are never deleted or moved. Returns 204 + an HX-Trigger so the calendar and
+    tab counts refresh.
+    """
+    from django.utils import timezone as _tz
+
+    from apps.composer.services import sync_post_scheduled_at
+
+    workspace = _get_workspace(request, workspace_id)
+    action = request.POST.get("action")
+    pp_ids = request.POST.getlist("platform_post_ids")
+    if action not in ("draft", "delete", "publish") or not pp_ids:
+        return JsonResponse({"error": "action and platform_post_ids required"}, status=400)
+
+    pps = list(
+        PlatformPost.objects.filter(id__in=pp_ids, post__workspace=workspace).select_related("post")
+    )
+    membership = getattr(request, "workspace_membership", None)
+    perms = membership.effective_permissions if membership else {}
+    can_edit_others = perms.get("edit_others_posts")
+    pps = [pp for pp in pps if pp.post.author_id == request.user.id or can_edit_others]
+
+    affected = set()
+    count = 0
+    if action == "delete":
+        for pp in pps:
+            if pp.status in PlatformPost.PROTECTED_STATUSES:
+                continue
+            affected.add(pp.post_id)
+            pp.delete()
+            count += 1
+    else:
+        # draft → unschedule; publish → schedule at now so the worker picks it up.
+        target = "draft" if action == "draft" else "scheduled"
+        new_dt = None if action == "draft" else _tz.now()
+        for pp in pps:
+            if pp.status in PlatformPost.PROTECTED_STATUSES or pp.status == target and action != "publish":
+                continue
+            if not pp.can_transition_to(target):
+                continue
+            pp.scheduled_at = new_dt
+            pp.transition_to(target)
+            pp.save(update_fields=["status", "scheduled_at", "updated_at"])
+            affected.add(pp.post_id)
+            count += 1
+
+    # Reconcile each touched parent Post (aggregate scheduled_at) and drop any
+    # post whose last platform row was just deleted.
+    for pid in affected:
+        post = Post.objects.filter(id=pid, workspace=workspace).first()
+        if not post:
+            continue
+        if not post.platform_posts.exists():
+            post.delete()
+        else:
+            sync_post_scheduled_at(post)
+
+    return HttpResponse(
+        status=204,
+        headers={"HX-Trigger": json.dumps({"bulkActionDone": {"action": action, "count": count}, "calendarRefresh": True})},
+    )
+
+
+@login_required
 def posting_slots(request, workspace_id):
     """Manage posting slots for a workspace's social accounts."""
     workspace = _get_workspace(request, workspace_id)

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -176,6 +176,10 @@ def _get_filtered_platform_posts(workspace, request):
     qs = (
         PlatformPost.objects.filter(post__workspace_id=workspace.id)
         .select_related("post", "post__author", "post__category", "social_account")
+        # Chips render the post's first media thumbnail; without this each chip
+        # would fire its own media_attachments + media_asset queries (N+1) on
+        # every month/week/day render.
+        .prefetch_related("post__media_attachments__media_asset")
         .annotate(effective_at=Coalesce("scheduled_at", "post__scheduled_at"))
     )
 

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -317,6 +317,38 @@ def _cell_compose_params(display_date, hour, display_tz, workspace_tz):
     return workspace_dt.strftime("%Y-%m-%d"), workspace_dt.strftime("%H:%M")
 
 
+def _publish_tab_counts(workspace):
+    """The four Publish tab-bar badge counts (queue / drafts / approvals / sent).
+
+    Shared by the initial page render (`_get_publish_context`) and each HTMX
+    tab partial, so switching a tab can refresh all four badges out-of-band and
+    they never drift from the real data.
+    """
+    return {
+        "queue_count": PlatformPost.objects.filter(post__workspace_id=workspace.id, status="scheduled").count(),
+        "drafts_count": PlatformPost.objects.filter(post__workspace_id=workspace.id, status="draft").count(),
+        # Distinct posts (one row per post in the redesigned tab), incl. on_hold —
+        # matches the tab's "All" pill count.
+        "approvals_count": Post.objects.for_workspace(workspace.id)
+        .filter(
+            platform_posts__status__in=[
+                "pending_review",
+                "pending_client",
+                "approved",
+                "rejected",
+                "changes_requested",
+                "on_hold",
+            ]
+        )
+        .distinct()
+        .count(),
+        "sent_count": PlatformPost.objects.filter(
+            post__workspace_id=workspace.id,
+            status__in=["published", "failed"],
+        ).count(),
+    }
+
+
 def _get_publish_context(workspace, request):
     """Build shared context for the publish page (channels, tags, timezone)."""
     # Channels that have posts in this workspace
@@ -349,27 +381,7 @@ def _get_publish_context(workspace, request):
         "display_timezone": display_timezone,
         "timezone_choices": tz_list,
         "workspace_timezone": ws_tz,
-        "queue_count": PlatformPost.objects.filter(post__workspace_id=workspace.id, status="scheduled").count(),
-        "drafts_count": PlatformPost.objects.filter(post__workspace_id=workspace.id, status="draft").count(),
-        # Distinct posts (one row per post in the redesigned tab), incl. on_hold —
-        # matches the tab's "All" pill count.
-        "approvals_count": Post.objects.for_workspace(workspace.id)
-        .filter(
-            platform_posts__status__in=[
-                "pending_review",
-                "pending_client",
-                "approved",
-                "rejected",
-                "changes_requested",
-                "on_hold",
-            ]
-        )
-        .distinct()
-        .count(),
-        "sent_count": PlatformPost.objects.filter(
-            post__workspace_id=workspace.id,
-            status__in=["published", "failed"],
-        ).count(),
+        **_publish_tab_counts(workspace),
     }
 
 
@@ -593,6 +605,19 @@ def calendar_view(request, workspace_id):
     view_type = request.GET.get("view", "month")
     target_date = _parse_date(request.GET.get("date"))
 
+    # Whether "today" already falls inside the period the calendar is showing.
+    # Lets the toolbar render the Today button as a no-op instead of firing an
+    # unnecessary navigation/reload when the user is already on the current
+    # month/week/day.
+    today = date.today()
+    if view_type == "week":
+        week_start = target_date - timedelta(days=target_date.weekday())
+        is_today_in_view = week_start <= today <= week_start + timedelta(days=6)
+    elif view_type == "day":
+        is_today_in_view = target_date == today
+    else:  # month (and any fallback)
+        is_today_in_view = (target_date.year, target_date.month) == (today.year, today.month)
+
     # Connected accounts for calendar filter UI
     social_accounts = (
         SocialAccount.objects.for_workspace(workspace.id)
@@ -643,6 +668,7 @@ def calendar_view(request, workspace_id):
         "active_filters": active_filters,
         "status_choices": Post.Status.choices,
         "show_holidays": show_holidays,
+        "is_today_in_view": is_today_in_view,
         **publish_ctx,
     }
 
@@ -984,6 +1010,10 @@ def _render_tab(request, workspace, tab):
     """Shared HTMX-tab renderer used by the four `publish_tab_*` endpoints."""
     ctx = _get_tab_context(request, workspace, tab)
     ctx["is_htmx"] = True
+    # Refresh all four tab-bar badges out-of-band so counts stay in sync when a
+    # tab is switched or reloaded (they live outside the swapped #tab-content).
+    ctx.update(_publish_tab_counts(workspace))
+    ctx["render_tab_counts_oob"] = True
     return render(request, _TAB_TEMPLATES[tab], ctx)
 
 

--- a/apps/calendar/views.py
+++ b/apps/calendar/views.py
@@ -48,6 +48,11 @@ COMMON_TIMEZONES = [
     "America/New_York",
 ]
 
+# Statuses a calendar drop promotes to ``scheduled`` (implicit schedule / retry)
+# rather than merely re-timing. Because that promotion hands the row to the
+# publisher, it is gated on ``publish_directly`` — see ``reschedule_post``.
+_IMPLICIT_SCHEDULE_STATUSES = ("draft", "failed")
+
 
 def _slots_updated_response(account_id):
     """Return a 204 response with an HX-Trigger header for slot grid refresh."""
@@ -1096,9 +1101,15 @@ def reschedule_post(request, workspace_id):
     membership = request.workspace_membership
     perms = membership.effective_permissions if membership else {}
     is_own_post = post.author_id == request.user.id
-    can_edit = is_own_post or perms.get("edit_others_posts")
+    can_edit = is_own_post or perms.get("edit_others_posts", False)
     if not can_edit:
         return JsonResponse({"error": "Permission denied."}, status=403)
+    # Dropping a draft/failed chip promotes it to "scheduled" below, which is the
+    # publish privilege every other scheduling path gates on (the composer's chip
+    # transition, save_post's publish-now branch, REST /schedule). Reject rather
+    # than silently degrading the drop to a time-only move.
+    if pp.status in _IMPLICIT_SCHEDULE_STATUSES and not perms.get("publish_directly", False):
+        return JsonResponse({"error": "You do not have permission to schedule this post."}, status=403)
 
     try:
         import zoneinfo
@@ -1113,7 +1124,7 @@ def reschedule_post(request, workspace_id):
         # (re)schedule / retry: move it into "scheduled" so the publisher picks
         # it up. Other statuses (approved, scheduled, pending_*) just change
         # time and keep their editorial status.
-        if pp.status in ("draft", "failed") and pp.can_transition_to("scheduled"):
+        if pp.status in _IMPLICIT_SCHEDULE_STATUSES and pp.can_transition_to("scheduled"):
             pp.transition_to("scheduled")
         pp.save(update_fields=["status", "scheduled_at", "updated_at"])
         # Keep any queue entry's slot mirror in step with the manual reschedule
@@ -1139,8 +1150,7 @@ def bulk_platform_action(request, workspace_id):
 
     Powers the Publish page's floating selection bar (list + calendar). Only
     rows the user may edit are touched, and ``published``/``publishing`` rows
-    are never deleted or moved. Returns 204 + an HX-Trigger so the calendar and
-    tab counts refresh.
+    are never deleted or moved. Returns the number of rows acted on.
     """
     from django.utils import timezone as _tz
 
@@ -1152,10 +1162,17 @@ def bulk_platform_action(request, workspace_id):
     if action not in ("draft", "delete", "publish") or not pp_ids:
         return JsonResponse({"error": "action and platform_post_ids required"}, status=400)
 
-    pps = list(PlatformPost.objects.filter(id__in=pp_ids, post__workspace=workspace).select_related("post"))
     membership = getattr(request, "workspace_membership", None)
     perms = membership.effective_permissions if membership else {}
-    can_edit_others = perms.get("edit_others_posts")
+    # Publishing now hands rows straight to the publisher's poll loop, skipping
+    # the approval workflow — the privilege the composer's chip transition,
+    # save_post's publish-now branch and REST /schedule all gate on. Draft and
+    # delete stay under plain edit rights.
+    if action == "publish" and not perms.get("publish_directly", False):
+        return JsonResponse({"error": "You do not have permission to publish directly."}, status=403)
+
+    pps = list(PlatformPost.objects.filter(id__in=pp_ids, post__workspace=workspace).select_related("post"))
+    can_edit_others = perms.get("edit_others_posts", False)
     pps = [pp for pp in pps if pp.post.author_id == request.user.id or can_edit_others]
 
     affected = set()
@@ -1167,18 +1184,36 @@ def bulk_platform_action(request, workspace_id):
             affected.add(pp.post_id)
             pp.delete()
             count += 1
-    else:
-        # draft → unschedule; publish → schedule at now so the worker picks it up.
-        target = "draft" if action == "draft" else "scheduled"
-        new_dt = None if action == "draft" else _tz.now()
+    elif action == "draft":
+        # Unschedule: back to draft and drop the time.
         for pp in pps:
-            if pp.status in PlatformPost.PROTECTED_STATUSES or pp.status == target and action != "publish":
+            if pp.status in PlatformPost.PROTECTED_STATUSES or pp.status == "draft":
                 continue
-            if not pp.can_transition_to(target):
+            if not pp.can_transition_to("draft"):
                 continue
-            pp.scheduled_at = new_dt
-            pp.transition_to(target)
+            pp.scheduled_at = None
+            pp.transition_to("draft")
             pp.save(update_fields=["status", "scheduled_at", "updated_at"])
+            affected.add(pp.post_id)
+            count += 1
+    else:
+        # Publish now: schedule at the current time so the worker picks it up.
+        now = _tz.now()
+        for pp in pps:
+            if pp.status in PlatformPost.PROTECTED_STATUSES:
+                continue
+            if pp.status == "scheduled":
+                # Already scheduled — the whole Queue tab. scheduled → scheduled
+                # is not a valid transition, so only pull the time forward: the
+                # publisher takes any scheduled row whose effective time passed.
+                pp.scheduled_at = now
+                pp.save(update_fields=["scheduled_at", "updated_at"])
+            elif pp.can_transition_to("scheduled"):
+                pp.scheduled_at = now
+                pp.transition_to("scheduled")
+                pp.save(update_fields=["status", "scheduled_at", "updated_at"])
+            else:
+                continue
             affected.add(pp.post_id)
             count += 1
 
@@ -1193,12 +1228,9 @@ def bulk_platform_action(request, workspace_id):
         else:
             sync_post_scheduled_at(post)
 
-    return HttpResponse(
-        status=204,
-        headers={
-            "HX-Trigger": json.dumps({"bulkActionDone": {"action": action, "count": count}, "calendarRefresh": True})
-        },
-    )
+    # Plain JSON, not an HX-Trigger header: the selection bar posts with fetch(),
+    # not htmx, and fires its own calendar/tab refresh events on success.
+    return JsonResponse({"action": action, "count": count})
 
 
 @login_required

--- a/apps/common/templatetags/common_extras.py
+++ b/apps/common/templatetags/common_extras.py
@@ -24,3 +24,53 @@ def json_attr(value):
     if value is None or value == "":
         return mark_safe(escape("[]"))
     return mark_safe(escape(json.dumps(value, ensure_ascii=False, default=str)))
+
+
+@register.inclusion_tag("components/ui_select.html")
+def ui_select(
+    *,
+    model,
+    options,
+    multiple=False,
+    onchange="",
+    placeholder="Select",
+    value_field="id",
+    label_field="",
+    icon_field="",
+):
+    """A styled single/multi select dropdown (Alpine + checkbox/click list).
+
+    A drop-in upgrade for a plain ``<select>`` in an Alpine/HTMX toolbar. The
+    panel is ``position: fixed`` (anchored on open) so an ``overflow`` filter
+    row can't clip it. Bind it to a property in the enclosing ``x-data`` scope:
+    an **array** when ``multiple`` (empty = "all"), otherwise a **string**.
+
+    Params:
+      model        Alpine expression holding the selection, e.g. "filters.status".
+      options      iterable of model instances, or ``{"value","label","icon"}`` dicts.
+      multiple     checkbox multi-select (True) vs single-select (False).
+      onchange     Alpine expression run after a change, e.g. "reloadTab()".
+      placeholder  trigger label shown when nothing is selected.
+      value_field / label_field / icon_field
+                   attribute names read off model instances (ignored for dicts).
+                   ``icon`` is treated as a platform code and rendered as a badge.
+    """
+    norm = []
+    for o in options:
+        if isinstance(o, dict):
+            value, label, icon = o.get("value"), o.get("label"), o.get("icon")
+        else:
+            value = getattr(o, value_field, None)
+            label = getattr(o, label_field) if label_field else str(o)
+            icon = getattr(o, icon_field, None) if icon_field else None
+        norm.append({"value": str(value) if value is not None else "", "label": label, "icon": icon})
+
+    return {
+        "model": model,
+        "options": norm,
+        # value+label only, for the Alpine trigger-label lookup in single mode.
+        "options_js": [{"value": o["value"], "label": str(o["label"])} for o in norm],
+        "multiple": bool(multiple),
+        "onchange": onchange,
+        "placeholder": placeholder,
+    }

--- a/apps/common/templatetags/common_extras.py
+++ b/apps/common/templatetags/common_extras.py
@@ -59,6 +59,12 @@ def ui_select(
     for o in options:
         if isinstance(o, dict):
             value, label, icon = o.get("value"), o.get("label"), o.get("icon")
+        elif isinstance(o, (tuple, list)) and len(o) >= 2:
+            # (value, label) pairs, e.g. Django `choices`.
+            value, label, icon = o[0], o[1], None
+        elif isinstance(o, str):
+            value = label = o
+            icon = None
         else:
             value = getattr(o, value_field, None)
             label = getattr(o, label_field) if label_field else str(o)

--- a/apps/composer/models.py
+++ b/apps/composer/models.py
@@ -356,6 +356,21 @@ class PlatformPost(models.Model):
     # user's call and intentionally bypasses this.
     PROTECTED_STATUSES = (Status.PUBLISHED, Status.PUBLISHING)
 
+    # Statuses whose scheduled time may be changed by a calendar drag-and-drop.
+    # A dropped draft/failed chip becomes ``scheduled`` (an implicit
+    # (re)schedule / retry); the others just move in time, keeping their status.
+    # ``published`` and ``publishing`` are excluded — the post is done or in
+    # flight and must not be dragged. Shared by the calendar chip templates and
+    # the reschedule endpoint so both agree on what's draggable.
+    RESCHEDULABLE_STATUSES = (
+        Status.DRAFT,
+        Status.APPROVED,
+        Status.SCHEDULED,
+        Status.FAILED,
+        Status.PENDING_REVIEW,
+        Status.PENDING_CLIENT,
+    )
+
     # Valid state transitions (from → set of allowed targets). Mirrors the old
     # Post-level state machine minus ``partially_published`` — that concept
     # only applies at the aggregate/Post level and is produced by
@@ -459,6 +474,11 @@ class PlatformPost(models.Model):
 
     def __str__(self):
         return f"PlatformPost({self.social_account.platform}): {self.status}"
+
+    @property
+    def is_reschedulable(self):
+        """Whether this chip may be dragged to a new date on the calendar."""
+        return self.status in self.RESCHEDULABLE_STATUSES
 
     # ------------------------------------------------------------------
     # State machine

--- a/apps/composer/models.py
+++ b/apps/composer/models.py
@@ -480,6 +480,15 @@ class PlatformPost(models.Model):
         """Whether this chip may be dragged to a new date on the calendar."""
         return self.status in self.RESCHEDULABLE_STATUSES
 
+    @property
+    def is_bulk_selectable(self):
+        """Whether this row can be the target of a bulk draft/publish/delete.
+
+        Every branch of ``bulk_platform_action`` skips ``PROTECTED_STATUSES``, so
+        offering a checkbox on those rows would only ever be a no-op.
+        """
+        return self.status not in self.PROTECTED_STATUSES
+
     # ------------------------------------------------------------------
     # State machine
     # ------------------------------------------------------------------

--- a/templates/base.html
+++ b/templates/base.html
@@ -953,6 +953,7 @@
     <script src="{% static 'js/alpine.min.js' %}" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.6/Sortable.min.js"></script>
     <script nonce="{{ request.csp_nonce }}">
         /* Analytics hero chart: read data attrs off the canvas, (re)create Chart.js.
            Lives in base.html so its CSP nonce matches the parent page — the chart

--- a/templates/calendar/calendar.html
+++ b/templates/calendar/calendar.html
@@ -299,8 +299,15 @@
         margin-left: auto;
     }
 
-    /* Draggable feedback */
-    .post-chip.dragging { opacity: 0.5; transform: rotate(2deg); }
+    /* Drag-and-drop (SortableJS) feedback */
+    .post-chip.is-draggable { cursor: grab; }
+    .post-chip.is-draggable:active { cursor: grabbing; }
+    /* Placeholder left in the source cell while dragging */
+    .chip-ghost { opacity: 0.4; }
+    /* The element under the cursor while dragging */
+    .chip-chosen { box-shadow: 0 4px 12px rgba(0,0,0,0.18); }
+    /* Highlight a cell as a valid drop target on hover-drag */
+    .cal-drop.sortable-drag-over { outline: 2px dashed #F97316; outline-offset: -2px; }
 
     @keyframes slideUp {
         from { opacity: 0; transform: translateY(8px); }
@@ -351,58 +358,68 @@ function calendarApp() {
             htmx.ajax('GET', url, {target: '#calendar-content', swap: 'innerHTML'});
         },
 
-        startDrag(event, platformPostId) {
-            this.draggedPlatformPostId = platformPostId;
-            event.dataTransfer.effectAllowed = 'move';
-            event.target.classList.add('dragging');
+        init() {
+            // SortableJS drag-and-drop. Wire on first load and re-wire after
+            // every HTMX swap of the calendar grid (nav, view change, filters).
+            this.$nextTick(() => this.initCalendarDnD());
+            document.body.addEventListener('htmx:afterSettle', (e) => {
+                const t = e.detail && e.detail.target;
+                if (t && (t.id === 'calendar-content' || (t.querySelector && t.querySelector('.cal-drop')))) {
+                    this.$nextTick(() => this.initCalendarDnD());
+                }
+            });
+            // A drag on an <a> chip would otherwise fire a trailing click and
+            // navigate to the editor. Swallow that click while a drag is in
+            // flight; genuine clicks (no drag) still open the post.
+            document.body.addEventListener('click', (e) => {
+                if (this._draggingChip && e.target.closest('.post-chip.is-draggable')) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                }
+            }, true);
         },
 
-        endDrag(event) {
-            event.target.classList.remove('dragging');
-            this.draggedPlatformPostId = null;
+        initCalendarDnD() {
+            if (typeof Sortable === 'undefined') return;
+            document.querySelectorAll('#calendar-content .cal-drop').forEach((cell) => {
+                if (Sortable.get(cell)) return; // already wired this cell
+                Sortable.create(cell, {
+                    group: 'calendar',
+                    draggable: '.post-chip.is-draggable',
+                    animation: 150,
+                    ghostClass: 'chip-ghost',
+                    chosenClass: 'chip-chosen',
+                    // Use the mouse-based fallback so the browser's native
+                    // anchor-drag (dragging the link URL) never kicks in.
+                    forceFallback: true,
+                    fallbackOnBody: true,
+                    fallbackTolerance: 3,
+                    // Touch: short hold before a drag begins so it doesn't
+                    // hijack a scroll. Desktop mouse is unaffected (immediate).
+                    delay: 150,
+                    delayOnTouchOnly: true,
+                    onStart: () => { this._draggingChip = true; },
+                    onEnd: (evt) => {
+                        setTimeout(() => { this._draggingChip = false; }, 60);
+                        if (evt.to === evt.from) return; // dropped back in place
+                        const ppId = evt.item.getAttribute('data-platform-post-id');
+                        const date = evt.to.getAttribute('data-date');
+                        const time = evt.to.getAttribute('data-time') || '09:00';
+                        if (!ppId || !date) return;
+                        this.rescheduleChip(ppId, date + 'T' + time + ':00');
+                    },
+                });
+            });
         },
 
-        allowDrop(event) {
-            event.preventDefault();
-            event.dataTransfer.dropEffect = 'move';
-        },
-
-        dropOnSlot(event, dateStr, timeStr) {
-            event.preventDefault();
-            const platformPostId = this.draggedPlatformPostId;
-            if (!platformPostId) return;
-
-            const chip = document.querySelector(
-                `[data-platform-post-id="${platformPostId}"]`
-            );
-            const targetCell = event.currentTarget;
-            if (!chip || !targetCell) return;
-
-            const originalParent = chip.parentNode;
-            const originalNextSibling = chip.nextSibling;
-
-            // Optimistically move the chip into the target slot so the user
-            // sees the reschedule immediately, with no full grid reload.
-            if (originalParent !== targetCell || originalNextSibling !== null) {
-                targetCell.appendChild(chip);
-            }
-            this.draggedPlatformPostId = null;
-
-            // dateStr/timeStr are the target cell's workspace-tz wall date/time
-            // (see _cell_compose_params); reschedule_post interprets the naive
-            // value in the workspace timezone, so the drop lands on the right
-            // instant even when the calendar display timezone differs from it.
-            const newDatetime = dateStr + 'T' + timeStr + ':00';
-
+        rescheduleChip(platformPostId, newDatetime) {
+            // newDatetime is the target cell's workspace-tz wall date/time (see
+            // _cell_compose_params); reschedule_post interprets the naive value
+            // in the workspace timezone, so the drop lands on the right instant.
             const csrfToken =
                 (document.querySelector('[name=csrfmiddlewaretoken]') || {}).value ||
                 (document.cookie.match(/(?:^|;\s*)csrftoken=([^;]+)/) || [])[1] ||
                 '';
-
-            const rollback = () => {
-                originalParent.insertBefore(chip, originalNextSibling);
-            };
-
             fetch('{% url "calendar:reschedule" workspace_id=workspace.id %}', {
                 method: 'POST',
                 headers: {
@@ -415,14 +432,9 @@ function calendarApp() {
                     new_datetime: newDatetime,
                 }),
             }).then((res) => {
-                if (!res.ok) {
-                    rollback();
-                    console.error('Reschedule failed', res.status);
-                }
-            }).catch((err) => {
-                rollback();
-                console.error('Reschedule failed', err);
-            });
+                // On failure snap the grid back to the server truth.
+                if (!res.ok) this.reloadCalendar();
+            }).catch(() => this.reloadCalendar());
         }
     };
 }

--- a/templates/calendar/calendar.html
+++ b/templates/calendar/calendar.html
@@ -313,6 +313,22 @@
        flicker under the cursor as it crosses cells. */
     body.cal-dragging .cal-add-btn { display: none !important; }
 
+    /* Bulk-selection checkbox (chips + list rows). Hover-reveal on chips; always
+       shown once checked or when a selection is active. */
+    .cal-select-box {
+        width: 15px; height: 15px; flex-shrink: 0; border: 1.5px solid #A8A29E;
+        border-radius: 4px; background: #fff; cursor: pointer; color: #fff;
+        display: inline-flex; align-items: center; justify-content: center;
+        opacity: 0; transition: opacity 120ms ease, background 120ms ease;
+    }
+    .post-chip:hover .cal-select-box,
+    .cal-select-box.is-checked,
+    body.has-selection .cal-select-box { opacity: 1; }
+    .cal-select-box.is-checked { background: #F97316; border-color: #F97316; }
+    .cal-select-box:hover { border-color: #F97316; }
+    /* In list rows the checkbox is always visible (there's room). */
+    .row-select-box { opacity: 1; }
+
     @keyframes slideUp {
         from { opacity: 0; transform: translateY(8px); }
         to   { opacity: 1; transform: translateY(0); }
@@ -333,10 +349,66 @@
 </div>
 {# Toast host — outside #tab-content so an approval action's list refresh doesn't tear down the toast #}
 {% include "approvals/partials/_toasts.html" %}
+
+{% comment %}Floating bulk-selection bar — outside the swapped regions so the
+selection survives grid reloads / tab switches. Shown when ≥1 chip/row is
+ticked (see the `sel` Alpine store).{% endcomment %}
+<div x-data="bulkBar()" x-cloak x-show="$store.sel.count > 0"
+     x-effect="document.body.classList.toggle('has-selection', $store.sel.count > 0)"
+     class="fixed bottom-6 left-1/2 -translate-x-1/2 z-[60] flex items-center gap-1 bg-stone-900 text-white rounded-full shadow-2xl pl-4 pr-2 py-2">
+    <span class="text-sm font-medium whitespace-nowrap" x-text="$store.sel.count + ' selected'"></span>
+    <span class="w-px h-5 bg-white/20 mx-1.5"></span>
+    <button @click="run('draft')" :disabled="busy" class="px-3 py-1.5 text-xs font-semibold rounded-full hover:bg-white/10 transition-colors disabled:opacity-50">Draft</button>
+    <button @click="run('publish')" :disabled="busy" class="px-3 py-1.5 text-xs font-semibold rounded-full bg-emerald-500 hover:bg-emerald-600 transition-colors disabled:opacity-50">Publish</button>
+    <button @click="run('delete')" :disabled="busy" class="px-3 py-1.5 text-xs font-semibold rounded-full text-red-300 hover:bg-red-500/20 transition-colors disabled:opacity-50">Delete</button>
+    <button @click="$store.sel.clear()" class="w-7 h-7 rounded-full hover:bg-white/10 flex items-center justify-center transition-colors" title="Clear selection">
+        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+    </button>
+</div>
 {% endblock %}
 
 {% block extra_js %}
 <script nonce="{{ request.csp_nonce }}">
+/* Bulk-selection store (survives HTMX grid/tab swaps) + floating-bar controller. */
+document.addEventListener('alpine:init', () => {
+    Alpine.store('sel', {
+        ids: [],
+        has(id) { return this.ids.includes(id); },
+        toggle(id) { const i = this.ids.indexOf(id); if (i >= 0) this.ids.splice(i, 1); else this.ids.push(id); },
+        clear() { this.ids = []; },
+        get count() { return this.ids.length; },
+    });
+});
+function bulkBar() {
+    return {
+        busy: false,
+        run(action) {
+            const store = Alpine.store('sel');
+            if (!store.count || this.busy) return;
+            if (action === 'delete' && !confirm(`Delete ${store.count} post(s)? This can't be undone.`)) return;
+            this.busy = true;
+            const csrf = (document.querySelector('[name=csrfmiddlewaretoken]') || {}).value
+                || (document.cookie.match(/(?:^|;\s*)csrftoken=([^;]+)/) || [])[1] || '';
+            const body = new URLSearchParams();
+            body.set('action', action);
+            store.ids.forEach(id => body.append('platform_post_ids', id));
+            fetch('{% url "calendar:bulk_platform_action" workspace_id=workspace.id %}', {
+                method: 'POST',
+                headers: { 'X-CSRFToken': csrf, 'X-Requested-With': 'XMLHttpRequest', 'Content-Type': 'application/x-www-form-urlencoded' },
+                body,
+            }).then((res) => {
+                this.busy = false;
+                if (!res.ok) return;
+                store.clear();
+                // Refresh whichever view is mounted: the calendar shell reloads
+                // its grid on `calendarRefresh` (from body); publishList reloads
+                // the active tab on the `post-deleted` window event.
+                if (window.htmx) htmx.trigger(document.body, 'calendarRefresh');
+                window.dispatchEvent(new CustomEvent('post-deleted'));
+            }).catch(() => { this.busy = false; });
+        },
+    };
+}
 function calendarApp() {
     return {
         activeView: '{{ view_type }}',

--- a/templates/calendar/calendar.html
+++ b/templates/calendar/calendar.html
@@ -302,12 +302,13 @@
     /* Drag-and-drop (SortableJS) feedback */
     .post-chip.is-draggable { cursor: grab; }
     .post-chip.is-draggable:active { cursor: grabbing; }
-    /* Placeholder left in the source cell while dragging */
-    .chip-ghost { opacity: 0.4; }
-    /* The element under the cursor while dragging */
-    .chip-chosen { box-shadow: 0 4px 12px rgba(0,0,0,0.18); }
-    /* Highlight a cell as a valid drop target on hover-drag */
-    .cal-drop.sortable-drag-over { outline: 2px dashed #F97316; outline-offset: -2px; }
+    /* Hide the source-cell placeholder entirely: for a day-granularity calendar
+       the only feedback that matters is which day cell is targeted, so we don't
+       want a translucent chip trailing into every cell the cursor passes. Only
+       the cursor-following drag clone stays visible. */
+    .chip-ghost { display: none !important; }
+    /* Highlight the day cell currently under the drag (toggled in onMove). */
+    .cal-drop.cal-drop-active { background: #FFF7ED; box-shadow: inset 0 0 0 2px #F97316; }
 
     @keyframes slideUp {
         from { opacity: 0; transform: translateY(8px); }
@@ -399,7 +400,14 @@ function calendarApp() {
                     delay: 150,
                     delayOnTouchOnly: true,
                     onStart: () => { this._draggingChip = true; },
+                    onMove: (evt) => {
+                        // Highlight only the day cell currently under the drag.
+                        document.querySelectorAll('.cal-drop.cal-drop-active').forEach(c => c.classList.remove('cal-drop-active'));
+                        if (evt.to) evt.to.classList.add('cal-drop-active');
+                        return true;
+                    },
                     onEnd: (evt) => {
+                        document.querySelectorAll('.cal-drop.cal-drop-active').forEach(c => c.classList.remove('cal-drop-active'));
                         setTimeout(() => { this._draggingChip = false; }, 60);
                         if (evt.to === evt.from) return; // dropped back in place
                         const ppId = evt.item.getAttribute('data-platform-post-id');

--- a/templates/calendar/calendar.html
+++ b/templates/calendar/calendar.html
@@ -309,6 +309,9 @@
     .chip-ghost { display: none !important; }
     /* Highlight the day cell currently under the drag (toggled in onMove). */
     .cal-drop.cal-drop-active { background: #FFF7ED; box-shadow: inset 0 0 0 2px #F97316; }
+    /* While dragging, suppress the per-cell "+" add buttons that would otherwise
+       flicker under the cursor as it crosses cells. */
+    body.cal-dragging .cal-add-btn { display: none !important; }
 
     @keyframes slideUp {
         from { opacity: 0; transform: translateY(8px); }
@@ -389,17 +392,24 @@ function calendarApp() {
                     draggable: '.post-chip.is-draggable',
                     animation: 150,
                     ghostClass: 'chip-ghost',
-                    chosenClass: 'chip-chosen',
-                    // Use the mouse-based fallback so the browser's native
-                    // anchor-drag (dragging the link URL) never kicks in.
-                    forceFallback: true,
-                    fallbackOnBody: true,
-                    fallbackTolerance: 3,
+                    // Native HTML5 drag: the browser renders a drag image that
+                    // reliably follows the cursor (a forceFallback clone did
+                    // not — it appeared stuck near the origin). We set that image
+                    // explicitly to the chip and clear the drag data so an <a>
+                    // chip never drags its URL instead of itself.
+                    setData: (dataTransfer, dragEl) => {
+                        try { dataTransfer.setDragImage(dragEl, 20, 12); } catch (e) {}
+                        dataTransfer.setData('text/plain', '');
+                    },
                     // Touch: short hold before a drag begins so it doesn't
                     // hijack a scroll. Desktop mouse is unaffected (immediate).
                     delay: 150,
                     delayOnTouchOnly: true,
-                    onStart: () => { this._draggingChip = true; },
+                    onStart: () => {
+                        this._draggingChip = true;
+                        // Suppress the per-cell "+" add buttons while dragging.
+                        document.body.classList.add('cal-dragging');
+                    },
                     onMove: (evt) => {
                         // Highlight only the day cell currently under the drag.
                         document.querySelectorAll('.cal-drop.cal-drop-active').forEach(c => c.classList.remove('cal-drop-active'));
@@ -407,6 +417,7 @@ function calendarApp() {
                         return true;
                     },
                     onEnd: (evt) => {
+                        document.body.classList.remove('cal-dragging');
                         document.querySelectorAll('.cal-drop.cal-drop-active').forEach(c => c.classList.remove('cal-drop-active'));
                         setTimeout(() => { this._draggingChip = false; }, 60);
                         if (evt.to === evt.from) return; // dropped back in place

--- a/templates/calendar/calendar.html
+++ b/templates/calendar/calendar.html
@@ -339,7 +339,7 @@ function calendarApp() {
         draggedPlatformPostId: null,
         calendarFilters: {
             status: '{{ active_filters.statuses.0|default:"" }}',
-            channel: '',
+            channels: [],
             tag: '{{ active_filters.tags.0|default:"" }}',
             tz: '{{ display_timezone|default:"UTC" }}',
         },
@@ -350,7 +350,7 @@ function calendarApp() {
             params.set('view', this.activeView);
             params.set('date', '{{ target_date|date:"Y-m-d" }}');
             if (this.calendarFilters.status) params.set('status', this.calendarFilters.status);
-            if (this.calendarFilters.channel) params.set('channel', this.calendarFilters.channel);
+            this.calendarFilters.channels.forEach(c => params.append('channel', c));
             if (this.calendarFilters.tag) params.set('tag', this.calendarFilters.tag);
             if (this.calendarFilters.tz) params.set('tz', this.calendarFilters.tz);
             {% if show_holidays %}params.set('holidays', '1');{% endif %}
@@ -442,7 +442,7 @@ function calendarApp() {
 function publishList() {
     return {
         activeTab: '{{ active_tab|default:"queue" }}',
-        activeChannel: '',
+        selectedChannels: [],
         activeTag: '',
         displayTimezone: '{{ display_timezone|default:"UTC" }}',
 
@@ -464,7 +464,7 @@ function publishList() {
 
         reloadTab() {
             const params = new URLSearchParams();
-            if (this.activeChannel) params.set('channel', this.activeChannel);
+            this.selectedChannels.forEach(c => params.append('channel', c));
             if (this.activeTag) params.set('tag', this.activeTag);
             if (this.displayTimezone) params.set('tz', this.displayTimezone);
             const url = this.tabUrls[this.activeTab] + '?' + params.toString();

--- a/templates/calendar/calendar.html
+++ b/templates/calendar/calendar.html
@@ -353,17 +353,45 @@
 {% comment %}Floating bulk-selection bar — outside the swapped regions so the
 selection survives grid reloads / tab switches. Shown when ≥1 chip/row is
 ticked (see the `sel` Alpine store).{% endcomment %}
-<div x-data="bulkBar()" x-cloak x-show="$store.sel.count > 0"
-     x-effect="document.body.classList.toggle('has-selection', $store.sel.count > 0)"
-     class="fixed bottom-6 left-1/2 -translate-x-1/2 z-[60] flex items-center gap-1 bg-stone-900 text-white rounded-full shadow-2xl pl-4 pr-2 py-2">
-    <span class="text-sm font-medium whitespace-nowrap" x-text="$store.sel.count + ' selected'"></span>
-    <span class="w-px h-5 bg-white/20 mx-1.5"></span>
-    <button @click="run('draft')" :disabled="busy" class="px-3 py-1.5 text-xs font-semibold rounded-full hover:bg-white/10 transition-colors disabled:opacity-50">Draft</button>
-    <button @click="run('publish')" :disabled="busy" class="px-3 py-1.5 text-xs font-semibold rounded-full bg-emerald-500 hover:bg-emerald-600 transition-colors disabled:opacity-50">Publish</button>
-    <button @click="run('delete')" :disabled="busy" class="px-3 py-1.5 text-xs font-semibold rounded-full text-red-300 hover:bg-red-500/20 transition-colors disabled:opacity-50">Delete</button>
-    <button @click="$store.sel.clear()" class="w-7 h-7 rounded-full hover:bg-white/10 flex items-center justify-center transition-colors" title="Clear selection">
-        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
-    </button>
+<div x-data="bulkBar()">
+    {# Floating action bar #}
+    <div x-cloak x-show="$store.sel.count > 0"
+         x-effect="document.body.classList.toggle('has-selection', $store.sel.count > 0)"
+         class="fixed bottom-6 left-1/2 -translate-x-1/2 z-[60] flex items-center gap-1 bg-stone-900 text-white rounded-full shadow-2xl pl-4 pr-2 py-2">
+        <span class="text-sm font-medium whitespace-nowrap" x-text="$store.sel.count + ' selected'"></span>
+        <span class="w-px h-5 bg-white/20 mx-1.5"></span>
+        <button @click="ask('draft')" :disabled="busy" class="px-3 py-1.5 text-xs font-semibold rounded-full hover:bg-white/10 transition-colors disabled:opacity-50">Draft</button>
+        <button @click="ask('publish')" :disabled="busy" class="px-3 py-1.5 text-xs font-semibold rounded-full bg-emerald-500 hover:bg-emerald-600 transition-colors disabled:opacity-50">Publish</button>
+        <button @click="ask('delete')" :disabled="busy" class="px-3 py-1.5 text-xs font-semibold rounded-full text-red-300 hover:bg-red-500/20 transition-colors disabled:opacity-50">Delete</button>
+        <button @click="$store.sel.clear()" class="w-7 h-7 rounded-full hover:bg-white/10 flex items-center justify-center transition-colors" title="Clear selection">
+            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/></svg>
+        </button>
+    </div>
+
+    {% comment %}Confirmation dialog for impactful actions (publish / delete).
+    Draft is reversible so it runs without a prompt.{% endcomment %}
+    <div x-cloak x-show="confirmAction" @keydown.escape.window="confirmAction = null"
+         class="fixed inset-0 z-[70] flex items-center justify-center bg-black/40 px-4" @click.self="confirmAction = null">
+        <div class="bg-white rounded-2xl shadow-2xl p-6 w-full max-w-xs text-center">
+            <div class="w-11 h-11 mx-auto rounded-full flex items-center justify-center mb-3"
+                 :class="confirmAction === 'delete' ? 'bg-red-50 text-red-500' : 'bg-emerald-50 text-emerald-600'">
+                <svg x-show="confirmAction === 'delete'" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
+                <svg x-show="confirmAction === 'publish'" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M5 10l7-7m0 0l7 7m-7-7v18"/></svg>
+            </div>
+            <h3 class="text-base font-bold text-stone-900" x-text="confirmAction === 'delete' ? 'Delete posts?' : 'Publish now?'"></h3>
+            <p class="text-sm text-stone-500 mt-1 leading-relaxed"
+               x-text="confirmAction === 'delete'
+                   ? ('Permanently delete ' + $store.sel.count + ' selected post' + ($store.sel.count === 1 ? '' : 's') + '. This can\'t be undone.')
+                   : ('Publish ' + $store.sel.count + ' selected post' + ($store.sel.count === 1 ? '' : 's') + ' now — they go out on their platforms shortly.')"></p>
+            <div class="flex gap-2 mt-5">
+                <button @click="confirmAction = null" class="flex-1 px-4 py-2 text-sm font-semibold rounded-full border border-stone-200 text-stone-600 hover:bg-stone-50 transition-colors">Cancel</button>
+                <button @click="exec(confirmAction)" :disabled="busy"
+                        :class="confirmAction === 'delete' ? 'bg-red-500 hover:bg-red-600' : 'bg-emerald-500 hover:bg-emerald-600'"
+                        class="flex-1 px-4 py-2 text-sm font-semibold rounded-full text-white transition-colors disabled:opacity-50"
+                        x-text="confirmAction === 'delete' ? 'Delete' : 'Publish'"></button>
+            </div>
+        </div>
+    </div>
 </div>
 {% endblock %}
 
@@ -382,10 +410,17 @@ document.addEventListener('alpine:init', () => {
 function bulkBar() {
     return {
         busy: false,
-        run(action) {
+        confirmAction: null, // 'publish' | 'delete' pending confirmation, else null
+        // Draft is reversible → run straight away. Publish/Delete open the dialog.
+        ask(action) {
+            if (!Alpine.store('sel').count || this.busy) return;
+            if (action === 'publish' || action === 'delete') { this.confirmAction = action; return; }
+            this.exec(action);
+        },
+        exec(action) {
+            this.confirmAction = null;
             const store = Alpine.store('sel');
             if (!store.count || this.busy) return;
-            if (action === 'delete' && !confirm(`Delete ${store.count} post(s)? This can't be undone.`)) return;
             this.busy = true;
             const csrf = (document.querySelector('[name=csrfmiddlewaretoken]') || {}).value
                 || (document.cookie.match(/(?:^|;\s*)csrftoken=([^;]+)/) || [])[1] || '';

--- a/templates/calendar/calendar.html
+++ b/templates/calendar/calendar.html
@@ -328,6 +328,10 @@
     .cal-select-box:hover { border-color: #F97316; }
     /* In list rows the checkbox is always visible (there's room). */
     .row-select-box { opacity: 1; }
+    /* The shared toast host and the selection bar both sit bottom-centre. Lift
+       the toasts clear while a selection is active, so a rejected bulk action
+       doesn't render its own explanation on top of the bar it came from. */
+    body.has-selection #bb-toast-host { bottom: 5rem; }
 
     @keyframes slideUp {
         from { opacity: 0; transform: translateY(8px); }
@@ -397,6 +401,18 @@ ticked (see the `sel` Alpine store).{% endcomment %}
 
 {% block extra_js %}
 <script nonce="{{ request.csp_nonce }}">
+/* Surface a rejected request through the shared toast host
+   (approvals/partials/_toasts.html), which listens for a `showToast` event on
+   document.body. These endpoints are called with fetch(), not htmx, so the
+   usual HX-Trigger route isn't available — dispatch the event directly. */
+function bbFailureToast(res, fallback) {
+    res.json().catch(() => ({})).then((data) => {
+        document.body.dispatchEvent(new CustomEvent('showToast', {
+            detail: { tone: 'error', title: (data && data.error) || fallback },
+        }));
+    });
+}
+
 /* Bulk-selection store (survives HTMX grid/tab swaps) + floating-bar controller. */
 document.addEventListener('alpine:init', () => {
     Alpine.store('sel', {
@@ -433,7 +449,12 @@ function bulkBar() {
                 body,
             }).then((res) => {
                 this.busy = false;
-                if (!res.ok) return;
+                if (!res.ok) {
+                    // e.g. the publish_directly gate. Keep the selection so the
+                    // user can retry with an action they are allowed to take.
+                    bbFailureToast(res, 'Could not complete that action.');
+                    return;
+                }
                 store.clear();
                 // Refresh whichever view is mounted: the calendar shell reloads
                 // its grid on `calendarRefresh` (from body); publishList reloads
@@ -558,8 +579,13 @@ function calendarApp() {
                     new_datetime: newDatetime,
                 }),
             }).then((res) => {
-                // On failure snap the grid back to the server truth.
-                if (!res.ok) this.reloadCalendar();
+                // On failure snap the grid back to the server truth, and say why
+                // — a drop rejected by the publish gate would otherwise look like
+                // the chip just sprang back for no reason.
+                if (!res.ok) {
+                    this.reloadCalendar();
+                    bbFailureToast(res, 'Could not reschedule that post.');
+                }
             }).catch(() => this.reloadCalendar());
         }
     };

--- a/templates/calendar/partials/_channel_multiselect.html
+++ b/templates/calendar/partials/_channel_multiselect.html
@@ -1,0 +1,47 @@
+{% comment %}
+Reusable channels multi-select dropdown (checkbox list). An empty selection
+means "all channels". Params:
+  model    — Alpine array holding selected SocialAccount ids
+             (e.g. "calendarFilters.channels" or "selectedChannels")
+  onchange — Alpine expression to run after a change (e.g. "reloadCalendar()")
+  accounts — iterable of SocialAccount to list
+
+The panel is position:fixed (anchored to the trigger on open) so it escapes the
+`overflow-x-auto` filter row that would otherwise clip it. Relies on the
+.cal-filter-select / .cal-filter-icon styles from calendar.html.
+{% endcomment %}
+<div class="relative flex-shrink-0"
+     x-data="{ chOpen: false, chTop: 0, chLeft: 0,
+               chToggle(e){ if (this.chOpen) { this.chOpen = false; return; }
+                            const r = e.currentTarget.getBoundingClientRect();
+                            this.chTop = r.bottom + 4;
+                            this.chLeft = Math.min(r.left, window.innerWidth - 236);
+                            this.chOpen = true; } }"
+     @click.away="chOpen = false" @keydown.escape="chOpen = false" @scroll.window="chOpen = false">
+    <svg class="cal-filter-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M16 8v5a3 3 0 006 0v-1a10 10 0 10-3.92 7.94"/></svg>
+    <button type="button" @click="chToggle($event)"
+            class="cal-filter-select has-icon flex items-center gap-1 whitespace-nowrap"
+            :class="{{ model }}.length && 'border-orange-300 text-orange-700'">
+        <span x-text="{{ model }}.length ? {{ model }}.length + ' selected' : 'Channels'"></span>
+        <svg class="w-3 h-3 text-stone-400 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
+    </button>
+    <div x-show="chOpen" x-cloak x-transition.opacity
+         :style="`top:${chTop}px; left:${chLeft}px;`"
+         class="fixed z-50 w-56 max-h-72 overflow-y-auto bg-white rounded-lg shadow-lg ring-1 ring-stone-200 py-1">
+        <button type="button" @click="{{ model }} = []; {{ onchange }}"
+                class="w-full text-left px-3 py-1.5 text-xs font-semibold hover:bg-stone-50 border-b border-stone-100"
+                :class="{{ model }}.length ? 'text-stone-500' : 'text-orange-600'">
+            All channels
+        </button>
+        {% for acc in accounts %}
+        <label class="flex items-center gap-2 px-3 py-1.5 text-xs text-stone-700 hover:bg-stone-50 cursor-pointer">
+            <input type="checkbox" value="{{ acc.id }}" x-model="{{ model }}" @change="{{ onchange }}"
+                   class="rounded border-stone-300 text-orange-500 focus:ring-orange-400">
+            <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ acc.platform }} flex-shrink-0 text-white">
+                {% include "social_accounts/partials/_platform_icon.html" with platform=acc.platform size="3" %}
+            </span>
+            <span class="truncate">{{ acc.account_name|default:acc.account_handle }}</span>
+        </label>
+        {% endfor %}
+    </div>
+</div>

--- a/templates/calendar/partials/_select_checkbox.html
+++ b/templates/calendar/partials/_select_checkbox.html
@@ -1,0 +1,12 @@
+{% comment %}
+Selection checkbox for the bulk-action bar. Expects `pp_id` (a PlatformPost id).
+Toggles the `sel` Alpine store. `.stop.prevent` keeps a click off the chip's
+own link/drag; it renders as a styled span (not an <input>) so preventDefault
+doesn't swallow the toggle.
+{% endcomment %}
+<span @click.stop.prevent="$store.sel.toggle('{{ pp_id }}')"
+      @mousedown.stop @dragstart.prevent.stop draggable="false"
+      class="cal-select-box {{ extra_class }}" :class="$store.sel.has('{{ pp_id }}') && 'is-checked'"
+      title="Select">
+    <svg x-show="$store.sel.has('{{ pp_id }}')" x-cloak class="w-2.5 h-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="4"><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7"/></svg>
+</span>

--- a/templates/calendar/partials/_tab_count_badge.html
+++ b/templates/calendar/partials/_tab_count_badge.html
@@ -1,0 +1,1 @@
+{% comment %}A single Publish tab-bar count pill. Expects `count`. Renders nothing when zero/None.{% endcomment %}{% if count %}<span class="inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 text-[11px] font-medium text-stone-500 bg-stone-100 rounded-full">{{ count }}</span>{% endif %}

--- a/templates/calendar/partials/_tab_counts_oob.html
+++ b/templates/calendar/partials/_tab_counts_oob.html
@@ -1,0 +1,10 @@
+{% comment %}
+Out-of-band refresh of the Publish tab-bar count badges. Emitted inside each
+HTMX tab-partial response so switching/reloading a tab keeps all four counts in
+sync — the badges live in the tab bar, outside the swapped #tab-content.
+Ids here must match the wrapper spans in publish_list_shell.html.
+{% endcomment %}
+<span id="tabcount-queue" hx-swap-oob="true">{% include "calendar/partials/_tab_count_badge.html" with count=queue_count %}</span>
+<span id="tabcount-drafts" hx-swap-oob="true">{% include "calendar/partials/_tab_count_badge.html" with count=drafts_count %}</span>
+<span id="tabcount-approvals" hx-swap-oob="true">{% include "calendar/partials/_tab_count_badge.html" with count=approvals_count %}</span>
+<span id="tabcount-sent" hx-swap-oob="true">{% include "calendar/partials/_tab_count_badge.html" with count=sent_count %}</span>

--- a/templates/calendar/partials/day_grid.html
+++ b/templates/calendar/partials/day_grid.html
@@ -48,6 +48,7 @@ Context: day_slots, target_date, workspace.
                class="post-chip status-{{ pp.status }}{% if pp.is_reschedulable %} is-draggable{% endif %}"
                title="{% if pp.is_reschedulable %}Move or open{% else %}Open{% endif %}"
                {% if pp.is_reschedulable %}draggable="true" data-platform-post-id="{{ pp.id }}"{% else %}draggable="false"{% endif %}>
+                {% include "calendar/partials/_select_checkbox.html" with pp_id=pp.id %}
                 <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ pp.social_account.platform }} flex-shrink-0 text-white">
                     {% include "social_accounts/partials/_platform_icon.html" with platform=pp.social_account.platform size="3" %}
                 </span>

--- a/templates/calendar/partials/day_grid.html
+++ b/templates/calendar/partials/day_grid.html
@@ -44,8 +44,9 @@ Context: day_slots, target_date, workspace.
             {% endif %}
             {% for pp in cell.posts %}
             <a href="{% url 'composer:compose_edit' workspace_id=workspace.id post_id=pp.post_id %}?account={{ pp.social_account_id }}"
-               class="post-chip status-{{ pp.status }}{% if pp.status == 'draft' or pp.status == 'approved' or pp.status == 'scheduled' %} is-draggable{% endif %}"
-               {% if pp.status == "draft" or pp.status == "approved" or pp.status == "scheduled" %}draggable="false" data-platform-post-id="{{ pp.id }}"{% endif %}>
+               class="post-chip status-{{ pp.status }}{% if pp.is_reschedulable %} is-draggable{% endif %}"
+               title="{% if pp.is_reschedulable %}Mover o abrir{% else %}Abrir{% endif %}"
+               {% if pp.is_reschedulable %}draggable="false" data-platform-post-id="{{ pp.id }}"{% endif %}>
                 <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ pp.social_account.platform }} flex-shrink-0 text-white">
                     {% include "social_accounts/partials/_platform_icon.html" with platform=pp.social_account.platform size="3" %}
                 </span>

--- a/templates/calendar/partials/day_grid.html
+++ b/templates/calendar/partials/day_grid.html
@@ -5,9 +5,8 @@ Context: day_slots, target_date, workspace.
 
 <div class="bg-white mx-auto" style="animation: slideUp 200ms cubic-bezier(0.16,1,0.3,1) both; max-height: calc(100vh - 200px); overflow-y: auto;">
 {% for cell in day_slots %}
-    <div class="flex border-b border-stone-100 min-h-[64px] cal-add-cell {% if cell.posts or cell.slots %}has-posts{% endif %} {% if is_today and cell.hour == current_hour %}bg-orange-50/50{% endif %}"
-         @dragover.prevent="allowDrop($event)"
-         @drop="dropOnSlot($event, '{{ cell.compose_date }}', '{{ cell.compose_time }}')">
+    <div class="flex border-b border-stone-100 min-h-[64px] cal-add-cell cal-drop {% if cell.posts or cell.slots %}has-posts{% endif %} {% if is_today and cell.hour == current_hour %}bg-orange-50/50{% endif %}"
+         data-date="{{ cell.compose_date }}" data-time="{{ cell.compose_time }}">
         <!-- Time label -->
         <div class="w-20 flex-shrink-0 border-r border-stone-200 px-3 py-2 text-right">
             <span class="text-xs font-medium tabular-nums {% if is_today and cell.hour == current_hour %}text-orange-600 font-semibold{% else %}text-stone-400{% endif %}">
@@ -45,11 +44,8 @@ Context: day_slots, target_date, workspace.
             {% endif %}
             {% for pp in cell.posts %}
             <a href="{% url 'composer:compose_edit' workspace_id=workspace.id post_id=pp.post_id %}?account={{ pp.social_account_id }}"
-               class="post-chip status-{{ pp.status }}"
-               {% if pp.status == "draft" or pp.status == "approved" or pp.status == "scheduled" %}draggable="true"
-               data-platform-post-id="{{ pp.id }}"
-               @dragstart="startDrag($event, '{{ pp.id }}')"
-               @dragend="endDrag($event)"{% endif %}>
+               class="post-chip status-{{ pp.status }}{% if pp.status == 'draft' or pp.status == 'approved' or pp.status == 'scheduled' %} is-draggable{% endif %}"
+               {% if pp.status == "draft" or pp.status == "approved" or pp.status == "scheduled" %}draggable="false" data-platform-post-id="{{ pp.id }}"{% endif %}>
                 <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ pp.social_account.platform }} flex-shrink-0 text-white">
                     {% include "social_accounts/partials/_platform_icon.html" with platform=pp.social_account.platform size="3" %}
                 </span>

--- a/templates/calendar/partials/day_grid.html
+++ b/templates/calendar/partials/day_grid.html
@@ -5,16 +5,17 @@ Context: day_slots, target_date, workspace.
 
 <div class="bg-white mx-auto" style="animation: slideUp 200ms cubic-bezier(0.16,1,0.3,1) both; max-height: calc(100vh - 200px); overflow-y: auto;">
 {% for cell in day_slots %}
-    <div class="flex border-b border-stone-100 min-h-[64px] cal-add-cell cal-drop {% if cell.posts or cell.slots %}has-posts{% endif %} {% if is_today and cell.hour == current_hour %}bg-orange-50/50{% endif %}"
-         data-date="{{ cell.compose_date }}" data-time="{{ cell.compose_time }}">
+    <div class="flex border-b border-stone-100 min-h-[64px] cal-add-cell {% if cell.posts or cell.slots %}has-posts{% endif %} {% if is_today and cell.hour == current_hour %}bg-orange-50/50{% endif %}">
         <!-- Time label -->
         <div class="w-20 flex-shrink-0 border-r border-stone-200 px-3 py-2 text-right">
             <span class="text-xs font-medium tabular-nums {% if is_today and cell.hour == current_hour %}text-orange-600 font-semibold{% else %}text-stone-400{% endif %}">
                 {% if cell.hour < 10 %}0{% endif %}{{ cell.hour }}:00
             </span>
         </div>
-        <!-- Slots and posts in this hour -->
-        <div class="flex-1 p-2 flex flex-col justify-center gap-1">
+        <!-- Slots and posts in this hour (the drop target: chips are its direct
+             children so SortableJS can manage them) -->
+        <div class="flex-1 p-2 flex flex-col justify-center gap-1 cal-drop"
+             data-date="{{ cell.compose_date }}" data-time="{{ cell.compose_time }}">
             {% if not is_past_day and not is_today or not is_past_day and cell.hour >= current_hour %}
             <a href="{% url 'composer:compose' workspace_id=workspace.id %}?scheduled_date={{ cell.compose_date }}&scheduled_time={{ cell.compose_time }}" class="cal-add-btn cal-add-btn--inline" style="position:static; margin:0 auto;" title="Create post">
                 <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
@@ -45,8 +46,8 @@ Context: day_slots, target_date, workspace.
             {% for pp in cell.posts %}
             <a href="{% url 'composer:compose_edit' workspace_id=workspace.id post_id=pp.post_id %}?account={{ pp.social_account_id }}"
                class="post-chip status-{{ pp.status }}{% if pp.is_reschedulable %} is-draggable{% endif %}"
-               title="{% if pp.is_reschedulable %}Mover o abrir{% else %}Abrir{% endif %}"
-               {% if pp.is_reschedulable %}draggable="false" data-platform-post-id="{{ pp.id }}"{% endif %}>
+               title="{% if pp.is_reschedulable %}Move or open{% else %}Open{% endif %}"
+               {% if pp.is_reschedulable %}draggable="true" data-platform-post-id="{{ pp.id }}"{% else %}draggable="false"{% endif %}>
                 <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ pp.social_account.platform }} flex-shrink-0 text-white">
                     {% include "social_accounts/partials/_platform_icon.html" with platform=pp.social_account.platform size="3" %}
                 </span>

--- a/templates/calendar/partials/day_grid.html
+++ b/templates/calendar/partials/day_grid.html
@@ -48,7 +48,7 @@ Context: day_slots, target_date, workspace.
                class="post-chip status-{{ pp.status }}{% if pp.is_reschedulable %} is-draggable{% endif %}"
                title="{% if pp.is_reschedulable %}Move or open{% else %}Open{% endif %}"
                {% if pp.is_reschedulable %}draggable="true" data-platform-post-id="{{ pp.id }}"{% else %}draggable="false"{% endif %}>
-                {% include "calendar/partials/_select_checkbox.html" with pp_id=pp.id %}
+                {% if pp.is_bulk_selectable %}{% include "calendar/partials/_select_checkbox.html" with pp_id=pp.id %}{% endif %}
                 <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ pp.social_account.platform }} flex-shrink-0 text-white">
                     {% include "social_accounts/partials/_platform_icon.html" with platform=pp.social_account.platform size="3" %}
                 </span>

--- a/templates/calendar/partials/month_grid.html
+++ b/templates/calendar/partials/month_grid.html
@@ -57,8 +57,8 @@ Enhanced with: holidays, custom events, category colors, recurring badges.
             {% for pp in day.posts %}
             <a href="{% url 'composer:compose_edit' workspace_id=workspace.id post_id=pp.post_id %}?account={{ pp.social_account_id }}"
                class="post-chip status-{{ pp.status }}{% if pp.is_reschedulable %} is-draggable{% endif %}"
-               title="{% if pp.is_reschedulable %}Mover o abrir{% else %}Abrir{% endif %}"
-               {% if pp.is_reschedulable %}draggable="false" data-platform-post-id="{{ pp.id }}"{% endif %}>
+               title="{% if pp.is_reschedulable %}Move or open{% else %}Open{% endif %}"
+               {% if pp.is_reschedulable %}draggable="true" data-platform-post-id="{{ pp.id }}"{% else %}draggable="false"{% endif %}>
                 <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ pp.social_account.platform }} flex-shrink-0 text-white">
                     {% include "social_accounts/partials/_platform_icon.html" with platform=pp.social_account.platform size="3" %}
                 </span>

--- a/templates/calendar/partials/month_grid.html
+++ b/templates/calendar/partials/month_grid.html
@@ -56,8 +56,9 @@ Enhanced with: holidays, custom events, category colors, recurring badges.
 
             {% for pp in day.posts %}
             <a href="{% url 'composer:compose_edit' workspace_id=workspace.id post_id=pp.post_id %}?account={{ pp.social_account_id }}"
-               class="post-chip status-{{ pp.status }}{% if pp.status == 'draft' or pp.status == 'approved' or pp.status == 'scheduled' %} is-draggable{% endif %}"
-               {% if pp.status == "draft" or pp.status == "approved" or pp.status == "scheduled" %}draggable="false" data-platform-post-id="{{ pp.id }}"{% endif %}>
+               class="post-chip status-{{ pp.status }}{% if pp.is_reschedulable %} is-draggable{% endif %}"
+               title="{% if pp.is_reschedulable %}Mover o abrir{% else %}Abrir{% endif %}"
+               {% if pp.is_reschedulable %}draggable="false" data-platform-post-id="{{ pp.id }}"{% endif %}>
                 <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ pp.social_account.platform }} flex-shrink-0 text-white">
                     {% include "social_accounts/partials/_platform_icon.html" with platform=pp.social_account.platform size="3" %}
                 </span>

--- a/templates/calendar/partials/month_grid.html
+++ b/templates/calendar/partials/month_grid.html
@@ -19,9 +19,8 @@ Enhanced with: holidays, custom events, category colors, recurring badges.
     {% for week in calendar_weeks %}
     <div class="grid grid-cols-7">
         {% for day in week %}
-        <div class="cal-day cal-add-cell {% if day.posts %}has-posts{% endif %} {% if day.is_today %}today{% elif day.is_past %}past{% endif %} {% if not day.is_current_month %}other-month{% endif %}"
-             @dragover.prevent="allowDrop($event)"
-             @drop="dropOnSlot($event, '{{ day.date|date:'Y-m-d' }}', '09:00')">
+        <div class="cal-day cal-add-cell cal-drop {% if day.posts %}has-posts{% endif %} {% if day.is_today %}today{% elif day.is_past %}past{% endif %} {% if not day.is_current_month %}other-month{% endif %}"
+             data-date="{{ day.date|date:'Y-m-d' }}" data-time="09:00">
             {% if not day.is_past %}
             <a href="{% url 'composer:compose' workspace_id=workspace.id %}?scheduled_date={{ day.date|date:'Y-m-d' }}&scheduled_time=09:00" class="cal-add-btn" title="Create post">
                 <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
@@ -57,11 +56,8 @@ Enhanced with: holidays, custom events, category colors, recurring badges.
 
             {% for pp in day.posts %}
             <a href="{% url 'composer:compose_edit' workspace_id=workspace.id post_id=pp.post_id %}?account={{ pp.social_account_id }}"
-               class="post-chip status-{{ pp.status }}"
-               {% if pp.status == "draft" or pp.status == "approved" or pp.status == "scheduled" %}draggable="true"
-               data-platform-post-id="{{ pp.id }}"
-               @dragstart="startDrag($event, '{{ pp.id }}')"
-               @dragend="endDrag($event)"{% endif %}>
+               class="post-chip status-{{ pp.status }}{% if pp.status == 'draft' or pp.status == 'approved' or pp.status == 'scheduled' %} is-draggable{% endif %}"
+               {% if pp.status == "draft" or pp.status == "approved" or pp.status == "scheduled" %}draggable="false" data-platform-post-id="{{ pp.id }}"{% endif %}>
                 <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ pp.social_account.platform }} flex-shrink-0 text-white">
                     {% include "social_accounts/partials/_platform_icon.html" with platform=pp.social_account.platform size="3" %}
                 </span>

--- a/templates/calendar/partials/month_grid.html
+++ b/templates/calendar/partials/month_grid.html
@@ -59,6 +59,7 @@ Enhanced with: holidays, custom events, category colors, recurring badges.
                class="post-chip status-{{ pp.status }}{% if pp.is_reschedulable %} is-draggable{% endif %}"
                title="{% if pp.is_reschedulable %}Move or open{% else %}Open{% endif %}"
                {% if pp.is_reschedulable %}draggable="true" data-platform-post-id="{{ pp.id }}"{% else %}draggable="false"{% endif %}>
+                {% include "calendar/partials/_select_checkbox.html" with pp_id=pp.id %}
                 <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ pp.social_account.platform }} flex-shrink-0 text-white">
                     {% include "social_accounts/partials/_platform_icon.html" with platform=pp.social_account.platform size="3" %}
                 </span>

--- a/templates/calendar/partials/month_grid.html
+++ b/templates/calendar/partials/month_grid.html
@@ -59,7 +59,7 @@ Enhanced with: holidays, custom events, category colors, recurring badges.
                class="post-chip status-{{ pp.status }}{% if pp.is_reschedulable %} is-draggable{% endif %}"
                title="{% if pp.is_reschedulable %}Move or open{% else %}Open{% endif %}"
                {% if pp.is_reschedulable %}draggable="true" data-platform-post-id="{{ pp.id }}"{% else %}draggable="false"{% endif %}>
-                {% include "calendar/partials/_select_checkbox.html" with pp_id=pp.id %}
+                {% if pp.is_bulk_selectable %}{% include "calendar/partials/_select_checkbox.html" with pp_id=pp.id %}{% endif %}
                 <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ pp.social_account.platform }} flex-shrink-0 text-white">
                     {% include "social_accounts/partials/_platform_icon.html" with platform=pp.social_account.platform size="3" %}
                 </span>

--- a/templates/calendar/partials/publish_approvals.html
+++ b/templates/calendar/partials/publish_approvals.html
@@ -1,3 +1,4 @@
+{% if render_tab_counts_oob %}{% include "calendar/partials/_tab_counts_oob.html" %}{% endif %}
 {% comment %}
 Approvals tab for the Publish page — one row per post, matching the approved design.
 Loaded into #tab-content. Re-fetches itself on approvalAction / bulkActionComplete

--- a/templates/calendar/partials/publish_calendar_shell.html
+++ b/templates/calendar/partials/publish_calendar_shell.html
@@ -82,16 +82,8 @@ Toolbar: nav arrows + period + Today + view dropdown | right: filter dropdowns.
                 </select>
             </div>
 
-            <!-- Channels filter -->
-            <div class="relative flex-shrink-0">
-                <svg class="cal-filter-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M16 8v5a3 3 0 006 0v-1a10 10 0 10-3.92 7.94"/></svg>
-                <select class="cal-filter-select has-icon" name="channel" x-model="calendarFilters.channel" @change="reloadCalendar()">
-                    <option value="">Channels</option>
-                    {% for acc in social_accounts %}
-                    <option value="{{ acc.id }}">{{ acc.account_name|default:acc.account_handle }}</option>
-                    {% endfor %}
-                </select>
-            </div>
+            <!-- Channels filter (multi-select) -->
+            {% include "calendar/partials/_channel_multiselect.html" with model="calendarFilters.channels" onchange="reloadCalendar()" accounts=social_accounts %}
 
             <!-- Tags filter -->
             <div class="relative flex-shrink-0">

--- a/templates/calendar/partials/publish_calendar_shell.html
+++ b/templates/calendar/partials/publish_calendar_shell.html
@@ -30,10 +30,17 @@ Toolbar: nav arrows + period + Today + view dropdown | right: filter dropdowns.
             {{ period_label }}
         </h2>
 
+        {% if is_today_in_view %}
+        <span class="px-3 py-1 text-xs font-semibold text-stone-300 border border-stone-100 rounded-md cursor-default select-none"
+              aria-disabled="true" title="Already showing today">
+            Today
+        </span>
+        {% else %}
         <a href="{% url 'calendar:calendar' workspace_id=workspace.id %}?mode=calendar&view={{ view_type }}"
            class="px-3 py-1 text-xs font-semibold text-stone-600 border border-stone-200 rounded-md hover:bg-stone-50 transition-all duration-150 no-underline">
             Today
         </a>
+        {% endif %}
 
         <!-- View dropdown (Month/Week/Day) -->
         <div class="relative" @click.away="viewOpen = false">

--- a/templates/calendar/partials/publish_calendar_shell.html
+++ b/templates/calendar/partials/publish_calendar_shell.html
@@ -81,14 +81,7 @@ Toolbar: nav arrows + period + Today + view dropdown | right: filter dropdowns.
             {% ui_select model="calendarFilters.tag" options=all_tags onchange="reloadCalendar()" placeholder="Tags" %}
 
             <!-- Timezone -->
-            <div class="relative flex-shrink-0">
-                <svg class="cal-filter-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
-                <select class="cal-filter-select has-icon" name="tz" x-model="calendarFilters.tz" @change="reloadCalendar()">
-                    {% for tz in timezone_choices %}
-                    <option value="{{ tz }}" {% if tz == display_timezone %}selected{% endif %}>{{ tz|cut:"America/"|cut:"Europe/"|cut:"Asia/"|cut:"US/"|cut:"Pacific/"|cut:"Australia/" }}{% if tz == workspace_timezone %} (workspace){% endif %}</option>
-                    {% endfor %}
-                </select>
-            </div>
+            {% ui_select model="calendarFilters.tz" options=timezone_options onchange="reloadCalendar()" placeholder="Timezone" %}
         </div>
     </div>
 

--- a/templates/calendar/partials/publish_calendar_shell.html
+++ b/templates/calendar/partials/publish_calendar_shell.html
@@ -1,4 +1,4 @@
-{% comment %}
+{% load common_extras %}{% comment %}
 Calendar mode shell for the Publish page.
 Toolbar: nav arrows + period + Today + view dropdown | right: filter dropdowns.
 {% endcomment %}
@@ -72,29 +72,13 @@ Toolbar: nav arrows + period + Today + view dropdown | right: filter dropdowns.
         <!-- Right side: filter dropdowns -->
         <div class="cal-filters-scroll flex items-center gap-2 ml-auto overflow-x-auto flex-nowrap" style="-webkit-overflow-scrolling: touch; scrollbar-width: none;">
             <!-- Status filter -->
-            <div class="relative flex-shrink-0">
-                <svg class="cal-filter-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"/></svg>
-                <select class="cal-filter-select has-icon" name="status" x-model="calendarFilters.status" @change="reloadCalendar()">
-                    <option value="">All Posts</option>
-                    {% for value, label in status_choices %}
-                    <option value="{{ value }}" {% if value in active_filters.statuses %}selected{% endif %}>{{ label }}</option>
-                    {% endfor %}
-                </select>
-            </div>
+            {% ui_select model="calendarFilters.status" options=status_choices onchange="reloadCalendar()" placeholder="All Posts" %}
 
             <!-- Channels filter (multi-select) -->
             {% include "calendar/partials/_channel_multiselect.html" with model="calendarFilters.channels" onchange="reloadCalendar()" accounts=social_accounts %}
 
             <!-- Tags filter -->
-            <div class="relative flex-shrink-0">
-                <svg class="cal-filter-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"/></svg>
-                <select class="cal-filter-select has-icon" name="tag" x-model="calendarFilters.tag" @change="reloadCalendar()">
-                    <option value="">Tags</option>
-                    {% for tag in all_tags %}
-                    <option value="{{ tag }}" {% if tag in active_filters.tags %}selected{% endif %}>#{{ tag }}</option>
-                    {% endfor %}
-                </select>
-            </div>
+            {% ui_select model="calendarFilters.tag" options=all_tags onchange="reloadCalendar()" placeholder="Tags" %}
 
             <!-- Timezone -->
             <div class="relative flex-shrink-0">

--- a/templates/calendar/partials/publish_drafts.html
+++ b/templates/calendar/partials/publish_drafts.html
@@ -10,6 +10,7 @@ Shows all draft platform posts in a table. Loaded via HTMX into #tab-content.
     <table class="w-full">
         <thead>
             <tr class="border-b border-stone-200 text-left">
+                <th class="pl-4 w-8"></th>
                 <th class="px-4 py-3 text-xs font-semibold text-stone-400 uppercase tracking-wider">Media</th>
                 <th class="px-4 py-3 text-xs font-semibold text-stone-400 uppercase tracking-wider">Caption</th>
                 <th class="px-4 py-3 text-xs font-semibold text-stone-400 uppercase tracking-wider">Platform</th>
@@ -22,6 +23,9 @@ Shows all draft platform posts in a table. Loaded via HTMX into #tab-content.
             {% for pp in platform_posts %}
             <tr class="border-b border-stone-100 hover:bg-stone-50 transition-colors duration-100 cursor-pointer"
                 @click="window.location='{% url 'composer:compose_edit' workspace_id=workspace.id post_id=pp.post_id %}?account={{ pp.social_account_id }}'">
+                <td class="pl-4 pr-1 py-3" @click.stop>
+                    {% include "calendar/partials/_select_checkbox.html" with pp_id=pp.id extra_class="row-select-box" %}
+                </td>
                 <td class="px-4 py-3">
                     {% with first_att=pp.post.media_attachments.all.0 %}
                     {% if first_att %}

--- a/templates/calendar/partials/publish_drafts.html
+++ b/templates/calendar/partials/publish_drafts.html
@@ -1,3 +1,4 @@
+{% if render_tab_counts_oob %}{% include "calendar/partials/_tab_counts_oob.html" %}{% endif %}
 {% comment %}
 Drafts tab partial for the Publish page.
 Shows all draft platform posts in a table. Loaded via HTMX into #tab-content.

--- a/templates/calendar/partials/publish_list_shell.html
+++ b/templates/calendar/partials/publish_list_shell.html
@@ -11,19 +11,19 @@ Tab switching is HTMX partial swaps only - no full page reload.
         <div class="flex items-center gap-1 -mb-px overflow-x-auto flex-nowrap">
             <button class="publish-tab" :class="activeTab === 'queue' && 'active'"
                     @click="switchTab('queue')">
-                Queue {% if queue_count %}<span class="inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 text-[11px] font-medium text-stone-500 bg-stone-100 rounded-full">{{ queue_count }}</span>{% endif %}
+                Queue <span id="tabcount-queue">{% include "calendar/partials/_tab_count_badge.html" with count=queue_count %}</span>
             </button>
             <button class="publish-tab" :class="activeTab === 'drafts' && 'active'"
                     @click="switchTab('drafts')">
-                Drafts {% if drafts_count %}<span class="inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 text-[11px] font-medium text-stone-500 bg-stone-100 rounded-full">{{ drafts_count }}</span>{% endif %}
+                Drafts <span id="tabcount-drafts">{% include "calendar/partials/_tab_count_badge.html" with count=drafts_count %}</span>
             </button>
             <button class="publish-tab" :class="activeTab === 'approvals' && 'active'"
                     @click="switchTab('approvals')">
-                Approvals {% if approvals_count %}<span class="inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 text-[11px] font-medium text-stone-500 bg-stone-100 rounded-full">{{ approvals_count }}</span>{% endif %}
+                Approvals <span id="tabcount-approvals">{% include "calendar/partials/_tab_count_badge.html" with count=approvals_count %}</span>
             </button>
             <button class="publish-tab" :class="activeTab === 'sent' && 'active'"
                     @click="switchTab('sent')">
-                Sent {% if sent_count %}<span class="inline-flex items-center justify-center min-w-[20px] h-5 px-1.5 text-[11px] font-medium text-stone-500 bg-stone-100 rounded-full">{{ sent_count }}</span>{% endif %}
+                Sent <span id="tabcount-sent">{% include "calendar/partials/_tab_count_badge.html" with count=sent_count %}</span>
             </button>
         </div>
 

--- a/templates/calendar/partials/publish_list_shell.html
+++ b/templates/calendar/partials/publish_list_shell.html
@@ -1,4 +1,4 @@
-{% comment %}
+{% load common_extras %}{% comment %}
 List mode shell for the Publish page.
 Contains tabs (Queue, Drafts, Approvals, Sent), filter dropdowns, and tab content area.
 Tab switching is HTMX partial swaps only - no full page reload.
@@ -33,15 +33,7 @@ Tab switching is HTMX partial swaps only - no full page reload.
             {% include "calendar/partials/_channel_multiselect.html" with model="selectedChannels" onchange="reloadTab()" accounts=channels_with_posts %}
 
             <!-- Tags filter -->
-            <div class="relative">
-                <svg class="publish-filter-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M7 7h.01M7 3h5c.512 0 1.024.195 1.414.586l7 7a2 2 0 010 2.828l-7 7a2 2 0 01-2.828 0l-7-7A1.994 1.994 0 013 12V7a4 4 0 014-4z"/></svg>
-                <select class="publish-filter-select has-icon" x-model="activeTag" @change="reloadTab()">
-                    <option value="">All Tags</option>
-                    {% for tag in all_tags %}
-                    <option value="{{ tag }}">#{{ tag }}</option>
-                    {% endfor %}
-                </select>
-            </div>
+            {% ui_select model="activeTag" options=all_tags onchange="reloadTab()" placeholder="All Tags" %}
 
             <!-- Timezone dropdown -->
             <div class="relative">

--- a/templates/calendar/partials/publish_list_shell.html
+++ b/templates/calendar/partials/publish_list_shell.html
@@ -36,14 +36,7 @@ Tab switching is HTMX partial swaps only - no full page reload.
             {% ui_select model="activeTag" options=all_tags onchange="reloadTab()" placeholder="All Tags" %}
 
             <!-- Timezone dropdown -->
-            <div class="relative">
-                <svg class="publish-filter-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 6v6l4 2"/></svg>
-                <select class="publish-filter-select has-icon" x-model="displayTimezone" @change="reloadTab()">
-                    {% for tz in timezone_choices %}
-                    <option value="{{ tz }}" {% if tz == display_timezone %}selected{% endif %}>{{ tz|cut:"America/"|cut:"Europe/"|cut:"Asia/"|cut:"US/"|cut:"Pacific/"|cut:"Australia/" }}{% if tz == workspace_timezone %} (workspace){% endif %}</option>
-                    {% endfor %}
-                </select>
-            </div>
+            {% ui_select model="displayTimezone" options=timezone_options onchange="reloadTab()" placeholder="Timezone" %}
         </div>
     </div>
 

--- a/templates/calendar/partials/publish_list_shell.html
+++ b/templates/calendar/partials/publish_list_shell.html
@@ -29,16 +29,8 @@ Tab switching is HTMX partial swaps only - no full page reload.
 
         <!-- Right: filter dropdowns -->
         <div class="flex items-center gap-2 pb-2 overflow-x-auto flex-shrink-0">
-            <!-- Channels filter -->
-            <div class="relative">
-                <svg class="publish-filter-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><circle cx="12" cy="12" r="4"/><path d="M16 8v5a3 3 0 006 0v-1a10 10 0 10-3.92 7.94"/></svg>
-                <select class="publish-filter-select has-icon" x-model="activeChannel" @change="reloadTab()">
-                    <option value="">All Channels</option>
-                    {% for channel in channels_with_posts %}
-                    <option value="{{ channel.id }}">{{ channel.account_name|default:channel.account_handle }} ({{ channel.get_platform_display }})</option>
-                    {% endfor %}
-                </select>
-            </div>
+            <!-- Channels filter (multi-select) -->
+            {% include "calendar/partials/_channel_multiselect.html" with model="selectedChannels" onchange="reloadTab()" accounts=channels_with_posts %}
 
             <!-- Tags filter -->
             <div class="relative">

--- a/templates/calendar/partials/publish_queue.html
+++ b/templates/calendar/partials/publish_queue.html
@@ -1,3 +1,4 @@
+{% if render_tab_counts_oob %}{% include "calendar/partials/_tab_counts_oob.html" %}{% endif %}
 {% comment %}
 Queue tab partial for the Publish page.
 Shows all scheduled platform posts grouped by date. Loaded via HTMX into #tab-content.

--- a/templates/calendar/partials/publish_queue.html
+++ b/templates/calendar/partials/publish_queue.html
@@ -18,6 +18,10 @@ Shows all scheduled platform posts grouped by date. Loaded via HTMX into #tab-co
         <div class="space-y-4">
             {% for pp in group.list %}
             <div class="flex gap-4">
+                <!-- Bulk-select checkbox -->
+                <div class="flex items-center shrink-0 pt-3">
+                    {% include "calendar/partials/_select_checkbox.html" with pp_id=pp.id extra_class="row-select-box" %}
+                </div>
                 <!-- Left: time + source -->
                 <div class="w-20 shrink-0 pt-3 text-right">
                     <div class="text-sm font-semibold text-stone-700 tabular-nums">

--- a/templates/calendar/partials/publish_sent.html
+++ b/templates/calendar/partials/publish_sent.html
@@ -1,3 +1,4 @@
+{% if render_tab_counts_oob %}{% include "calendar/partials/_tab_counts_oob.html" %}{% endif %}
 {% comment %}
 Sent tab partial for the Publish page.
 Shows all published/partially_published platform posts. Loaded via HTMX into #tab-content.

--- a/templates/calendar/partials/publish_sent.html
+++ b/templates/calendar/partials/publish_sent.html
@@ -9,6 +9,7 @@ Shows all published/partially_published platform posts. Loaded via HTMX into #ta
     <table class="w-full">
         <thead>
             <tr class="border-b border-stone-200 text-left">
+                <th class="pl-4 w-8"></th>
                 <th class="px-4 py-3 text-xs font-semibold text-stone-400 uppercase tracking-wider">Media</th>
                 <th class="px-4 py-3 text-xs font-semibold text-stone-400 uppercase tracking-wider">Status</th>
                 <th class="px-4 py-3 text-xs font-semibold text-stone-400 uppercase tracking-wider">Published</th>
@@ -21,6 +22,9 @@ Shows all published/partially_published platform posts. Loaded via HTMX into #ta
             {% for pp in platform_posts %}
             <tr class="border-b border-stone-100 hover:bg-stone-50 transition-colors duration-100 cursor-pointer"
                 @click="window.location='{% url 'composer:compose_edit' workspace_id=workspace.id post_id=pp.post_id %}?account={{ pp.social_account_id }}'">
+                <td class="pl-4 pr-1 py-3" @click.stop>
+                    {% include "calendar/partials/_select_checkbox.html" with pp_id=pp.id extra_class="row-select-box" %}
+                </td>
                 <td class="px-4 py-3">
                     {% with first_att=pp.post.media_attachments.all.0 %}
                     {% if first_att %}

--- a/templates/calendar/partials/publish_sent.html
+++ b/templates/calendar/partials/publish_sent.html
@@ -23,7 +23,8 @@ Shows all published/partially_published platform posts. Loaded via HTMX into #ta
             <tr class="border-b border-stone-100 hover:bg-stone-50 transition-colors duration-100 cursor-pointer"
                 @click="window.location='{% url 'composer:compose_edit' workspace_id=workspace.id post_id=pp.post_id %}?account={{ pp.social_account_id }}'">
                 <td class="pl-4 pr-1 py-3" @click.stop>
-                    {% include "calendar/partials/_select_checkbox.html" with pp_id=pp.id extra_class="row-select-box" %}
+                    {# published rows are protected — every bulk action skips them, so no checkbox. `failed` rows stay selectable (retry / delete). #}
+                    {% if pp.is_bulk_selectable %}{% include "calendar/partials/_select_checkbox.html" with pp_id=pp.id extra_class="row-select-box" %}{% endif %}
                 </td>
                 <td class="px-4 py-3">
                     {% with first_att=pp.post.media_attachments.all.0 %}

--- a/templates/calendar/partials/week_grid.html
+++ b/templates/calendar/partials/week_grid.html
@@ -56,6 +56,7 @@ Context: week_days, week_slots, workspace.
                class="post-chip status-{{ pp.status }}{% if pp.is_reschedulable %} is-draggable{% endif %}"
                title="{% if pp.is_reschedulable %}Move or open{% else %}Open{% endif %}"
                {% if pp.is_reschedulable %}draggable="true" data-platform-post-id="{{ pp.id }}"{% else %}draggable="false"{% endif %}>
+                {% include "calendar/partials/_select_checkbox.html" with pp_id=pp.id %}
                 <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ pp.social_account.platform }} flex-shrink-0 text-white">
                     {% include "social_accounts/partials/_platform_icon.html" with platform=pp.social_account.platform size="3" %}
                 </span>

--- a/templates/calendar/partials/week_grid.html
+++ b/templates/calendar/partials/week_grid.html
@@ -53,8 +53,9 @@ Context: week_days, week_slots, workspace.
             {% endif %}
             {% for pp in cell.posts %}
             <a href="{% url 'composer:compose_edit' workspace_id=workspace.id post_id=pp.post_id %}?account={{ pp.social_account_id }}"
-               class="post-chip status-{{ pp.status }}{% if pp.status == 'draft' or pp.status == 'approved' or pp.status == 'scheduled' %} is-draggable{% endif %}"
-               {% if pp.status == "draft" or pp.status == "approved" or pp.status == "scheduled" %}draggable="false" data-platform-post-id="{{ pp.id }}"{% endif %}>
+               class="post-chip status-{{ pp.status }}{% if pp.is_reschedulable %} is-draggable{% endif %}"
+               title="{% if pp.is_reschedulable %}Mover o abrir{% else %}Abrir{% endif %}"
+               {% if pp.is_reschedulable %}draggable="false" data-platform-post-id="{{ pp.id }}"{% endif %}>
                 <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ pp.social_account.platform }} flex-shrink-0 text-white">
                     {% include "social_accounts/partials/_platform_icon.html" with platform=pp.social_account.platform size="3" %}
                 </span>

--- a/templates/calendar/partials/week_grid.html
+++ b/templates/calendar/partials/week_grid.html
@@ -54,8 +54,8 @@ Context: week_days, week_slots, workspace.
             {% for pp in cell.posts %}
             <a href="{% url 'composer:compose_edit' workspace_id=workspace.id post_id=pp.post_id %}?account={{ pp.social_account_id }}"
                class="post-chip status-{{ pp.status }}{% if pp.is_reschedulable %} is-draggable{% endif %}"
-               title="{% if pp.is_reschedulable %}Mover o abrir{% else %}Abrir{% endif %}"
-               {% if pp.is_reschedulable %}draggable="false" data-platform-post-id="{{ pp.id }}"{% endif %}>
+               title="{% if pp.is_reschedulable %}Move or open{% else %}Open{% endif %}"
+               {% if pp.is_reschedulable %}draggable="true" data-platform-post-id="{{ pp.id }}"{% else %}draggable="false"{% endif %}>
                 <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ pp.social_account.platform }} flex-shrink-0 text-white">
                     {% include "social_accounts/partials/_platform_icon.html" with platform=pp.social_account.platform size="3" %}
                 </span>

--- a/templates/calendar/partials/week_grid.html
+++ b/templates/calendar/partials/week_grid.html
@@ -22,9 +22,8 @@ Context: week_days, week_slots, workspace.
             <span class="text-[11px] font-medium text-stone-400 tabular-nums">{{ hour }}:00</span>
         </div>
         {% for cell in day_cells %}
-        <div class="border-r border-stone-100 last:border-r-0 p-1 cal-add-cell {% if cell.posts or cell.slots %}has-posts{% endif %} {% if cell.day == today %}bg-orange-50/30{% endif %}"
-             @dragover.prevent="allowDrop($event)"
-             @drop="dropOnSlot($event, '{{ cell.compose_date }}', '{{ cell.compose_time }}')">
+        <div class="border-r border-stone-100 last:border-r-0 p-1 cal-add-cell cal-drop {% if cell.posts or cell.slots %}has-posts{% endif %} {% if cell.day == today %}bg-orange-50/30{% endif %}"
+             data-date="{{ cell.compose_date }}" data-time="{{ cell.compose_time }}">
             {% if cell.day > today or cell.day == today and hour >= current_hour %}
             <a href="{% url 'composer:compose' workspace_id=workspace.id %}?scheduled_date={{ cell.compose_date }}&scheduled_time={{ cell.compose_time }}" class="cal-add-btn" title="Create post">
                 <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="3"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4"/></svg>
@@ -54,11 +53,8 @@ Context: week_days, week_slots, workspace.
             {% endif %}
             {% for pp in cell.posts %}
             <a href="{% url 'composer:compose_edit' workspace_id=workspace.id post_id=pp.post_id %}?account={{ pp.social_account_id }}"
-               class="post-chip status-{{ pp.status }}"
-               {% if pp.status == "draft" or pp.status == "approved" or pp.status == "scheduled" %}draggable="true"
-               data-platform-post-id="{{ pp.id }}"
-               @dragstart="startDrag($event, '{{ pp.id }}')"
-               @dragend="endDrag($event)"{% endif %}>
+               class="post-chip status-{{ pp.status }}{% if pp.status == 'draft' or pp.status == 'approved' or pp.status == 'scheduled' %} is-draggable{% endif %}"
+               {% if pp.status == "draft" or pp.status == "approved" or pp.status == "scheduled" %}draggable="false" data-platform-post-id="{{ pp.id }}"{% endif %}>
                 <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ pp.social_account.platform }} flex-shrink-0 text-white">
                     {% include "social_accounts/partials/_platform_icon.html" with platform=pp.social_account.platform size="3" %}
                 </span>

--- a/templates/calendar/partials/week_grid.html
+++ b/templates/calendar/partials/week_grid.html
@@ -56,7 +56,7 @@ Context: week_days, week_slots, workspace.
                class="post-chip status-{{ pp.status }}{% if pp.is_reschedulable %} is-draggable{% endif %}"
                title="{% if pp.is_reschedulable %}Move or open{% else %}Open{% endif %}"
                {% if pp.is_reschedulable %}draggable="true" data-platform-post-id="{{ pp.id }}"{% else %}draggable="false"{% endif %}>
-                {% include "calendar/partials/_select_checkbox.html" with pp_id=pp.id %}
+                {% if pp.is_bulk_selectable %}{% include "calendar/partials/_select_checkbox.html" with pp_id=pp.id %}{% endif %}
                 <span class="w-4 h-4 rounded flex items-center justify-center pi-{{ pp.social_account.platform }} flex-shrink-0 text-white">
                     {% include "social_accounts/partials/_platform_icon.html" with platform=pp.social_account.platform size="3" %}
                 </span>

--- a/templates/components/ui_select.html
+++ b/templates/components/ui_select.html
@@ -1,0 +1,51 @@
+{% load common_extras %}{% comment %}
+Reusable styled select dropdown — see the `ui_select` inclusion tag docstring.
+Bind `model` to a property in the enclosing x-data scope (array if `multiple`,
+else string). The panel is position:fixed so an overflow toolbar can't clip it.
+
+Expressions that reference `model` live in Alpine DIRECTIVES (x-text / :class /
+@click), which resolve via the scope chain — NOT in x-data methods, whose plain
+JS body can't see the parent scope.
+{% endcomment %}
+<div class="relative flex-shrink-0"
+     x-data="{
+        open: false, top: 0, left: 0,
+        opts: {{ options_js|json_attr }},
+        uiLabel(v){ if (!v) return '{{ placeholder|escapejs }}'; const o = this.opts.find(o => String(o.value) === String(v)); return o ? o.label : '{{ placeholder|escapejs }}'; },
+        uiToggle(e){ if (this.open) { this.open = false; return; } const r = e.currentTarget.getBoundingClientRect(); this.top = r.bottom + 4; this.left = Math.min(r.left, window.innerWidth - 236); this.open = true; }
+     }"
+     @click.away="open = false" @keydown.escape="open = false" @scroll.window="open = false">
+    <button type="button" @click="uiToggle($event)"
+            class="cal-filter-select flex items-center gap-1 whitespace-nowrap"
+            :class="{% if multiple %}{{ model }}.length{% else %}{{ model }}{% endif %} && 'border-orange-300 text-orange-700'">
+        <span x-text="{% if multiple %}{{ model }}.length ? {{ model }}.length + ' selected' : '{{ placeholder|escapejs }}'{% else %}uiLabel({{ model }}){% endif %}"></span>
+        <svg class="w-3 h-3 text-stone-400 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
+    </button>
+    <div x-show="open" x-cloak x-transition.opacity
+         :style="`top:${top}px; left:${left}px;`"
+         class="fixed z-50 w-56 max-h-72 overflow-y-auto bg-white rounded-lg shadow-lg ring-1 ring-stone-200 py-1">
+        <button type="button"
+                @click="{% if multiple %}{{ model }} = []{% else %}{{ model }} = ''; open = false{% endif %}; {{ onchange }}"
+                class="w-full text-left px-3 py-1.5 text-xs font-semibold hover:bg-stone-50 border-b border-stone-100"
+                :class="{% if multiple %}!{{ model }}.length{% else %}!{{ model }}{% endif %} ? 'text-orange-600' : 'text-stone-500'">
+            {{ placeholder }} — all
+        </button>
+        {% for opt in options %}
+        {% if multiple %}
+        <label class="flex items-center gap-2 px-3 py-1.5 text-xs text-stone-700 hover:bg-stone-50 cursor-pointer">
+            <input type="checkbox" value="{{ opt.value }}" x-model="{{ model }}" @change="{{ onchange }}"
+                   class="rounded border-stone-300 text-orange-500 focus:ring-orange-400">
+            {% if opt.icon %}<span class="w-4 h-4 rounded flex items-center justify-center pi-{{ opt.icon }} flex-shrink-0 text-white">{% include "social_accounts/partials/_platform_icon.html" with platform=opt.icon size="3" %}</span>{% endif %}
+            <span class="truncate">{{ opt.label }}</span>
+        </label>
+        {% else %}
+        <button type="button" @click="{{ model }} = '{{ opt.value|escapejs }}'; open = false; {{ onchange }}"
+                class="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-stone-700 hover:bg-stone-50 text-left"
+                :class="String({{ model }}) === '{{ opt.value|escapejs }}' && 'bg-orange-50 text-orange-700'">
+            {% if opt.icon %}<span class="w-4 h-4 rounded flex items-center justify-center pi-{{ opt.icon }} flex-shrink-0 text-white">{% include "social_accounts/partials/_platform_icon.html" with platform=opt.icon size="3" %}</span>{% endif %}
+            <span class="truncate">{{ opt.label }}</span>
+        </button>
+        {% endif %}
+        {% endfor %}
+    </div>
+</div>

--- a/templates/components/ui_select.html
+++ b/templates/components/ui_select.html
@@ -21,7 +21,7 @@ JS body can't see the parent scope.
         <span x-text="{% if multiple %}{{ model }}.length ? {{ model }}.length + ' selected' : '{{ placeholder|escapejs }}'{% else %}uiLabel({{ model }}){% endif %}"></span>
         <svg class="w-3 h-3 text-stone-400 ml-1" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7"/></svg>
     </button>
-    <div x-show="open" x-cloak x-transition.opacity
+    <div x-show="open" x-cloak
          :style="`top:${top}px; left:${left}px;`"
          class="fixed z-50 w-56 max-h-72 overflow-y-auto bg-white rounded-lg shadow-lg ring-1 ring-stone-200 py-1">
         <button type="button"


### PR DESCRIPTION
## Summary

A batch of Publish-page UX improvements, each verified locally against a seeded
workspace (Django + HTMX + Alpine, no new backend deps beyond a pinned SortableJS CDN):

- **Tab counts stay in sync** — Queue/Drafts/Approvals/Sent badges refresh via
  `hx-swap-oob` on any tab load instead of drifting until a full reload.
- **"Today" is a no-op** when the current month/week/day already contains today.
- **Smooth drag-and-drop rescheduling** (SortableJS, native drag image) across
  month/week/day — the previous hand-rolled native DnD fought the chip's link.
  Locked chips (published/publishing/on_hold/rejected) aren't draggable;
  dragging a failed chip retries it. Hidden placeholder + target-cell highlight;
  drag verified end-to-end (drop → reschedule persisted).
- **Perf**: prefetch chip media to kill an N+1 on every grid render (32→2
  queries for 31 chips).
- **Multi-select channels filter** (`channel__in`) across calendar chips, list
  tabs, and the approvals subquery.
- **`ui_select`** — a reusable single/multiple dropdown component (`{% ui_select %}`
  tag + partial), wired into the status and tags filters. `position: fixed` panel
  so an overflow toolbar can't clip it.
- **Bulk selection** — checkboxes on calendar chips and list rows backed by a
  global Alpine store (survives HTMX swaps), with a floating centered action bar
  (Draft / Publish / Delete). New `calendar:bulk_platform_action` endpoint honours
  edit RBAC and never touches published/publishing rows.

## Testing

Calendar tests (58) + composer tests pass; `ruff`/`check` clean. Each feature
was exercised in a browser: DnD reschedule, multi-select filtering (24→6→12
chips), ui_select filter, and bulk draft/delete/publish in both calendar and
list views (counts update, protected rows skipped).

Happy to split this into smaller PRs if you'd prefer to land them piecemeal.