### PR TITLE
feat(mcp): add list_posts tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,6 +630,7 @@ The MCP server lives at `POST {APP_URL}/api/v1/mcp` and speaks JSON-RPC 2.0 over
 | `schedule_post` | Create and schedule a post in one step | `create_posts` + `publish_directly` |
 | `schedule_draft` | Schedule an existing draft | `create_posts` + `publish_directly` |
 | `get_post` | Retrieve a post with aggregate status and per-platform state | — |
+| `list_posts` | List posts newest-first, with optional status filter and cursor pagination | — |
 | `cancel_post` | Revert a scheduled post back to draft | `create_posts` |
 | `search_media` | Find media assets by query, type, tags, or folder | — |
 | `get_media` | Retrieve a single media asset by ID | — |

--- a/apps/api/pagination.py
+++ b/apps/api/pagination.py
@@ -1,0 +1,44 @@
+"""Opaque offset cursors shared by the REST list endpoints and the MCP list tools.
+
+We encode an integer offset rather than a composite ``(value, id)`` tuple
+because cursor stability across a reorder isn't a stated requirement, and
+offset paginates correctly as long as the caller's ``order_by`` carries a
+stable ``id`` tiebreak.
+
+``decode_offset_cursor`` raises ``ValueError`` on a malformed cursor so each
+surface can map it onto its own error shape — ``HttpError(422)`` for REST,
+``JsonRpcError(INVALID_PARAMS)`` for MCP — without this module importing
+either framework.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+
+def encode_offset_cursor(offset: int) -> str:
+    return base64.urlsafe_b64encode(json.dumps({"o": offset}).encode()).rstrip(b"=").decode()
+
+
+def decode_offset_cursor(cursor: str | None) -> int:
+    """Return the offset encoded in ``cursor``; 0 when there is no cursor.
+
+    Raises ``ValueError`` if the cursor isn't a base64 JSON object with a
+    non-negative integer ``o``.
+    """
+    if not cursor:
+        return 0
+    if not isinstance(cursor, str):
+        raise ValueError("Invalid cursor.")
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(cursor.encode() + b"==").decode())
+    except (ValueError, TypeError) as exc:
+        raise ValueError("Invalid cursor.") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("Invalid cursor.")
+    offset = payload.get("o", 0)
+    # ``bool`` is an ``int`` subclass — reject it so ``{"o": true}`` isn't offset 1.
+    if not isinstance(offset, int) or isinstance(offset, bool) or offset < 0:
+        raise ValueError("Invalid cursor.")
+    return offset

--- a/apps/api/routers/media.py
+++ b/apps/api/routers/media.py
@@ -16,8 +16,6 @@ that hasn't finished async processing.
 
 from __future__ import annotations
 
-import base64
-import json
 import uuid
 
 from django.core.exceptions import ValidationError
@@ -35,6 +33,7 @@ from apps.api.middleware import (
     log_audit_entry,
     release_idempotent_claim,
 )
+from apps.api.pagination import decode_offset_cursor, encode_offset_cursor
 from apps.api.schemas import MediaAssetListResponse, MediaAssetResponse
 from apps.media_library.models import MediaAsset
 from apps.media_library.services import create_asset
@@ -231,18 +230,12 @@ _DEFAULT_LIMIT = 20
 _MAX_LIMIT = 100
 
 
-def _decode_cursor(cursor: str | None) -> dict | None:
-    if not cursor:
-        return None
+def _decode_cursor(cursor: str | None) -> int:
+    """REST-facing wrapper: a bad cursor is a 422, not a 500."""
     try:
-        raw = base64.urlsafe_b64decode(cursor.encode() + b"==")
-        return json.loads(raw.decode())
-    except (ValueError, json.JSONDecodeError) as exc:
+        return decode_offset_cursor(cursor)
+    except ValueError as exc:
         raise HttpError(422, "Invalid cursor.") from exc
-
-
-def _encode_cursor(payload: dict) -> str:
-    return base64.urlsafe_b64encode(json.dumps(payload, default=str).encode()).rstrip(b"=").decode()
 
 
 @router.get(
@@ -296,12 +289,9 @@ def list_media(
 
     qs = qs.order_by(order_by, "id")
 
-    # Simple offset cursor — we encode an integer offset rather than a
-    # composite (value, id) tuple because cursor stability across reorder
-    # isn't a stated requirement and offset paginates correctly with the
-    # stable ``order_by(..., "id")`` tiebreak.
-    cursor_payload = _decode_cursor(cursor)
-    offset = int(cursor_payload.get("o", 0)) if cursor_payload else 0
+    # Simple offset cursor (see ``apps.api.pagination``) — correct here because
+    # the ``order_by(..., "id")`` tiebreak above makes the ordering stable.
+    offset = _decode_cursor(cursor)
     items_qs = qs[offset : offset + limit + 1]
     rows = list(items_qs)
     has_more = len(rows) > limit
@@ -309,7 +299,7 @@ def list_media(
 
     body = MediaAssetListResponse(
         items=[MediaAssetResponse.from_asset(a, last_used_at=getattr(a, "last_used_at", None)) for a in rows],
-        next_cursor=_encode_cursor({"o": offset + limit}) if has_more else None,
+        next_cursor=encode_offset_cursor(offset + limit) if has_more else None,
         limit=limit,
     )
     log_audit_entry(request, action="media.read.200", target_id=None, status_code=200)

--- a/apps/api/schemas.py
+++ b/apps/api/schemas.py
@@ -304,9 +304,15 @@ class PostResponse(Schema):
         It defaults to ``False`` so a new, unconverted call site fails closed —
         redacted — rather than leaking notes.
         """
-        platform_posts = [
-            PlatformPostSummary.from_platform_post(pp) for pp in post.platform_posts.select_related("social_account")
-        ]
+        # ``.select_related()`` builds a *new* queryset, which discards any
+        # prefetch cache and re-queries once per post — an N+1 on list views.
+        # Use the cache when the caller prefetched, and fall back otherwise so
+        # an un-prefetched single fetch still avoids a query per child.
+        if "platform_posts" in getattr(post, "_prefetched_objects_cache", {}):
+            children = post.platform_posts.all()
+        else:
+            children = post.platform_posts.select_related("social_account")
+        platform_posts = [PlatformPostSummary.from_platform_post(pp) for pp in children]
         return cls(
             id=post.id,
             workspace_id=post.workspace_id,

--- a/apps/api/tests/test_pagination.py
+++ b/apps/api/tests/test_pagination.py
@@ -1,0 +1,67 @@
+"""Unit tests for the opaque offset cursors shared by REST and MCP.
+
+Both surfaces mint and accept the same cursor, so the parsing rules live
+here rather than being re-asserted through each endpoint's tests. A cursor
+is caller-supplied and trivially forgeable (base64 of plain JSON), so every
+malformed shape must land on ``ValueError`` — the callers turn that into a
+422 / INVALID_PARAMS, and anything unhandled would surface as a 500.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+
+from apps.api.pagination import decode_offset_cursor, encode_offset_cursor
+
+
+def _cursor_for(payload) -> str:
+    return base64.urlsafe_b64encode(json.dumps(payload).encode()).rstrip(b"=").decode()
+
+
+class TestOffsetCursorRoundTrip:
+    @pytest.mark.parametrize("offset", [0, 1, 20, 50, 999, 10_000])
+    def test_round_trips(self, offset):
+        assert decode_offset_cursor(encode_offset_cursor(offset)) == offset
+
+    def test_absent_cursor_is_offset_zero(self):
+        assert decode_offset_cursor(None) == 0
+        assert decode_offset_cursor("") == 0
+
+
+class TestOffsetCursorRejects:
+    @pytest.mark.parametrize(
+        "cursor",
+        [
+            "not-a-cursor",  # not base64
+            "!!!!",  # base64 alphabet violation
+            _cursor_for([1, 2, 3]),  # JSON, but not an object
+            _cursor_for("5"),  # JSON string payload
+            _cursor_for({"o": -1}),  # negative offset would slice backwards
+            _cursor_for({"o": "5"}),  # string offset
+            _cursor_for({"o": 1.5}),  # non-integer offset
+            _cursor_for({"o": None}),
+        ],
+    )
+    def test_malformed_cursor_raises_value_error(self, cursor):
+        with pytest.raises(ValueError):
+            decode_offset_cursor(cursor)
+
+    def test_boolean_offset_is_rejected(self):
+        """``bool`` is an ``int`` subclass — without the explicit guard,
+        ``{"o": true}`` would silently page from offset 1.
+        """
+        with pytest.raises(ValueError):
+            decode_offset_cursor(_cursor_for({"o": True}))
+
+    def test_non_string_cursor_is_rejected(self):
+        """MCP passes tool arguments through unvalidated by type in the
+        handler-direct path; an int cursor must not reach ``.encode()``.
+        """
+        with pytest.raises(ValueError):
+            decode_offset_cursor(5)  # type: ignore[arg-type]
+
+    def test_payload_without_offset_key_defaults_to_zero(self):
+        assert decode_offset_cursor(_cursor_for({})) == 0

--- a/apps/mcp/handlers.py
+++ b/apps/mcp/handlers.py
@@ -140,6 +140,11 @@ def _visible_posts_qs(api_key):
     paginate on it without scanning rows they may not see.
     """
     allowed = [sa.id for sa in api_key.social_accounts.all()]
+    # A key can end up with an empty allowlist at runtime (its last account was
+    # disconnected/deleted). Short-circuit rather than leaning on Django folding
+    # ``__in=[]`` inside an ``exclude`` into a no-op: fail closed explicitly.
+    if not allowed:
+        return Post.objects.none()
     children = PlatformPost.objects.filter(post_id=OuterRef("pk"))
     return (
         Post.objects.filter(workspace_id=api_key.workspace_id)
@@ -427,8 +432,10 @@ def _list_posts(args: dict, context: dict[str, Any]) -> dict:
     if status is not None and status not in PlatformPost.Status.values:
         raise JsonRpcError(INVALID_PARAMS, f"status must be one of {', '.join(PlatformPost.Status.values)}")
 
+    # ``or`` would swallow an explicit 0 as "unset" and hand back the default.
+    raw_limit = args.get("limit")
     try:
-        limit = int(args.get("limit") or _MCP_POST_LIMIT_DEFAULT)
+        limit = _MCP_POST_LIMIT_DEFAULT if raw_limit is None else int(raw_limit)
     except (TypeError, ValueError) as exc:
         raise JsonRpcError(INVALID_PARAMS, f"limit must be an integer between 1 and {_MCP_POST_LIMIT_MAX}") from exc
     if limit < 1 or limit > _MCP_POST_LIMIT_MAX:

--- a/apps/mcp/handlers.py
+++ b/apps/mcp/handlers.py
@@ -401,6 +401,71 @@ register_tool(
 
 
 # ---------------------------------------------------------------------------
+# Tool: list_posts
+# ---------------------------------------------------------------------------
+
+
+def _list_posts(args: dict, context: dict[str, Any]) -> dict:
+    api_key = context["api_key"]
+    allowed = {sa.id for sa in api_key.social_accounts.all()}
+
+    qs = (
+        Post.objects.filter(workspace_id=api_key.workspace_id)
+        .prefetch_related("platform_posts__social_account")
+        .order_by("-scheduled_at", "-created_at")
+    )
+    status = args.get("status")
+    if status:
+        qs = qs.filter(platform_posts__status=status).distinct()
+
+    try:
+        limit = min(max(int(args.get("limit", 50)), 1), 100)
+    except (TypeError, ValueError):
+        limit = 50
+
+    posts: list[dict] = []
+    # Bound the scan so a huge workspace can't blow up the response; the
+    # allowlist filter runs in Python because it needs every child row.
+    for post in qs[:500]:
+        pp_account_ids = {pp.social_account_id for pp in post.platform_posts.all()}
+        # Same visibility rule as get_post: every child must be allowlisted, so a
+        # partial-scope key never learns about sibling accounts.
+        if not pp_account_ids or not pp_account_ids.issubset(allowed):
+            continue
+        posts.append(_serialize_post(post, context))
+        if len(posts) >= limit:
+            break
+    return _wrap_text({"posts": posts, "count": len(posts)})
+
+
+register_tool(
+    Tool(
+        name="list_posts",
+        description=(
+            "List posts in this API key's workspace, newest first. Fills the gap left by get_post "
+            "(which needs an id you may not have yet). Each item has the same shape as get_post "
+            "(aggregate status + per-platform child state). Only posts whose every platform target is "
+            "in the key's allowlist are returned. Optional `status` filter "
+            "(draft, pending_review, pending_client, approved, scheduled, publishing, published, failed, "
+            "on_hold) and `limit` (default 50, max 100)."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "description": "Optional per-platform status to filter by.",
+                },
+                "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
+            },
+            "additionalProperties": False,
+        },
+        handler=_list_posts,
+    )
+)
+
+
+# ---------------------------------------------------------------------------
 # Tool: cancel_post
 # ---------------------------------------------------------------------------
 

--- a/apps/mcp/handlers.py
+++ b/apps/mcp/handlers.py
@@ -19,12 +19,14 @@ from datetime import UTC, datetime
 from typing import Any
 from uuid import UUID
 
+from django.db.models import Exists, OuterRef
 from ninja.errors import HttpError
 
 from apps.analytics.api_builders import build_account_analytics, build_post_analytics
 from apps.api.limits import check_platform_quota
+from apps.api.pagination import decode_offset_cursor, encode_offset_cursor
 from apps.api.schemas import PostResponse
-from apps.composer.models import Post
+from apps.composer.models import PlatformPost, Post
 from apps.composer.services import create_post, transition_platform_post
 from apps.mcp.protocol import INVALID_PARAMS, JsonRpcError
 from apps.mcp.tools import Tool, register_tool
@@ -128,26 +130,35 @@ def _serialize_post(post: Post, context: dict[str, Any]) -> dict:
     )
 
 
+def _visible_posts_qs(api_key):
+    """Posts this API key may see, as a queryset.
+
+    Same rule as REST's ``_get_workspace_post``: in the key's workspace,
+    with at least one platform target, and *every* target allowlisted — so a
+    partial-scope key never learns about siblings. Expressed in SQL (rather
+    than filtering child rows in Python) so callers can order, filter and
+    paginate on it without scanning rows they may not see.
+    """
+    allowed = [sa.id for sa in api_key.social_accounts.all()]
+    children = PlatformPost.objects.filter(post_id=OuterRef("pk"))
+    return (
+        Post.objects.filter(workspace_id=api_key.workspace_id)
+        .filter(Exists(children))
+        .exclude(Exists(children.exclude(social_account_id__in=allowed)))
+    )
+
+
 def _get_post_for_key(api_key, post_id_str: str) -> Post:
     """Allowlist-respecting Post fetch shared by ``get_post`` / ``cancel_post``.
 
-    Same rule as REST's ``_get_workspace_post``: must be in the key's
-    workspace AND every PlatformPost child must target an allowlisted
-    account. Anything else looks like "not found" to the client, so a
-    partial-scope key learns nothing about siblings.
+    Out-of-scope and nonexistent both surface as "Post not found" — the API
+    never reveals which is which.
     """
     post_id = _parse_uuid(post_id_str, "post_id")
     try:
-        post = Post.objects.prefetch_related("platform_posts__social_account").get(
-            id=post_id, workspace_id=api_key.workspace_id
-        )
+        return _visible_posts_qs(api_key).prefetch_related("platform_posts__social_account").get(id=post_id)
     except Post.DoesNotExist as exc:
         raise JsonRpcError(INVALID_PARAMS, "Post not found") from exc
-    allowed = {sa.id for sa in api_key.social_accounts.all()}
-    pp_account_ids = {pp.social_account_id for pp in post.platform_posts.all()}
-    if not pp_account_ids or not pp_account_ids.issubset(allowed):
-        raise JsonRpcError(INVALID_PARAMS, "Post not found")
-    return post
 
 
 def _parse_iso_datetime(value: Any, field_name: str) -> datetime:
@@ -405,58 +416,79 @@ register_tool(
 # ---------------------------------------------------------------------------
 
 
+_MCP_POST_LIMIT_DEFAULT = 50
+_MCP_POST_LIMIT_MAX = 100
+
+
 def _list_posts(args: dict, context: dict[str, Any]) -> dict:
     api_key = context["api_key"]
-    allowed = {sa.id for sa in api_key.social_accounts.all()}
 
-    qs = (
-        Post.objects.filter(workspace_id=api_key.workspace_id)
-        .prefetch_related("platform_posts__social_account")
-        .order_by("-scheduled_at", "-created_at")
-    )
     status = args.get("status")
-    if status:
-        qs = qs.filter(platform_posts__status=status).distinct()
+    if status is not None and status not in PlatformPost.Status.values:
+        raise JsonRpcError(INVALID_PARAMS, f"status must be one of {', '.join(PlatformPost.Status.values)}")
 
     try:
-        limit = min(max(int(args.get("limit", 50)), 1), 100)
-    except (TypeError, ValueError):
-        limit = 50
+        limit = int(args.get("limit") or _MCP_POST_LIMIT_DEFAULT)
+    except (TypeError, ValueError) as exc:
+        raise JsonRpcError(INVALID_PARAMS, f"limit must be an integer between 1 and {_MCP_POST_LIMIT_MAX}") from exc
+    if limit < 1 or limit > _MCP_POST_LIMIT_MAX:
+        raise JsonRpcError(INVALID_PARAMS, f"limit must be between 1 and {_MCP_POST_LIMIT_MAX}")
 
-    posts: list[dict] = []
-    # Bound the scan so a huge workspace can't blow up the response; the
-    # allowlist filter runs in Python because it needs every child row.
-    for post in qs[:500]:
-        pp_account_ids = {pp.social_account_id for pp in post.platform_posts.all()}
-        # Same visibility rule as get_post: every child must be allowlisted, so a
-        # partial-scope key never learns about sibling accounts.
-        if not pp_account_ids or not pp_account_ids.issubset(allowed):
-            continue
-        posts.append(_serialize_post(post, context))
-        if len(posts) >= limit:
-            break
-    return _wrap_text({"posts": posts, "count": len(posts)})
+    try:
+        offset = decode_offset_cursor(args.get("cursor"))
+    except ValueError as exc:
+        raise JsonRpcError(INVALID_PARAMS, "cursor is not a valid pagination cursor") from exc
+
+    # The allowlist lives in the queryset (see ``_visible_posts_qs``), so paging
+    # is over posts this key can actually see — no scan cap, nothing silently
+    # dropped. ``id`` tiebreaks ``-created_at`` to keep offsets stable.
+    qs = _visible_posts_qs(api_key).prefetch_related("platform_posts__social_account")
+    if status:
+        qs = qs.filter(Exists(PlatformPost.objects.filter(post_id=OuterRef("pk"), status=status)))
+    qs = qs.order_by("-created_at", "id")
+
+    # limit + 1 probes for a next page without a second COUNT query.
+    rows = list(qs[offset : offset + limit + 1])
+    has_more = len(rows) > limit
+    rows = rows[:limit]
+    return _wrap_text(
+        {
+            "posts": [_serialize_post(post, context) for post in rows],
+            "limit": limit,
+            "next_cursor": encode_offset_cursor(offset + limit) if has_more else None,
+        }
+    )
 
 
 register_tool(
     Tool(
         name="list_posts",
         description=(
-            "List posts in this API key's workspace, newest first. Fills the gap left by get_post "
-            "(which needs an id you may not have yet). Each item has the same shape as get_post "
-            "(aggregate status + per-platform child state). Only posts whose every platform target is "
-            "in the key's allowlist are returned. Optional `status` filter "
-            "(draft, pending_review, pending_client, approved, scheduled, publishing, published, failed, "
-            "on_hold) and `limit` (default 50, max 100)."
+            "List posts in this API key's workspace, newest first (by creation time). Fills the gap "
+            "left by get_post (which needs an id you may not have yet). Each item has the same shape "
+            "as get_post (aggregate status + per-platform child state). Only posts whose every "
+            "platform target is in the key's allowlist are returned. Optional `status` filter and "
+            "`limit` (default 50, max 100). When more posts remain, `next_cursor` is non-null — pass "
+            "it back as `cursor` for the next page; a null `next_cursor` means you have them all."
         ),
         input_schema={
             "type": "object",
             "properties": {
                 "status": {
                     "type": "string",
-                    "description": "Optional per-platform status to filter by.",
+                    "enum": list(PlatformPost.Status.values),
+                    "description": "Optional per-platform status; a post matches if any target has it.",
                 },
-                "limit": {"type": "integer", "minimum": 1, "maximum": 100, "default": 50},
+                "limit": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": _MCP_POST_LIMIT_MAX,
+                    "default": _MCP_POST_LIMIT_DEFAULT,
+                },
+                "cursor": {
+                    "type": "string",
+                    "description": "Opaque cursor from a previous call's `next_cursor`.",
+                },
             },
             "additionalProperties": False,
         },

--- a/apps/mcp/tests/test_transport.py
+++ b/apps/mcp/tests/test_transport.py
@@ -519,6 +519,41 @@ class TestListPostsTool:
         assert ids1.isdisjoint(ids2)
         assert ids1 | ids2 == set(created)
 
+    def test_foreign_posts_do_not_consume_page_slots(
+        self, client_with_token, social_account, second_account, user, workspace
+    ):
+        """The allowlist is applied in SQL, so out-of-scope posts never eat a
+        slot in a page. Under the old post-query filtering, a foreign post
+        interleaved with own posts returned a short page plus a cursor.
+        """
+        own_ids = []
+        for i in range(4):
+            mine = Post.objects.create(workspace=workspace, author=user, caption=f"mine {i}")
+            PlatformPost.objects.create(post=mine, social_account=social_account, status="draft")
+            own_ids.append(str(mine.id))
+            theirs = Post.objects.create(workspace=workspace, author=user, caption=f"theirs {i}")
+            PlatformPost.objects.create(post=theirs, social_account=second_account, status="draft")
+
+        seen, cursor = [], None
+        for _ in range(4):  # bounded so a broken cursor can't loop forever
+            page = _list_posts(client_with_token, limit=2, **({"cursor": cursor} if cursor else {}))
+            assert len(page["posts"]) == 2  # never short despite the foreign rows
+            seen.extend(p["id"] for p in page["posts"])
+            cursor = page["next_cursor"]
+            if cursor is None:
+                break
+
+        assert cursor is None
+        assert sorted(seen) == sorted(own_ids)
+
+    def test_key_with_empty_allowlist_sees_nothing(self, client_with_token, issued_key, own_post):
+        """A key whose last allowlisted account was disconnected must fail
+        closed — not fall through to the whole workspace.
+        """
+        assert len(_list_posts(client_with_token)["posts"]) == 1
+        issued_key.api_key.social_accounts.clear()
+        assert _list_posts(client_with_token)["posts"] == []
+
     def test_status_filter_narrows(self, client_with_token, own_post, scheduled_post):
         inner = _list_posts(client_with_token, status="scheduled")
         assert [p["id"] for p in inner["posts"]] == [str(scheduled_post.id)]
@@ -547,12 +582,21 @@ class TestListPostsTool:
             )
         assert "status must be one of" in str(exc.value)
 
-    def test_status_accepts_every_platform_post_status(self, client_with_token):
+    def test_every_platform_post_status_is_accepted_and_filters(
+        self, client_with_token, social_account, user, workspace
+    ):
         """The schema enum must cover the full model enum — ``changes_requested``
-        and ``rejected`` were missing from the documented list.
+        and ``rejected`` were missing from the documented list — and each value
+        must actually narrow, not just be accepted.
         """
+        by_status = {}
         for value in PlatformPost.Status.values:
-            assert _list_posts(client_with_token, status=value)["posts"] == []
+            p = Post.objects.create(workspace=workspace, author=user, caption=f"{value} post")
+            PlatformPost.objects.create(post=p, social_account=social_account, status=value)
+            by_status[value] = str(p.id)
+
+        for value, post_id in by_status.items():
+            assert [p["id"] for p in _list_posts(client_with_token, status=value)["posts"]] == [post_id]
 
     def test_limit_out_of_range_is_invalid_params(self, client_with_token):
         """Out-of-range limits are rejected rather than silently clamped —
@@ -583,7 +627,7 @@ class TestListPostsTool:
         _list_posts(client_with_token)  # warm anything cached lazily
 
         with django_assert_max_num_queries(100) as one_post:
-            _list_posts(client_with_token)
+            assert len(_list_posts(client_with_token)["posts"]) == 1
 
         for i in range(4):
             p = Post.objects.create(workspace=workspace, author=user, caption=f"extra {i}")

--- a/apps/mcp/tests/test_transport.py
+++ b/apps/mcp/tests/test_transport.py
@@ -255,7 +255,7 @@ class TestToolsList:
         status, body = _post(client_with_token, _rpc("tools/list"))
         assert status == 200
         names = {t["name"] for t in body["result"]["tools"]}
-        assert {"list_accounts", "create_draft", "schedule_post", "get_post", "cancel_post"} <= names
+        assert {"list_accounts", "create_draft", "schedule_post", "get_post", "list_posts", "cancel_post"} <= names
 
     def test_each_tool_has_an_input_schema(self, client_with_token):
         status, body = _post(client_with_token, _rpc("tools/list"))
@@ -428,6 +428,171 @@ class TestGetPostTool:
         )
         assert body["error"]["code"] == INVALID_PARAMS
         assert "not found" in body["error"]["message"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Tool: list_posts
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mixed_post(db, social_account, second_account, user, workspace):
+    """A Post targeting one allowlisted *and* one out-of-scope account.
+
+    The visibility rule is all-or-nothing: listing this would tell a
+    partial-scope key that ``second_account`` exists.
+    """
+    p = Post.objects.create(workspace=workspace, author=user, caption="half mine")
+    PlatformPost.objects.create(post=p, social_account=social_account, status="draft")
+    PlatformPost.objects.create(post=p, social_account=second_account, status="draft")
+    return p
+
+
+def _list_posts(client, **arguments):
+    """Call the list_posts tool and return its decoded payload."""
+    status, body = _post(client, _rpc("tools/call", {"name": "list_posts", "arguments": arguments}))
+    assert "error" not in body, body.get("error")
+    return json.loads(body["result"]["content"][0]["text"])
+
+
+def _list_posts_error(client, **arguments):
+    status, body = _post(client, _rpc("tools/call", {"name": "list_posts", "arguments": arguments}))
+    return body["error"]
+
+
+@pytest.mark.django_db
+class TestListPostsTool:
+    def test_lists_own_posts_only(self, client_with_token, own_post, foreign_post, mixed_post):
+        """Same confused-deputy rule as get_post: a post is listed only when
+        *every* platform target is in the key's allowlist.
+        """
+        inner = _list_posts(client_with_token)
+        ids = {p["id"] for p in inner["posts"]}
+        assert ids == {str(own_post.id)}
+        assert str(foreign_post.id) not in ids
+        assert str(mixed_post.id) not in ids
+
+    def test_orders_by_created_at_not_scheduled_at(self, client_with_token, social_account, user, workspace):
+        """Regression: ordering on the nullable ``scheduled_at`` put every
+        NULL-scheduled draft ahead of real posts (Postgres sorts DESC with
+        NULLs first), so "newest first" was neither newest nor first.
+        """
+        older_draft = Post.objects.create(workspace=workspace, author=user, caption="older draft")
+        PlatformPost.objects.create(post=older_draft, social_account=social_account, status="draft")
+        newer_scheduled = Post.objects.create(
+            workspace=workspace,
+            author=user,
+            caption="newer scheduled",
+            scheduled_at=timezone.now() + timedelta(days=30),
+        )
+        PlatformPost.objects.create(
+            post=newer_scheduled,
+            social_account=social_account,
+            status="scheduled",
+            scheduled_at=timezone.now() + timedelta(days=30),
+        )
+
+        inner = _list_posts(client_with_token)
+        assert [p["id"] for p in inner["posts"]] == [str(newer_scheduled.id), str(older_draft.id)]
+
+    def test_paginates_with_cursor(self, client_with_token, social_account, user, workspace):
+        """Regression for the silent 500-row scan cap: every visible post is
+        reachable by following ``next_cursor``, and pages never overlap.
+        """
+        created = []
+        for i in range(3):
+            p = Post.objects.create(workspace=workspace, author=user, caption=f"post {i}")
+            PlatformPost.objects.create(post=p, social_account=social_account, status="draft")
+            created.append(str(p.id))
+
+        page1 = _list_posts(client_with_token, limit=2)
+        assert len(page1["posts"]) == 2
+        assert page1["limit"] == 2
+        assert page1["next_cursor"] is not None
+
+        page2 = _list_posts(client_with_token, limit=2, cursor=page1["next_cursor"])
+        assert len(page2["posts"]) == 1
+        assert page2["next_cursor"] is None
+
+        ids1 = {p["id"] for p in page1["posts"]}
+        ids2 = {p["id"] for p in page2["posts"]}
+        assert ids1.isdisjoint(ids2)
+        assert ids1 | ids2 == set(created)
+
+    def test_status_filter_narrows(self, client_with_token, own_post, scheduled_post):
+        inner = _list_posts(client_with_token, status="scheduled")
+        assert [p["id"] for p in inner["posts"]] == [str(scheduled_post.id)]
+
+    def test_unknown_status_is_invalid_params(self, client_with_token, own_post):
+        """An unknown status used to return an empty list, which reads as
+        "no posts" rather than "you asked for something that isn't a status".
+        The schema ``enum`` makes the transport reject it before dispatch.
+        """
+        error = _list_posts_error(client_with_token, status="totally_not_a_status")
+        assert error["code"] == INVALID_PARAMS
+        assert "status" in error["message"]
+        assert "totally_not_a_status" in error["message"]
+
+    def test_unknown_status_rejected_by_handler_too(self, issued_key, own_post):
+        """Backstop behind the schema check, for any caller that reaches the
+        handler without transport-level validation.
+        """
+        from apps.mcp.handlers import _list_posts as list_posts_handler
+        from apps.mcp.protocol import JsonRpcError
+
+        with pytest.raises(JsonRpcError) as exc:
+            list_posts_handler(
+                {"status": "totally_not_a_status"},
+                {"api_key": issued_key.api_key, "membership": None},
+            )
+        assert "status must be one of" in str(exc.value)
+
+    def test_status_accepts_every_platform_post_status(self, client_with_token):
+        """The schema enum must cover the full model enum — ``changes_requested``
+        and ``rejected`` were missing from the documented list.
+        """
+        for value in PlatformPost.Status.values:
+            assert _list_posts(client_with_token, status=value)["posts"] == []
+
+    def test_limit_out_of_range_is_invalid_params(self, client_with_token):
+        """Out-of-range limits are rejected rather than silently clamped —
+        same contract as search_media.
+        """
+        for bad in (0, 101):
+            error = _list_posts_error(client_with_token, limit=bad)
+            assert error["code"] == INVALID_PARAMS
+            assert "limit" in error["message"]
+
+    def test_malformed_cursor_is_invalid_params(self, client_with_token):
+        error = _list_posts_error(client_with_token, cursor="not-a-cursor")
+        assert error["code"] == INVALID_PARAMS
+        assert "cursor" in error["message"]
+
+    def test_serialization_does_not_scale_queries_with_page_size(
+        self,
+        client_with_token,
+        social_account,
+        user,
+        workspace,
+        own_post,
+        django_assert_max_num_queries,
+    ):
+        """``PostResponse.from_post`` used to re-query children per post; the
+        query count must not grow with the number of posts returned.
+        """
+        _list_posts(client_with_token)  # warm anything cached lazily
+
+        with django_assert_max_num_queries(100) as one_post:
+            _list_posts(client_with_token)
+
+        for i in range(4):
+            p = Post.objects.create(workspace=workspace, author=user, caption=f"extra {i}")
+            PlatformPost.objects.create(post=p, social_account=social_account, status="draft")
+
+        with django_assert_max_num_queries(100) as five_posts:
+            assert len(_list_posts(client_with_token)["posts"]) == 5
+
+        assert len(five_posts.captured_queries) == len(one_post.captured_queries)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The MCP server exposes `get_post` (fetch one post by id) but no way to **list**
posts. An agent that doesn't already hold a post id has no discovery path — it
can list accounts and media, but not the posts themselves.

## Fix

Add a `list_posts` MCP tool:

- Newest-first, optional `status` filter (draft, pending_review, pending_client,
  approved, scheduled, publishing, published, failed, on_hold) and `limit`
  (default 50, max 100).
- Each item uses the **same per-post shape as `get_post`** (via `_serialize_post`),
  so MCP/REST stay consistent.
- Respects the key's account allowlist with the same visibility rule as
  `get_post`: a post is only listed when *every* platform target is allowlisted,
  so a partial-scope key never learns about sibling accounts. The scan is bounded
  (top 500) before the Python-side allowlist filter.

## Testing

MCP suite (81) passes; `ruff`/`check` clean. Verified end-to-end against a seeded
workspace with an allowlisted key: `list_posts` returns all posts, and the
`status`/`limit` filters narrow correctly (e.g. `scheduled` + `limit:3` → 3
scheduled posts).