### PR TITLE
Migrate to Django 6.0.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: "pip"
 
       - name: Install ruff
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: "pip"
 
       - name: Install dependencies
@@ -104,7 +104,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: "3.12"
+          python-version: "3.13"
           cache: "pip"
 
       - name: Install dependencies
@@ -113,11 +113,56 @@ jobs:
       - name: pytest
         run: pytest --cov=apps --cov-report=term-missing
 
+  # THIS JOB HAS NEVER RUN ANYWHERE. It needs a GitHub runner, so the first
+  # push is its first execution - and `build` gates on it, so if it comes up red
+  # for an environmental reason (the apt layout under /usr/lib/postgresql,
+  # playwright's system deps, the timeout against initdb + a Chromium download)
+  # then nothing in the repository can merge until it is fixed.
+  #
+  # If that happens: take `e2e` out of `build.needs`, fix it, and put it back
+  # once it has been green once. Do not debug it with main blocked.
+  e2e:
+    name: End-to-end (browser + ephemeral Postgres)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.13"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Install Chromium
+        run: python -m playwright install --with-deps chromium
+
+      # The suite creates and destroys its OWN cluster with initdb/pg_ctl, so
+      # what is needed is the server BINARIES, not a running server. A
+      # `services:` container would not do: the fixture has to run initdb
+      # itself, and tests/e2e/conftest.py looks under /usr/lib/postgresql/*/bin.
+      - name: Install PostgreSQL server binaries
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql
+
+      # -m on the command line overrides the `-m 'not e2e'` in addopts, and
+      # --ds is NOT optional: config/settings/test.py runs CSP report-only,
+      # under which a blocked-script defect cannot reproduce.
+      - name: pytest -m e2e
+        run: pytest -m e2e --ds=config.settings.e2e tests/e2e
+
   build:
     name: Docker build
     runs-on: ubuntu-latest
     timeout-minutes: 15
-    needs: [lint, typecheck, test]
+    needs: [lint, typecheck, test, e2e]
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@
 # Reference: https://pre-commit.com
 
 default_language_version:
-  python: python3.12
+  python: python3.13
 
 repos:
   # Basic hygiene: trailing whitespace, EOF newlines, large files, merge conflicts, etc.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim AS base
+FROM python:3.13-slim AS base
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,10 @@ test: ## Run tests
 test-cov: ## Run tests with coverage
 	pytest --cov=apps --cov-report=term-missing
 
+test-e2e: ## Run the end-to-end suite (ephemeral Postgres + real browser)
+	python -m playwright install chromium
+	pytest -m e2e --ds=config.settings.e2e tests/e2e
+
 lint: ## Run linter and format check
 	ruff check .
 	ruff format --check .

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 <p align="center">
   <a href="https://github.com/brightbeanxyz/brightbean-studio/actions/workflows/ci.yml"><img src="https://github.com/brightbeanxyz/brightbean-studio/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-AGPL--3.0-blue.svg" alt="License: AGPL-3.0"></a>
-  <a href="https://www.python.org/"><img src="https://img.shields.io/badge/Python-3.12%2B-blue.svg" alt="Python 3.12+"></a>
-  <a href="https://www.djangoproject.com/"><img src="https://img.shields.io/badge/Django-5.x-green.svg" alt="Django 5.x"></a>
+  <a href="https://www.python.org/"><img src="https://img.shields.io/badge/Python-3.13%2B-blue.svg" alt="Python 3.13+"></a>
+  <a href="https://www.djangoproject.com/"><img src="https://img.shields.io/badge/Django-6.0-green.svg" alt="Django 6.0"></a>
 </p>
 
 <p align="center">
@@ -156,7 +156,7 @@ Run everything natively - no Docker, no PostgreSQL install. Uses SQLite for the 
 
 ### Prerequisites
 
-- Python 3.12+
+- Python 3.13+
 - Node.js 20+
 
 ### Setup
@@ -660,7 +660,7 @@ Don't want to wire up your own client? The companion [brightbean-studio-agent](h
 
 | Layer | Technology |
 |-------|-----------|
-| Backend | Django 5.x |
+| Backend | Django 6.0 |
 | Frontend | Django templates, HTMX, Alpine.js |
 | CSS | Tailwind CSS 4 via django-tailwind |
 | Database | PostgreSQL 16+ |

--- a/apps/api/api.py
+++ b/apps/api/api.py
@@ -30,7 +30,7 @@ class NoncedSwagger(Swagger):
     # Ninja loads swagger_cdn.html by absolute path, bypassing Django's
     # template loader, so a file in templates/ninja/ won't shadow it.
     # Point at our project override so its inline <script> tags can carry
-    # nonce="{{ request.csp_nonce }}" and satisfy production CSP.
+    # nonce="{{ csp_nonce }}" and satisfy production CSP.
     template_cdn = str(settings.BASE_DIR / "templates" / "ninja" / "swagger_cdn.html")
 
 

--- a/apps/approvals/tasks.py
+++ b/apps/approvals/tasks.py
@@ -15,7 +15,9 @@ from .models import ApprovalReminder
 
 logger = logging.getLogger(__name__)
 
-# Default reminder thresholds (overridable via settings_manager)
+# Reminder thresholds. These are module constants and are NOT read
+# through apps.settings_manager - nothing in this module calls
+# get_setting(). Change them here, or wire the cascade in deliberately.
 PENDING_REVIEW_HOURS = 24
 PENDING_CLIENT_HOURS = 48
 MAX_REMINDERS = 2

--- a/apps/calendar/holidays.py
+++ b/apps/calendar/holidays.py
@@ -13,7 +13,7 @@ from pathlib import Path
 def _load_holidays():
     """Load holidays.json once and cache."""
     data_path = Path(__file__).parent / "data" / "holidays.json"
-    with open(data_path) as f:
+    with open(data_path, encoding="utf-8") as f:
         return json.load(f)
 
 

--- a/apps/composer/tests/test_preview.py
+++ b/apps/composer/tests/test_preview.py
@@ -30,7 +30,7 @@ class ComposerPreviewTests(ComposerTestCase):
         return preview(request, self.workspace.id)
 
     def test_compose_page_posts_live_preview_form_data(self):
-        template = Path("templates/composer/compose.html").read_text()
+        template = Path("templates/composer/compose.html").read_text(encoding="utf-8")
 
         self.assertIn("hx-post=\"{% url 'composer:preview' workspace_id=workspace.id %}\"", template)
         self.assertNotIn("hx-get=\"{% url 'composer:preview' workspace_id=workspace.id %}\"", template)

--- a/apps/intelligence/tests/test_discard_checkout.py
+++ b/apps/intelligence/tests/test_discard_checkout.py
@@ -377,7 +377,7 @@ class SubscribeTemplateBranchingTests(TestCase):
     def setUpClass(cls):
         super().setUpClass()
         template_path = settings.BASE_DIR / "templates" / "intelligence" / "subscribe.html"
-        src = template_path.read_text()
+        src = template_path.read_text(encoding="utf-8")
         body = cls._BLOCK_RE.search(src).group(1)
         loads = "".join(cls._LOAD_RE.findall(src))
         cls._tpl = DjangoTemplate(loads + body)

--- a/apps/oauth_server/urls.py
+++ b/apps/oauth_server/urls.py
@@ -5,8 +5,9 @@ django-oauth-toolkit resolves against these routes. Only the routes the MCP
 flow needs are exposed — DOT's application-management UI is left unmounted.
 """
 
-from csp.decorators import csp_update
+from django.conf import settings
 from django.urls import path
+from django.views.decorators.csp import csp_override
 from oauth2_provider import views as oauth2_views
 
 from . import views
@@ -17,10 +18,15 @@ app_name = "oauth2_provider"
 # client's redirect_uri (Claude: https://claude.ai|claude.com/api/mcp/auth_callback).
 # Chromium enforces form-action across the whole redirect chain, so the redirect
 # target must be allowlisted on the consent page or the flow dies silently there.
-# csp_update appends to the global CSP_FORM_ACTION, scoping the relaxation here only.
-authorize_view = csp_update(FORM_ACTION="https://claude.ai https://claude.com")(
-    oauth2_views.AuthorizationView.as_view()
-)
+# csp_override replaces the WHOLE policy, not one directive, so the base policy
+# is splatted back in - without that this view would serve form-action and
+# nothing else, losing script-src entirely. The relaxation stays scoped here.
+_AUTHORIZE_CSP = {
+    **settings.CSP_POLICY,
+    "form-action": [*settings.CSP_POLICY["form-action"], "https://claude.ai", "https://claude.com"],
+}
+
+authorize_view = csp_override(_AUTHORIZE_CSP)(oauth2_views.AuthorizationView.as_view())
 
 urlpatterns = [
     path("authorize/", authorize_view, name="authorize"),

--- a/apps/onboarding/views.py
+++ b/apps/onboarding/views.py
@@ -8,7 +8,6 @@ import logging
 import secrets
 from datetime import timedelta
 
-from csp.decorators import csp_update
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -20,6 +19,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
+from django.views.decorators.csp import csp_override
 from django.views.decorators.http import require_GET, require_POST
 
 from apps.credentials.models import PlatformCredential
@@ -276,9 +276,6 @@ def connection_page(request, token):
     )
 
 
-@csp_update(
-    FORM_ACTION="'self' https://accounts.google.com https://www.facebook.com https://api.instagram.com https://www.instagram.com https://threads.net https://www.threads.com https://www.linkedin.com https://www.pinterest.com https://www.tiktok.com"
-)
 @require_POST
 def connection_oauth_start(request, token):
     """Initiate OAuth flow from the connection link page."""
@@ -561,7 +558,7 @@ def connection_bluesky_connect(request, token):
     return redirect("onboarding:connection_page", token=token)
 
 
-@csp_update(FORM_ACTION="'self' https:")
+@csp_override({**settings.CSP_POLICY, "form-action": [*settings.CSP_POLICY["form-action"], "https:"]})
 @require_POST
 def connection_mastodon_start(request, token):
     """Initiate Mastodon OAuth from the connection link page."""

--- a/apps/publisher/engine.py
+++ b/apps/publisher/engine.py
@@ -23,7 +23,7 @@ from datetime import timedelta
 
 from background_task import background
 from django.conf import settings
-from django.db import transaction
+from django.db import connections, transaction
 from django.db.models.functions import Coalesce
 from django.utils import timezone
 
@@ -96,6 +96,25 @@ MAX_CONCURRENT_PUBLISHES = getattr(settings, "PUBLISHER_MAX_CONCURRENT_PUBLISHES
 MAX_CONCURRENT_POSTS = getattr(settings, "PUBLISHER_MAX_CONCURRENT_POSTS", 4)
 
 
+def _run_and_release_connection(work, *args, **kwargs):
+    """Run `work` on a pool thread, then hand that thread's DB connection back.
+
+    Django opens a database connection per thread and closes it only when the
+    thread's local storage is eventually garbage collected. A worker process
+    fires none of the request_started / request_finished signals that would
+    otherwise call close_old_connections(), and both pools below are rebuilt on
+    every tick - so idle backends accumulate for as long as the collector takes
+    to notice, against a server with a finite connection limit.
+
+    Found by the publish-path e2e test, which could not drop its own database
+    afterwards: five sessions were still attached to it.
+    """
+    try:
+        return work(*args, **kwargs)
+    finally:
+        connections.close_all()
+
+
 class PublishEngine:
     """Orchestrates the publishing of scheduled posts."""
 
@@ -115,7 +134,8 @@ class PublishEngine:
         published_count = 0
         with ThreadPoolExecutor(max_workers=min(len(groups), MAX_CONCURRENT_POSTS) or 1) as executor:
             futures = {
-                executor.submit(self._publish_post_group, pps[0].post, pps): post_id for post_id, pps in groups.items()
+                executor.submit(_run_and_release_connection, self._publish_post_group, pps[0].post, pps): post_id
+                for post_id, pps in groups.items()
             }
             for future in as_completed(futures):
                 post_id = futures[future]
@@ -182,7 +202,10 @@ class PublishEngine:
         # Publish in parallel
         results = {}
         with ThreadPoolExecutor(max_workers=min(len(platform_posts), 5)) as executor:
-            futures = {executor.submit(self._publish_platform_post, pp): pp for pp in platform_posts}
+            futures = {
+                executor.submit(_run_and_release_connection, self._publish_platform_post, pp): pp
+                for pp in platform_posts
+            }
             for future in as_completed(futures):
                 pp = futures[future]
                 try:

--- a/apps/social_accounts/views.py
+++ b/apps/social_accounts/views.py
@@ -8,7 +8,6 @@ import secrets
 from datetime import timedelta
 from urllib.parse import urlsplit
 
-from csp.decorators import csp_update
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
@@ -16,6 +15,7 @@ from django.core import signing
 from django.core.exceptions import PermissionDenied
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
+from django.views.decorators.csp import csp_override
 from django.views.decorators.http import require_GET, require_POST
 from django_ratelimit.decorators import ratelimit
 
@@ -621,7 +621,7 @@ def connect_devto(request, workspace_id):
 # ------------------------------------------------------------------
 
 
-@csp_update(FORM_ACTION="'self' https:")
+@csp_override({**settings.CSP_POLICY, "form-action": [*settings.CSP_POLICY["form-action"], "https:"]})
 @login_required
 @require_permission("manage_social_accounts")
 def connect_mastodon(request, workspace_id):

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,109 @@
+# Changelog
+
+Historic detail lives here rather than in source comments (rule 3): comments
+describe what is alive, this file records how it got that way.
+
+Entries are newest-first. Each carries the commit the change was applied on
+top of, and that commit's own date.
+
+The date is the BASELINE COMMIT's, not the moment of generation, and it is
+labelled as such. Derived output that stamps the current time differs on every
+run, so regenerating this file produced a diff that meant nothing. If you want
+to know when a change landed, read the git history of this file; the stamp
+below tells you what it was applied to.
+
+## Django 5.1 -> 6.0.7
+
+- **Base commit:** `e4da3a2c2b717f9140af54a7a03a34b90ae4cf59`
+- **Baseline dated:** 2026-07-02T22:16:40+02:00
+
+### python-floor
+
+- `Dockerfile` - python 3.12-slim -> 3.13-slim
+  - *Why:* Conform to .python-version, which already declared 3.13.
+- `pyproject.toml` - ruff target-version and mypy python_version -> 3.13
+  - *Why:* Static analysis must target the version actually deployed, or it reports on syntax the runtime never sees.
+- `.github/workflows/ci.yml` - all 3 setup-python jobs 3.12 -> 3.13
+  - *Why:* CI installed and tested on an interpreter the application no longer ships on. The file was absent from the plan, so the requirement this step generates was contradicted by the tree it was generated from.
+- `.pre-commit-config.yaml` - default_language_version python3.12 -> python3.13
+  - *Why:* Hooks ran ruff and mypy under a different interpreter than the one the project declares, so a contributor's pre-commit run and CI could disagree with the deployed runtime.
+
+### csp
+
+- `config/settings/base.py` - django-csp flat CSP_* settings -> core SECURE_CSP dict; form-action named
+  - *Why:* Django 6.0 provides CSP in core. Removes a dependency and the settings/decorator API divergence django-csp 4.0 would have forced.
+- `config/settings/development.py` - CSP_REPORT_ONLY flag -> SECURE_CSP_REPORT_ONLY setting
+  - *Why:* Core CSP expresses report-only as a separate policy, not a flag on one.
+- `config/settings/test.py` - CSP_REPORT_ONLY flag -> SECURE_CSP_REPORT_ONLY setting
+  - *Why:* Core CSP expresses report-only as a separate policy, not a flag on one.
+- `3 modules` - @csp_update -> @csp_override, splatting the named form-action base
+  - *Why:* csp_update appends to a directive; csp_override replaces it. Restating the base at each site would be four copies that drift, so each splats one named list instead.
+- `apps/onboarding/views.py` - DELETED the @csp_update on connection_oauth_start instead of converting it
+  - *Why:* It appended ten form-action hosts that the base list already contains, so under django-csp's append semantics the policy it served WAS the base policy - settled by set membership against the two lists, not by judgement. Converting it would have shipped a decorator claiming an effect it does not have. Called out on its own line because a CSP decorator disappearing from an OAuth start view must be visible in the record even when it is provably a no-op.
+- `templates/ + apps/api/api.py` - 27 template sites, plus the comment in apps/api/api.py: {{ request.csp_nonce }} -> {{ csp_nonce }}
+  - *Why:* Core Django stores the nonce privately as request._csp_nonce and publishes it as csp_nonce via the context processor. The old spelling renders empty and blocks every inline script - silently, in production.
+- `tests/test_csp_overrides.py` - new unit test: every @csp_override site must widen the base policy, not replace it
+  - *Why:* The e2e test covers the one override site reachable without auth; the account-connection sites were argued correct and never executed, and a site added later was covered by nothing. This discovers the sites from the URLconf, so the property holds for all of them and for future ones.
+
+### comment-truth
+
+- `apps/approvals/tasks.py` - corrected a comment claiming a settings_manager override that does not exist
+  - *Why:* No call site in this module calls get_setting(); the override path was aspirational.
+- `3 files` - reads name encoding="utf-8" instead of inheriting the platform's
+  - *Why:* Python falls back to the locale encoding, so these behaved one way on CI and another on a German Windows shell - one of them silently changing whether the test suite passed. apps/calendar/holidays.py is application code and would raise in production on such a host.
+- `README.md, development_specs/architecture.md` - the shipped docs state Django 6.0, Python 3.13 and core CSP
+  - *Why:* The repository front page and the architecture spec still declared Django 5.x, Python 3.12+ and a CSP provided by django-csp - the dependency this same run deletes. Nothing gates markdown, so all of it survived every check; and a contributor following the front page installs 3.12, whereupon pre-commit fails looking for python3.13.
+- *Note:* scanned every module; no comment names removed machinery
+
+### requirements
+
+- `requirements.txt` - Django 5.1 -> 6.0.7
+  - *Why:* Migration target.
+- `requirements.txt` - removed django-csp
+  - *Why:* Django 6.0 ships Content Security Policy in core (django.middleware.csp.ContentSecurityPolicyMiddleware).
+- *Note:* django-background-tasks RETAINED - measured to run clean on 6.0.7 (migrations apply, a @background call enqueues, and `process_tasks` executed all eleven recurring jobs with zero failures), and replacing it is out of scope for a framework migration
+- *Note:* `mcp` pin is imported by NOTHING - flagged as removable, but left in place because dependency removal is out of scope for a Django migration. Recorded as a design note instead.
+
+### e2e
+
+- `tests/e2e/ + config/settings/e2e.py` - new end-to-end suite: 9 files
+  - *Why:* Rule 6. The first test pins the empty-nonce regression, which no existing gate in this repository could see.
+- `pyproject.toml` - registered the e2e marker and deselected it by default (-m "not e2e")
+  - *Why:* The unit suite must stay as fast as it was. An e2e run is a separate command because it also needs a different settings module.
+- `requirements.txt` - added pytest-playwright
+  - *Why:* Supplies the browser the e2e suite drives. Postgres is NOT added as a dependency: the suite uses the server's own binaries directly and psycopg is already required.
+- `Makefile` - added a test-e2e target
+  - *Why:* The e2e run needs --ds=config.settings.e2e and a browser binary; putting that in one target stops it being rediscovered each time.
+- `.github/workflows/ci.yml` - added an e2e job, so the end-to-end suite actually runs on push and PR
+  - *Why:* CI ran a bare `pytest`, which inherits `-m 'not e2e'` from addopts, so EVERY e2e test was deselected on every run. The only detectors for the two silent CSP defects were therefore never executed by anything automated. UNVERIFIED: this job has not been run - it needs GitHub's runner - so its first push is its first execution.
+- `apps/publisher/engine.py` - publisher pool threads now release their database connection
+  - *Why:* Django opens a connection per thread and frees it only on garbage collection; a worker process fires none of the signals that call close_old_connections(), and both pools are rebuilt every tick. Surfaced by the new publish-path e2e test, which could not drop its database afterwards.
+
+### docs
+
+- `requirements/python-version.md` - generated requirement entry
+  - *Why:* Rule 4.
+- `requirements/content-security-policy.md` - generated requirement entry
+  - *Why:* Rule 4.
+- `design/csp-provider.md` - generated design entry
+  - *Why:* Rule 4.
+- `design/settings-manager-is-unwired.md` - generated design entry
+  - *Why:* Rule 4.
+- `design/unused-mcp-dependency.md` - generated design entry
+  - *Why:* Rule 4.
+- `requirements/dependency-currency.md` - generated requirement entry
+  - *Why:* Rule 4.
+- `design/no-lockfile.md` - generated design entry
+  - *Why:* Rule 4.
+- `requirements/end-to-end-testing.md` - generated requirement entry
+  - *Why:* Rule 4.
+- `design/e2e-ephemeral-postgres.md` - generated design entry
+  - *Why:* Rule 4.
+- `design/django-6-0-not-5-2-lts.md` - generated design entry
+  - *Why:* Rule 4.
+- `design/keep-django-background-tasks.md` - generated design entry
+  - *Why:* Rule 4.
+- `requirements/background-work.md` - generated requirement entry
+  - *Why:* Rule 4.
+- `changelog.md` - recorded this migration
+  - *Why:* Rule 3.

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import environ
+from django.utils.csp import CSP
 
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
@@ -42,7 +43,6 @@ THIRD_PARTY_APPS = [
     "allauth.socialaccount.providers.google",
     "django_htmx",
     "tailwind",
-    "csp",
     # OAuth 2.1 Authorization Server backing the MCP connector flow.
     "oauth2_provider",
     "apps.background_task_config.BackgroundTaskConfig",
@@ -95,7 +95,7 @@ MIDDLEWARE = [
     "apps.members.middleware.RBACMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "csp.middleware.CSPMiddleware",
+    "django.middleware.csp.ContentSecurityPolicyMiddleware",
 ]
 
 ROOT_URLCONF = "config.urls"
@@ -115,6 +115,7 @@ TEMPLATES = [
                 "apps.common.context_processors.sidebar_context",
                 "apps.onboarding.context_processors.onboarding_checklist",
                 "apps.intelligence.context_processors.intelligence_flag",
+                "django.template.context_processors.csp",
             ],
         },
     },
@@ -278,30 +279,61 @@ else:
 # Tailwind
 TAILWIND_APP_NAME = "theme"
 
-# CSP - Alpine.js standard build requires unsafe-eval for inline expression
-# evaluation. Styles use unsafe-inline because Tailwind utility classes are inline.
-CSP_DEFAULT_SRC = ("'self'",)
-CSP_SCRIPT_SRC = ("'self'", "'unsafe-eval'", "https://cdn.jsdelivr.net")
-CSP_STYLE_SRC = ("'self'", "'unsafe-inline'", "https://cdn.jsdelivr.net")
-CSP_IMG_SRC = ("'self'", "data:", "blob:", "https:")
-CSP_FONT_SRC = ("'self'",)
-CSP_CONNECT_SRC = ("'self'", "https://cdn.jsdelivr.net")
-CSP_MEDIA_SRC = ("'self'", "blob:")
-CSP_FORM_ACTION = (
-    "'self'",
-    "https://accounts.google.com",
-    "https://checkout.stripe.com",
-    "https://billing.stripe.com",
-    "https://www.facebook.com",
-    "https://api.instagram.com",
-    "https://www.instagram.com",
-    "https://www.threads.com",
-    "https://threads.net",
-    "https://www.linkedin.com",
-    "https://www.pinterest.com",
-    "https://www.tiktok.com",
-)
-CSP_INCLUDE_NONCE_IN = ["script-src"]
+# Content Security Policy (Django 6.0 core).
+#
+# Alpine.js's standard build evaluates expressions at runtime, so script-src
+# needs 'unsafe-eval'. Tailwind emits utility classes inline, so style-src
+# needs 'unsafe-inline'. CSP.NONCE is placed in script-src so the nonce the
+# middleware generates is honoured for our own inline <script> tags; it
+# reaches templates as {{ csp_nonce }} via the csp context processor.
+#
+# form-action lists every host an OAuth flow may POST to. Chromium enforces
+# form-action across a whole redirect chain, so a provider's post-consent
+# redirect target must be listed here or the flow dies silently.
+#
+# The policy has its own name, and SECURE_CSP is that name, because four views
+# widen form-action with @csp_override. csp_override does NOT override one
+# directive - it replaces the WHOLE policy. django/middleware/csp.py reads the
+# decorator's dict INSTEAD of settings.SECURE_CSP and merges nothing, so an
+# override carrying only form-action serves a page with no script-src and no
+# default-src, which restricts scripts not at all. Measured against
+# django/middleware/csp.py, which reads response._csp_config INSTEAD of this
+# setting and merges nothing; tests/test_csp_overrides.py holds it down for
+# every routed override site.
+#
+# So those views splat this whole dict and replace one key. They cannot read it
+# back off SECURE_CSP, because dev and test set that to None and move the
+# policy to SECURE_CSP_REPORT_ONLY.
+CSP_POLICY = {
+    "default-src": [CSP.SELF],
+    "script-src": [CSP.SELF, CSP.UNSAFE_EVAL, CSP.NONCE, "https://cdn.jsdelivr.net"],
+    "style-src": [CSP.SELF, CSP.UNSAFE_INLINE, "https://cdn.jsdelivr.net"],
+    "img-src": [CSP.SELF, "data:", "blob:", "https:"],
+    "font-src": [CSP.SELF],
+    "connect-src": [CSP.SELF, "https://cdn.jsdelivr.net"],
+    "media-src": [CSP.SELF, "blob:"],
+    "form-action": [
+        CSP.SELF,
+        "https://accounts.google.com",
+        "https://checkout.stripe.com",
+        "https://billing.stripe.com",
+        "https://www.facebook.com",
+        "https://api.instagram.com",
+        "https://www.instagram.com",
+        "https://www.threads.com",
+        "https://threads.net",
+        "https://www.linkedin.com",
+        "https://www.pinterest.com",
+        "https://www.tiktok.com",
+    ],
+}
+
+# Both settings are Optional across environments: development and test move
+# the policy onto the report-only key and set this one to None, and
+# config/settings/e2e.py moves it back. Annotating them keeps that flip
+# type-checkable instead of an error in every settings module that does it.
+SECURE_CSP: dict | None = CSP_POLICY
+SECURE_CSP_REPORT_ONLY: dict | None = None
 
 # Allow media/images from the storage domain in CSP
 if STORAGE_BACKEND.lower() == "s3":
@@ -311,8 +343,8 @@ if STORAGE_BACKEND.lower() == "s3":
             _storage_origin = f"https://{_storage_origin}"
         _parsed = urlparse(_storage_origin)
         _storage_origin = f"{_parsed.scheme}://{_parsed.hostname}"
-        CSP_MEDIA_SRC = (*CSP_MEDIA_SRC, _storage_origin)  # type: ignore[assignment]
-        CSP_IMG_SRC = (*CSP_IMG_SRC, _storage_origin)  # type: ignore[assignment]
+        CSP_POLICY["media-src"].append(_storage_origin)
+        CSP_POLICY["img-src"].append(_storage_origin)
 
 # Media Library
 MEDIA_LIBRARY_MAX_IMAGE_SIZE = 20 * 1024 * 1024  # 20MB

--- a/config/settings/development.py
+++ b/config/settings/development.py
@@ -37,8 +37,16 @@ STORAGES["staticfiles"] = {  # noqa: F405
 # Use console email backend in development
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
-# Disable CSP in development
-CSP_REPORT_ONLY = True
+# Report-only CSP: violations are reported, nothing is blocked.
+# Django 6.0 expresses this as a separate setting rather than a flag,
+# so the policy is moved wholesale onto the report-only key. Assigning
+# from CSP_POLICY rather than from SECURE_CSP keeps this a definition
+# rather than a read of a name this module also rebinds.
+#
+# Note that this makes a blocked-script defect impossible to reproduce
+# here. The e2e suite therefore runs its own enforcing settings.
+SECURE_CSP = None
+SECURE_CSP_REPORT_ONLY = CSP_POLICY  # noqa: F405
 
 # Django debug toolbar (optional)
 try:

--- a/config/settings/e2e.py
+++ b/config/settings/e2e.py
@@ -1,0 +1,29 @@
+"""Settings for the end-to-end suite: the test settings, with CSP ENFORCED.
+
+That single difference is the reason this module exists.
+
+config/settings/test.py runs the Content Security Policy in report-only mode.
+Under report-only a violating inline script is reported to the console and then
+executed anyway, so the page works and a broken policy is invisible. An e2e
+suite that inherited those settings would pass happily against a tree in which
+every inline script is refused in production.
+
+Do not "simplify" this file by deleting the two lines that swap the policy back.
+They are the entire point of it.
+"""
+
+from .test import *  # noqa: F403
+
+# test.py runs the policy report-only. Enforce it here, so the browser really
+# refuses what production refuses. Taken from CSP_POLICY rather than from
+# SECURE_CSP_REPORT_ONLY so this reads as "e2e enforces the base policy",
+# which is the intent, instead of a swap between two names.
+SECURE_CSP = CSP_POLICY  # noqa: F405
+SECURE_CSP_REPORT_ONLY = None
+
+# live_server speaks plain HTTP. A redirect to https would end every test
+# before it reached a page.
+SECURE_SSL_REDIRECT = False
+
+# live_server binds an arbitrary port on localhost.
+ALLOWED_HOSTS = ["*"]

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -16,8 +16,16 @@ PASSWORD_HASHERS = [
 # Use in-memory email backend
 EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
 
-# Disable CSP in tests
-CSP_REPORT_ONLY = True
+# Report-only CSP: violations are reported, nothing is blocked.
+# Django 6.0 expresses this as a separate setting rather than a flag,
+# so the policy is moved wholesale onto the report-only key. Assigning
+# from CSP_POLICY rather than from SECURE_CSP keeps this a definition
+# rather than a read of a name this module also rebinds.
+#
+# Note that this makes a blocked-script defect impossible to reproduce
+# here. The e2e suite therefore runs its own enforcing settings.
+SECURE_CSP = None
+SECURE_CSP_REPORT_ONLY = CSP_POLICY  # noqa: F405
 
 # Use local storage in tests
 STORAGE_BACKEND = "local"

--- a/design/csp-provider.md
+++ b/design/csp-provider.md
@@ -1,0 +1,13 @@
+# CSP is provided by core Django, not django-csp
+
+Django 6.0 moved CSP into core (`django.middleware.csp.ContentSecurityPolicyMiddleware`, `SECURE_CSP`).
+
+The alternative was upgrading `django-csp` 3.8 -> 4.x, which itself required rewriting flat `CSP_*` settings into a nested dict. Since the settings had to be rewritten either way, the version that removes a dependency was chosen.
+
+**Two hazards, recorded because both are quiet.**
+
+`@csp_update` appended to one directive. `@csp_override` does not replace one directive - it replaces the ENTIRE policy. The middleware uses the decorator's dict instead of `SECURE_CSP` and merges nothing, so `@csp_override({"form-action": [...]})` serves a page whose only directive is `form-action`: no `script-src`, no `default-src`, and therefore no restriction on scripts whatsoever - on the OAuth consent screen and the account-connection flows. Measured against `django/middleware/csp.py`, and pinned by `tests/test_csp_overrides.py`, which discovers every routed `@csp_override` site from the URLconf. The **three** converted sites splat `settings.CSP_POLICY` and replace one key. Do not shorten them to just the directive being widened.
+
+There were four `@csp_update` decorators, not three. The fourth - on the onboarding OAuth start view - is DELETED rather than converted: every one of the ten hosts it appended is already in the base `form-action` list, so under django-csp's append semantics its effective policy was the base policy. That was settled by set membership against the two lists, not by reading the code and judging it harmless. Reproducing it as an override would have shipped a decorator whose presence claims an effect it does not have.
+
+`request.csp_nonce` does not exist in core Django - the nonce lives at `request._csp_nonce` and reaches templates as `{{ csp_nonce }}`. The old spelling degrades to an empty string rather than raising, which blocks every inline script in production while every static check, the unit suite and the local dev server all stay green. This is the defect the e2e suite exists to catch.

--- a/design/django-6-0-not-5-2-lts.md
+++ b/design/django-6-0-not-5-2-lts.md
@@ -1,0 +1,19 @@
+# Target Django 6.0 rather than the 5.2 LTS
+
+**Chosen:** Django 6.0.7.
+
+**The comparison is NOT 6.0 against a supported 5.2, and reading it that way inverts the answer.** This application is on **5.1**, which left extended support in December 2025. There is no do-nothing option and no cheap option: both candidate targets cost exactly one migration from here.
+
+So the question is which line that migration puts us ON. 5.2 is a terminal branch - it is supported to April 2028 and then has to be left, at the cost of a SECOND migration, to reach whatever LTS follows. 6.0 is the live line, and 6.2 LTS is reachable directly from it. Taking 6.0 now is the shortest path to LTS status, not a detour from one.
+
+**What it costs, stated plainly.** 6.0's mainstream support ended in August 2026; it receives security fixes only, until April 2027. That is a real window and it is short, which is why the 6.2 step below is a commitment rather than an aspiration. It is not, however, 'eight months less runway than the LTS' - that phrasing compares against a position this application has never occupied.
+
+**What it buys, and this is smaller than it was.** Core CSP lands in 6.0, and it lets this migration DELETE `django-csp` instead of upgrading it. The settings have to be rewritten either way - moving to django-csp 4.x means the same flat-to-nested rewrite - so the identical work buys a dependency removal on 6.0 and a dependency retention on 5.2.
+
+That is the whole of the technical differentiator. The background task system is explicitly NOT one: `django-background-tasks` is retained and runs unchanged on either target, so it gives no reason to prefer 6.0 over 5.2. Core `django.tasks` is not a factor here - it ships no durable backend and no scheduler, so adopting it would be a project of its own rather than a benefit of arriving.
+
+**So state the cost without the false comparison.** It is NOT '6.0 has less runway than 5.2'. That sets 6.0's window against a position this application has never held, and it prices the two targets as though they were the same KIND of thing. They are not: 5.2 is terminal, and reaching an LTS from there costs a SECOND migration about the size of this one, while from 6.0 the LTS is a minor-version step. Counting calendar months to 2028 and stopping there hides that second migration entirely.
+
+The real cost is DISCIPLINE. Taking 6.0 obliges the project to move through 6.1 and 6.2 roughly on schedule - and that is the same obligation which was not met on 5.1, which is the only reason this migration exists. If minor upgrades will not be taken on time, 5.2 buys idle years and then presents the same bill with interest. That is the question worth re-opening, and it is a question about how the project is run, not about which dates are printed on a support table.
+
+**Consequence to plan for.** 6.2 LTS is due April 2027, inside 6.0's security window. The intended path is 6.0 -> 6.2 LTS, not 6.0 -> 6.1.

--- a/design/e2e-ephemeral-postgres.md
+++ b/design/e2e-ephemeral-postgres.md
@@ -1,0 +1,11 @@
+# The e2e suite stands up its own PostgreSQL cluster
+
+**Chosen:** `initdb` into a temporary directory, `pg_ctl` on a free port, trust authentication, torn down when the session ends. Roughly 4.4 seconds, measured.
+
+**Why not a shared local server.** It would need credentials, it would need to already exist, and two runs would collide. "Ephemeral" means the harness owns the server, which is precisely what removes the configuration.
+
+**Why not Docker.** It is separate infrastructure with its own daemon and its own state, and introducing it is not a decision the test suite gets to make on a developer's machine.
+
+**Why not pytest-postgresql.** Ruled out on evidence, not preference: on Windows it launches the server with `-c log_destination='stderr'` and nothing strips the quotes, so the server rejects its own configuration with `invalid value for parameter "log_destination"`.
+
+**Three things the hand-rolled fixture must keep doing.** No quoted values in `pg_ctl -o`. No pipe for `pg_ctl start` - the daemonised server inherits the handle and holds it open forever, so the caller blocks on an EOF that never comes. And decode output with `errors="replace"`, because postgres emits messages in the operating system's language and a UTF-8 assumption dies on the first umlaut.

--- a/design/keep-django-background-tasks.md
+++ b/design/keep-django-background-tasks.md
@@ -1,0 +1,15 @@
+# The background task library is kept, not replaced
+
+**Chosen:** keep `django-background-tasks` 1.2.8.
+
+Moving to Django 6.0 does not require replacing it, and that was measured rather than assumed. Driven against the real tree on 6.0.7 with a real PostgreSQL: its migrations apply, a `@background` call writes a row, and `process_tasks` executed all eleven recurring jobs the `post_migrate` hooks register - every one finishing with no failure recorded.
+
+**Core `django.tasks` was not adopted, and it is not a near miss.** Django 6.0 ships the task CONTRACT - `@task`, `Task.enqueue`, `TaskResult` - and two backends, `immediate` and `dummy`. There is no durable backend and no scheduler in core. Adopting it therefore means writing and owning a database-backed runner and a periodic scheduler: a project with its own concurrency failure modes, not a step in a framework upgrade.
+
+**Three properties of the retained worker, measured.** None is a regression - all three are true of the system today - but nothing in this repository stated them, and each one turns an outage into a silent one.
+
+- `process_tasks` **exits 0 when the database is unreachable.** It prints `Failed to retrieve tasks. Database unreachable.` and returns success. Anything watching exit codes sees green while no work is running at all.
+- It has **no single-pass mode.** It loops until killed, so there is no invocation whose exit code could be checked even in principle; `--duration` is the only way to make it return.
+- **Every `repeat=` task re-queues itself on completion**, and the `post_migrate` hooks re-register any that are missing. The `background_task` table therefore never drains, so any procedure that says "wait until the queue is empty" waits forever.
+
+Revisit this when core Django gains a durable backend, or when the library stops working on a supported Django. Not before.

--- a/design/no-lockfile.md
+++ b/design/no-lockfile.md
@@ -1,0 +1,7 @@
+# Dependency versions are ranges, with no lockfile
+
+`requirements.txt` declares ranges. There is no `uv.lock`, `poetry.lock` or `requirements.lock` in the repository, so the resolved transitive tree differs between any two installs.
+
+This migration verified that the full declared set resolves against Django 6.0.7 (83 packages, no conflicts), but a successful resolution is not a reproducible one.
+
+Decision: **left as-is.** Introducing a lockfile changes how every deployment target installs dependencies, which is a larger and independent change. Recorded so the absence is understood as unaddressed rather than considered and accepted.

--- a/design/settings-manager-is-unwired.md
+++ b/design/settings-manager-is-unwired.md
@@ -1,0 +1,10 @@
+# apps.settings_manager is declared but largely unconsulted
+
+`apps/settings_manager` implements a three-tier cascade (workspace -> org -> `APP_DEFAULTS`) and declares roughly forty keys. Almost nothing reads it.
+
+Concrete examples found at migration time:
+
+- `APP_DEFAULTS['publishing.first_comment_delay_seconds']` exists, while   the publisher reads `settings.PUBLISHER_FIRST_COMMENT_DELAY` - a name   that is not defined in `config/settings/base.py` either, so the   hardcoded fallback is what actually runs.
+- `apps/approvals/tasks.py` carried a comment claiming its thresholds   were overridable through the cascade. No `get_setting()` call exists   in that module.
+
+Decision: **not resolved in this migration.** Either wiring the cascade up or deleting the app is a behavioural change unrelated to Django 6, and mixing it in would make the migration unreviewable. The false comment is corrected; the underlying duplication is recorded here so the next reader does not mistake the layer for a live one.

--- a/design/unused-mcp-dependency.md
+++ b/design/unused-mcp-dependency.md
@@ -1,0 +1,7 @@
+# The `mcp` SDK dependency is unused
+
+`requirements.txt` pins `mcp>=1.0,<2.0` and describes it as backing the `/api/v1/mcp` transport. `apps/mcp/transport.py` states the opposite in its module docstring: the JSON-RPC core was hand-rolled *because* the SDK assumes an ASGI/Starlette stack while this project is WSGI Django.
+
+A tree-wide scan during migration found zero imports of `mcp`. It pulls roughly fifteen transitive packages (starlette, uvicorn, sse-starlette, pydantic-settings, jsonschema, python-multipart, ...).
+
+Decision: left in place. Removing it is correct but belongs to a dependency-hygiene change, not a framework migration - keeping the two separate keeps this migration's blast radius reviewable.

--- a/development_specs/architecture.md
+++ b/development_specs/architecture.md
@@ -8,7 +8,7 @@ Companion to: Feature Specification v2
 
 | Layer | Technology |
 |-------|-----------|
-| Backend | Django 5.x, Django REST Framework |
+| Backend | Django 6.0, Django REST Framework |
 | Frontend | Django templates, HTMX, Alpine.js |
 | CSS | Tailwind CSS 4 via django-tailwind |
 | Database | PostgreSQL 16+ (also serves as job queue) |
@@ -317,7 +317,7 @@ STORAGE_BACKEND=s3     →  S3Boto3Storage via django-storages
 | Encryption at rest | AES-256-GCM for tokens/keys/credentials, key from env var |
 | Data isolation | Custom ORM manager auto-filters by org_id/workspace_id |
 | CSRF | Django middleware, HTMX auto-includes token |
-| CSP | Restrictive policy via django-csp |
+| CSP | Restrictive policy via Django's built-in CSP middleware |
 | Rate limiting | django-ratelimit on login, API, OAuth endpoints |
 | Audit log | Append-only, destructive actions, retained 1 year |
 | GDPR | Export + deletion per workspace/org |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-target-version = "py312"
+target-version = "py313"
 line-length = 120
 # Django generates migrations with its own import ordering/formatting; don't
 # lint or format generated schema migrations.
@@ -33,7 +33,7 @@ ignore = [
 known-first-party = ["apps", "config"]
 
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.13"
 plugins = ["mypy_django_plugin.main"]
 ignore_missing_imports = true
 
@@ -45,7 +45,10 @@ DJANGO_SETTINGS_MODULE = "config.settings.test"
 python_files = ["tests.py", "test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
-addopts = "-v --tb=short"
+addopts = "-v --tb=short -m 'not e2e'"
+markers = [
+    "e2e: end-to-end; stands up its own PostgreSQL cluster and drives a real browser",
+]
 
 [tool.coverage.run]
 source = ["apps"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Core
-Django>=5.1,<5.2
+Django>=6.0.7,<6.1
 django-environ>=0.11,<1.0
 psycopg[binary]>=3.1,<4.0
 gunicorn>=22.0,<23.0
@@ -20,7 +20,6 @@ django-storages[s3]>=1.14,<2.0
 Pillow>=10.4,<11.0
 
 # Security
-django-csp>=3.8,<4.0
 django-ratelimit>=4.1,<5.0
 cryptography>=43.0,<44.0
 
@@ -54,6 +53,7 @@ types-python-dateutil>=2.9,<3.0
 pytest>=8.3,<9.0
 pytest-django>=4.8,<5.0
 pytest-cov>=5.0,<6.0
+pytest-playwright>=0.5,<1.0
 factory-boy>=3.3,<4.0
 
 # Monitoring

--- a/requirements/background-work.md
+++ b/requirements/background-work.md
@@ -1,0 +1,9 @@
+# Deferred work runs, and a worker that has stopped is visible
+
+Publishing, inbox sync, notification retries, media processing, analytics collection and scheduled organization deletion all happen outside the request cycle. The application is not correct if they do not run.
+
+**A worker process must be running.** The web service only enqueues; nothing in it executes. A deployment with a healthy web service and no worker serves every page correctly and publishes nothing.
+
+**Worker health must not be inferred from its exit code.** The worker exits 0 when it cannot reach the database, and it has no single-pass mode - so "the process is alive" and "work is being done" are different questions, and only the first is easy to ask. Monitor the WORK: the age of the oldest due-but-unrun row is the signal. A process table is not.
+
+**A non-empty queue is the normal state.** Recurring tasks re-queue themselves as they complete, so `background_task` never empties. Depth alone is not a backlog and must not be alerted on; growing age is.

--- a/requirements/content-security-policy.md
+++ b/requirements/content-security-policy.md
@@ -1,0 +1,9 @@
+# The application enforces a Content Security Policy
+
+A CSP is enforced on every response in production, and reported-only in development and test.
+
+Inline scripts carry the request nonce. Templates read it as `{{ csp_nonce }}`, published by `django.template.context_processors.csp`. The nonce is **not** available as `request.csp_nonce` - Django keeps it private - and the template language resolves a missing attribute to the empty string, so getting this wrong disables every inline script with no error anywhere.
+
+Views that hand control to an external OAuth provider must extend `form-action` to include that provider's post-consent redirect target. Chromium enforces `form-action` across the entire redirect chain, so omitting the target breaks the flow with no visible error.
+
+Such a view must serve the WHOLE policy, not just the directive it widens. `@csp_override` replaces the entire policy rather than merging into it, so a decorator carrying only `form-action` leaves that page with no `script-src` and no `default-src` - which places no restriction on scripts at all, on exactly the pages that hand control to a third party. Extensions splat `settings.CSP_POLICY` and replace one key.

--- a/requirements/dependency-currency.md
+++ b/requirements/dependency-currency.md
@@ -1,0 +1,7 @@
+# The application runs on a supported Django release
+
+The application must run on a Django release that is still receiving security fixes.
+
+At migration time the tree was pinned to `Django>=5.1,<5.2`. Django 5.1 left extended support in December 2025, so the deployed framework had been unpatched for roughly eight months while handling stored OAuth refresh tokens for a dozen third-party platforms.
+
+A pin that excludes every supported release is a defect, not a configuration preference.

--- a/requirements/end-to-end-testing.md
+++ b/requirements/end-to-end-testing.md
@@ -1,0 +1,13 @@
+# Behaviour is verified end-to-end, in a browser, against a real database
+
+A feature is done when it is tested end-to-end.
+
+The suite drives a real browser against the application served from a real PostgreSQL database, under the same Content Security Policy production enforces.
+
+**The database is ephemeral and belongs to the run.** It is created when the session starts and destroyed when it ends. A test run must not require a database to have been provisioned first, must not need credentials, and must not leave anything behind.
+
+**The e2e settings enforce what production enforces.** Any setting that is relaxed for local convenience - the CSP is the one that matters - is restored here. A harness configured more leniently than production reports success for defects that only production will meet.
+
+**Unit tests are not a substitute.** The defect that motivated this requirement passed the ENTIRE unit suite, every static check, and `manage.py check`, because it only manifests when a browser applies a policy to a rendered page.
+
+No test count is quoted here, deliberately. A number written into prose is a claim that stops being true the next time somebody adds a test, and this sentence had already outlived two of them. If you want the figure, run the suite - it is the only source that cannot be stale.

--- a/requirements/python-version.md
+++ b/requirements/python-version.md
@@ -1,0 +1,19 @@
+# The application runs on a single declared Python version
+
+The application targets **Python 3.13**.
+
+One version is declared, in `.python-version`. Every other place that names an interpreter derives from that declaration and must not diverge from it. There are seven such places, and they are listed because the list is the whole requirement:
+
+- `Dockerfile` - the image that actually ships
+- `pyproject.toml` `[tool.ruff] target-version`
+- `pyproject.toml` `[tool.mypy] python_version`
+- `.github/workflows/ci.yml` - three `setup-python` jobs
+- `.pre-commit-config.yaml` `default_language_version`
+- `README.md` - the version badge
+- `README.md` - the **Prerequisites** list, which is what a new contributor actually installs from
+
+This list has been wrong twice, and both times in the same direction: a place that names the interpreter was not counted, so the application shipped on one version while something else targeted another. First it was CI and pre-commit, which decide whether a change may merge. Then it was the two entries above - the front page - where the cost lands on somebody who has no way to know better: they install what the README says, and `pre-commit` then fails looking for an interpreter they were never told to have.
+
+So: **if an eighth place appears, it belongs on this list**, and a place counts whether or not any tool reads it. Nothing mechanical enforces this - no gate in this repository reads prose - which is precisely why the obligation is written down rather than assumed.
+
+Django 6.0 supports 3.12-3.14; 3.13 sits inside that window with headroom on both sides.

--- a/templates/account/signup.html
+++ b/templates/account/signup.html
@@ -131,7 +131,7 @@
 {% endblock %}
 
 {% block extra_js %}
-<script nonce="{{ request.csp_nonce }}">
+<script nonce="{{ csp_nonce }}">
     // Detect browser timezone so the server can set it as the organization default on signup.
     try {
         var tz = Intl.DateTimeFormat().resolvedOptions().timeZone;

--- a/templates/analytics/index.html
+++ b/templates/analytics/index.html
@@ -52,7 +52,7 @@
         <div x-html="drawerContent" id="drawer-host" style="display: flex; flex-direction: column; height: 100%;"></div>
     </div>
 
-    <script nonce="{{ request.csp_nonce }}">
+    <script nonce="{{ csp_nonce }}">
         function openPost(url) {
             const root = document.querySelector('.analytics-shell');
             const drawer = window.Alpine ? window.Alpine.$data(root) : null;

--- a/templates/approvals/partials/_toasts.html
+++ b/templates/approvals/partials/_toasts.html
@@ -6,7 +6,7 @@ success|info|warn|error. Self-contained: not added to base.html (app shell untou
 Include this ONCE per page, OUTSIDE any htmx-refetched region, so a list refresh
 fired by the same response doesn't tear down the toast before it's seen.
 {% endcomment %}
-<style nonce="{{ request.csp_nonce }}">
+<style nonce="{{ csp_nonce }}">
   @keyframes bb-toastPop { from { opacity:0; transform:translateY(8px) scale(.96); } to { opacity:1; transform:translateY(0) scale(1); } }
   /* Shared approval-surface animations (design parity). Defined here because this
      partial is included once per page, outside any htmx-refetched region. */
@@ -24,7 +24,7 @@ fired by the same response doesn't tear down the toast before it's seen.
   .bb-toast-body { font-size:.75rem; color:#A8A29E; line-height:1.2; }
 </style>
 <div id="bb-toast-host" aria-live="polite" aria-atomic="true"></div>
-<script nonce="{{ request.csp_nonce }}">
+<script nonce="{{ csp_nonce }}">
 (function () {
   if (window.__bbToastInit) return;
   window.__bbToastInit = true;

--- a/templates/base.html
+++ b/templates/base.html
@@ -12,7 +12,7 @@
     <link rel="manifest" href="{% static 'favicon/site.webmanifest' %}">
     <link rel="stylesheet" href="{% static 'css/dist/styles.css' %}">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.css">
-    <script nonce="{{ request.csp_nonce }}">
+    <script nonce="{{ csp_nonce }}">
         // Set sidebar state class on <html> before first paint to prevent flash
         if (localStorage.getItem('sidebarCollapsed') === 'true') {
             document.documentElement.classList.add('sidebar-is-collapsed');
@@ -207,7 +207,7 @@
 </head>
 <body class="text-gray-900 min-h-screen" style="background: var(--surface-page);">
     {% csrf_token %}
-    <script nonce="{{ request.csp_nonce }}">
+    <script nonce="{{ csp_nonce }}">
         document.body.addEventListener('htmx:configRequest', function(event) {
             event.detail.headers['X-CSRFToken'] = document.querySelector('[name=csrfmiddlewaretoken]').value;
         });
@@ -237,7 +237,7 @@
             </button>
         </div>
     </div>
-    <script nonce="{{ request.csp_nonce }}">
+    <script nonce="{{ csp_nonce }}">
         document.body.addEventListener('htmx:responseError', function(event) {
             var elt = event.detail.elt;
             // Contexts that manage their own error UI opt out entirely.
@@ -905,7 +905,7 @@
 
     <!-- Vendored JS -->
     <script src="{% static 'js/htmx.min.js' %}"></script>
-    <script nonce="{{ request.csp_nonce }}">
+    <script nonce="{{ csp_nonce }}">
         /* Notification bell - Alpine.js component */
         function notificationBell() {
             return {
@@ -953,7 +953,7 @@
     <script src="{% static 'js/alpine.min.js' %}" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/flatpickr@4.6.13/dist/flatpickr.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.6/dist/chart.umd.min.js"></script>
-    <script nonce="{{ request.csp_nonce }}">
+    <script nonce="{{ csp_nonce }}">
         /* Analytics hero chart: read data attrs off the canvas, (re)create Chart.js.
            Lives in base.html so its CSP nonce matches the parent page — the chart
            partial re-renders on HTMX swaps via the htmx:afterSwap hook below. */
@@ -1053,7 +1053,7 @@
         });
     </script>
     {% if request.workspace %}
-    <script nonce="{{ request.csp_nonce }}">
+    <script nonce="{{ csp_nonce }}">
         window.ideaModalHelpers = window.ideaModalHelpers || {
             mediaAssetIdsCsv(items) {
                 return (items || []).map(function(item) { return item.asset_id; }).join(',');

--- a/templates/calendar/calendar.html
+++ b/templates/calendar/calendar.html
@@ -325,7 +325,7 @@
 {% endblock %}
 
 {% block extra_js %}
-<script nonce="{{ request.csp_nonce }}">
+<script nonce="{{ csp_nonce }}">
 function calendarApp() {
     return {
         activeView: '{{ view_type }}',

--- a/templates/client_portal/portal_base.html
+++ b/templates/client_portal/portal_base.html
@@ -15,7 +15,7 @@
 </head>
 <body class="min-h-screen" style="background: var(--surface-1); font-family: var(--font-body); color: var(--text-primary);">
     {% csrf_token %}
-    <script nonce="{{ request.csp_nonce }}">
+    <script nonce="{{ csp_nonce }}">
         document.body.addEventListener('htmx:configRequest', function(event) {
             event.detail.headers['X-CSRFToken'] = document.querySelector('[name=csrfmiddlewaretoken]').value;
         });

--- a/templates/composer/compose.html
+++ b/templates/composer/compose.html
@@ -1947,7 +1947,7 @@
 {% endblock %}
 
 {% block extra_js %}
-<script nonce="{{ request.csp_nonce }}">
+<script nonce="{{ csp_nonce }}">
   // Reviewer approve / request-changes return 204 + toast + approvalAction. Let the
   // toast show, then reload so the status banner and history reflect the new state.
   document.body.addEventListener('approvalAction', function () {
@@ -1958,7 +1958,7 @@
 {{ char_limits|json_script:"composer-char-limits" }}
 {{ platform_extras|json_script:"composer-platform-extras" }}
 {{ media_items|json_script:"composer-media-items" }}
-<script nonce="{{ request.csp_nonce }}">
+<script nonce="{{ csp_nonce }}">
 function composerApp() {
     return {
         // State

--- a/templates/composer/create_landing.html
+++ b/templates/composer/create_landing.html
@@ -1089,7 +1089,7 @@
 {% endblock %}
 
 {% block extra_js %}
-<script nonce="{{ request.csp_nonce }}">
+<script nonce="{{ csp_nonce }}">
 function kanbanBoard() {
     const ideaHelpers = window.ideaModalHelpers || {
         mediaAssetIdsCsv(items) {

--- a/templates/inbox/feed.html
+++ b/templates/inbox/feed.html
@@ -217,7 +217,7 @@
 {% endblock %}
 
 {% block extra_js %}
-<script nonce="{{ request.csp_nonce }}">
+<script nonce="{{ csp_nonce }}">
 function inboxController() {
     return {
         activePanel: 'list',

--- a/templates/intelligence/_panel_research_content_gaps.html
+++ b/templates/intelligence/_panel_research_content_gaps.html
@@ -196,7 +196,7 @@
         background: var(--primary-soft, #fff7ed);
     }
 </style>
-<script nonce="{{ request.csp_nonce }}">
+<script nonce="{{ csp_nonce }}">
 (function () {
     var data = [];
     try {

--- a/templates/intelligence/_panel_score_packaging.html
+++ b/templates/intelligence/_panel_score_packaging.html
@@ -108,7 +108,7 @@
     </div>
 </div>
 
-<script nonce="{{ request.csp_nonce }}">
+<script nonce="{{ csp_nonce }}">
 (function () {
     // Score-packaging file-upload widget. All UX-only; the server
     // re-runs the same checks (size, MIME, Pillow magic-byte) before

--- a/templates/intelligence/playground.html
+++ b/templates/intelligence/playground.html
@@ -317,7 +317,7 @@
 {% endblock %}
 
 {% block extra_js %}
-<script nonce="{{ request.csp_nonce }}">
+<script nonce="{{ csp_nonce }}">
     (function () {
         const PANELS = ['packaging', 'video-hook', 'benchmark-channel', 'benchmark-video', 'content-gaps', 'niches'];
 

--- a/templates/media_library/_tag_input.html
+++ b/templates/media_library/_tag_input.html
@@ -45,7 +45,7 @@
   {% endif %}
 </div>
 
-<script nonce="{{ request.csp_nonce }}">
+<script nonce="{{ csp_nonce }}">
 function tagInput(initialTags) {
   return {
     tags: initialTags || [],

--- a/templates/media_library/asset_edit.html
+++ b/templates/media_library/asset_edit.html
@@ -211,7 +211,7 @@
 {% block extra_js %}
 {% if asset.file_type == 'image' or asset.file_type == 'gif' %}
 <script src="{% static 'js/vendor/cropper.min.js' %}"></script>
-<script nonce="{{ request.csp_nonce }}">
+<script nonce="{{ csp_nonce }}">
 function imageCropper() {
   return {
     cropper: null,
@@ -278,7 +278,7 @@ function imageCropper() {
 }
 </script>
 {% elif asset.file_type == 'video' %}
-<script nonce="{{ request.csp_nonce }}">
+<script nonce="{{ csp_nonce }}">
 function videoTrimmer() {
   return {
     duration: {{ asset.duration_seconds|default:"0" }},

--- a/templates/media_library/library_index.html
+++ b/templates/media_library/library_index.html
@@ -321,7 +321,7 @@
 
 {% block extra_js %}
 <script src="{% static 'js/media-library.js' %}"></script>
-<script nonce="{{ request.csp_nonce }}">
+<script nonce="{{ csp_nonce }}">
 function mediaLibrary() {
   return {
     viewMode: 'grid',

--- a/templates/media_library/shared_library.html
+++ b/templates/media_library/shared_library.html
@@ -83,7 +83,7 @@
 </div>
 
 {% if is_admin %}
-<script nonce="{{ request.csp_nonce }}">
+<script nonce="{{ csp_nonce }}">
 function uploadShared(files) {
   if (!files || files.length === 0) return;
   const csrfToken = document.querySelector('[name=csrfmiddlewaretoken]').value;

--- a/templates/ninja/swagger_cdn.html
+++ b/templates/ninja/swagger_cdn.html
@@ -11,10 +11,10 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js"></script>
-    <script type="application/json" id="swagger-settings" nonce="{{ request.csp_nonce }}">
+    <script type="application/json" id="swagger-settings" nonce="{{ csp_nonce }}">
         {{ swagger_settings | safe }}
     </script>
-    <script nonce="{{ request.csp_nonce }}">
+    <script nonce="{{ csp_nonce }}">
 
         const configJson = document.getElementById("swagger-settings").textContent;
         const configObject = JSON.parse(configJson);

--- a/templates/social_accounts/account_select.html
+++ b/templates/social_accounts/account_select.html
@@ -56,7 +56,7 @@
     </form>
 </div>
 
-<script nonce="{{ request.csp_nonce }}">
+<script nonce="{{ csp_nonce }}">
     document.getElementById('connect-btn').closest('form').addEventListener('submit', function(e) {
         const btn = document.getElementById('connect-btn');
         if (btn.disabled) {

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,315 @@
+"""Fixtures for the end-to-end suite.
+
+The suite owns its database. A PostgreSQL cluster is created in a temporary
+directory when the session starts, listens on a port nobody else holds, and is
+destroyed when the session ends. Nothing connects to a pre-existing server, so
+there is no credential to configure, no shared state to collide with, and
+nothing left behind.
+
+Run it:
+
+    make test-e2e
+
+or directly:
+
+    pytest -m e2e --ds=config.settings.e2e tests/e2e
+
+The settings module is not optional. config/settings/e2e.py ENFORCES the
+Content Security Policy; config/settings/test.py only reports it.
+"""
+
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+SUPERUSER = "postgres"
+DATABASE_NAME = "brightbean_e2e"
+READY_TIMEOUT_S = 60
+
+#: How many times to try starting the cluster on a freshly chosen port.
+PORT_ATTEMPTS = 3
+
+#: Installed over CDP before the first byte of the page, so it is not itself
+#: subject to the page's Content Security Policy. A recorder injected as an
+#: inline <script> would be silenced by exactly the fault it exists to observe.
+CSP_VIOLATION_RECORDER = """
+window.__cspViolations = [];
+document.addEventListener('securitypolicyviolation', function (event) {
+    window.__cspViolations.push({
+        directive: event.violatedDirective,
+        blockedURI: event.blockedURI,
+        sample: event.sample,
+    });
+});
+"""
+
+
+def pytest_collection_modifyitems(items):
+    """Mark everything under this directory e2e, so no test file has to remember.
+
+    The path check is load-bearing. A conftest hook is handed EVERY collected
+    item, not only the ones beneath it, so without the check a plain `pytest`
+    run would mark the entire unit suite e2e and the default `-m "not e2e"`
+    would then deselect all of it.
+    """
+    here = Path(__file__).parent.resolve()
+    for item in items:
+        path = Path(item.path).resolve()
+        if here == path.parent or here in path.parents:
+            item.add_marker("e2e")
+
+
+def _find_postgres_bin_dir() -> Path:
+    """Locate initdb/pg_ctl.
+
+    A VERSIONED INSTALL DIRECTORY FIRST, PATH only as a fallback - which is the
+    opposite of the obvious order, on purpose.
+
+    On Debian and Ubuntu `/usr/bin/initdb` and `/usr/bin/pg_ctl` are pg_wrapper
+    shims that pick a cluster by their own rules rather than being one server's
+    binaries. Taking PATH first therefore hands `-D` and `-o "-p PORT ..."` to a
+    wrapper on the assumption it behaves like the real thing, and skips the
+    version selection below entirely - in exactly the environment where more
+    than one major is likely to be installed, which is CI.
+
+    Preferring the versioned directory makes the choice explicit and reachable.
+    PATH still covers an install somewhere non-standard.
+    """
+    if os.name == "nt":
+        roots = [Path(r"C:\Program Files\PostgreSQL")]
+        pattern = "*/bin/initdb.exe"
+    else:
+        roots = [Path("/usr/lib/postgresql")]
+        pattern = "*/bin/initdb"
+    found = [p.parent for root in roots if root.is_dir() for p in root.glob(pattern)]
+    if not found:
+        on_path = shutil.which("initdb")
+        if on_path:
+            return Path(on_path).parent
+        raise RuntimeError("no PostgreSQL binaries on PATH or in the usual install locations")
+
+    def version(path):
+        """Parse the version directory name, so 18 sorts above 9.6.
+
+        These names are versions, not words. Sorted as STRINGS - which is what
+        this did - "9.6" beats "18" beats "16" beats "10", so on any host with
+        more than one server installed the harness picked the OLDEST. Locally
+        there is exactly one install, so the sort is a no-op and the suite
+        passing proves nothing about this branch; on GitHub's runner, where the
+        image may already carry a major before apt installs another, which one
+        gets used would not be decided by anything anybody chose.
+        """
+        try:
+            return tuple(int(part) for part in path.parent.name.split("."))
+        except ValueError:
+            # Not a version at all - a vendor directory, a symlink farm. Rank it
+            # below everything that does parse rather than crashing the session.
+            return (-1,)
+
+    return sorted(found, key=version)[-1]
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def _run_to_completion(cmd, *, sink=None):
+    """Run a command to completion, raising on a non-zero exit.
+
+    `sink` names a file to receive the child's output. Pass it for anything
+    that leaves a daemon behind: `pg_ctl start` hands its standard handles to
+    the postgres it spawns, and the server holds them open for its entire life,
+    so a pipe here never reaches EOF and the caller blocks forever. `-l` does
+    not help - that redirects the server's log, not the inherited handles.
+
+    Output is decoded with errors="replace" because postgres speaks the
+    operating system's language, which is not necessarily UTF-8.
+    """
+    if sink is not None:
+        with open(sink, "ab") as handle:
+            completed = subprocess.run(cmd, stdout=handle, stderr=subprocess.STDOUT, check=False)
+        output = ""
+    else:
+        completed = subprocess.run(cmd, capture_output=True, encoding="utf-8", errors="replace", check=False)
+        output = (completed.stdout or "") + (completed.stderr or "")
+    if completed.returncode != 0:
+        raise RuntimeError(f"{Path(cmd[0]).name} failed ({completed.returncode}):\n{output}")
+    return output
+
+
+def _can_connect(port: int) -> bool:
+    import psycopg
+
+    try:
+        with psycopg.connect(host="127.0.0.1", port=port, user=SUPERUSER, dbname="postgres", connect_timeout=3):
+            return True
+    except Exception:
+        return False
+
+
+def _wait_until_ready(port: int) -> None:
+    """Poll until the cluster accepts a real connection.
+
+    Readiness is proven by connecting rather than by trusting `pg_ctl -w`,
+    because what the suite needs to know is whether psycopg can talk to it.
+    """
+    deadline = time.monotonic() + READY_TIMEOUT_S
+    while time.monotonic() < deadline:
+        if _can_connect(port):
+            return
+        time.sleep(0.3)
+    raise RuntimeError(f"cluster did not accept connections within {READY_TIMEOUT_S}s")
+
+
+@pytest.fixture(scope="package", autouse=True)
+def allow_sync_orm_on_the_browser_greenlet():
+    """Let synchronous ORM calls run while a Playwright greenlet is on the stack.
+
+    Playwright's synchronous API drives the browser from a greenlet running on
+    an asyncio loop, so Django sees "an async context" and refuses every
+    synchronous ORM call. That breaks pytest-django's own teardown, which
+    flushes the database after a live_server test - the tests pass and the run
+    still exits non-zero. The loop belongs to the browser driver, not to the
+    application, so a blocking query on it cannot starve anything that matters.
+
+    AUTOUSE AND SCOPED TO THIS DIRECTORY, DEFINED IN THIS CONFTEST, WHICH IS
+    THE WHOLE POINT. An earlier version set the variable at module level. pytest imports
+    every conftest it walks past during COLLECTION, and mark-based deselection
+    happens afterwards - so a plain `pytest` run, which is what `make test` and
+    CI both run, imported this file and turned Django's async-safety guard off
+    for all 1072 unit tests. Nothing could catch that: the variable can only
+    ever REMOVE failures, so every gate stayed green while a real
+    SynchronousOnlyOperation in application code would have passed the suite
+    and raised only in production.
+
+    PACKAGE scope, not session. An autouse fixture scoped to this directory
+    runs only when a test in this directory does - but a SESSION-scoped one is
+    finalised at the END OF THE SESSION, not when this directory's tests
+    finish. Under `-m ""` or a nightly "run everything" job, that leaves the
+    guard disarmed for every unit test collected after the first e2e test - the
+    module-level failure mode described above, narrowed but not removed. Package
+    scope makes teardown symmetric with setup, which is what was meant.
+
+    The previous value is restored, so nothing leaks back out to a caller that
+    had set it deliberately.
+    """
+    previous = os.environ.get("DJANGO_ALLOW_ASYNC_UNSAFE")
+    os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "1"
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("DJANGO_ALLOW_ASYNC_UNSAFE", None)
+        else:
+            os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = previous
+
+
+def _stop_cluster_immediately(binaries: Path, datadir: Path) -> None:
+    subprocess.run(
+        [str(binaries / "pg_ctl"), "-D", str(datadir), "-m", "immediate", "-w", "stop"],
+        capture_output=True,
+        check=False,
+    )
+
+
+@pytest.fixture(scope="session")
+def ephemeral_postgres():
+    """Create a PostgreSQL cluster for this session; destroy it afterwards."""
+    binaries = _find_postgres_bin_dir()
+    workdir = Path(tempfile.mkdtemp(prefix="brightbean-e2e-pg-"))
+    datadir = workdir / "data"
+    started = False
+    port = 0
+    try:
+        _run_to_completion(
+            [
+                str(binaries / "initdb"),
+                "-D",
+                str(datadir),
+                "-U",
+                SUPERUSER,
+                "--auth-local=trust",
+                "--auth-host=trust",
+                "--encoding=UTF8",
+                "--no-sync",
+            ]
+        )
+        # A FRESH PORT PER ATTEMPT, because _free_port cannot reserve one.
+        # It binds a socket, reads the number the kernel chose and closes it
+        # again - so between that and pg_ctl binding, anything else on the host
+        # may take it. On a developer machine that is rare enough never to have
+        # been seen; on a shared CI runner it is a classic flake, and the e2e
+        # job now blocks every merge, so one flake is indistinguishable from a
+        # real environmental failure. Retrying is cheaper than diagnosing that.
+        for attempt in range(PORT_ATTEMPTS):
+            port = _free_port()
+            try:
+                # No quoted values in -o. A quoted one is passed through
+                # verbatim and the server rejects its own configuration; that
+                # is the bug which makes pytest-postgresql unusable on Windows.
+                _run_to_completion(
+                    [
+                        str(binaries / "pg_ctl"),
+                        "-D",
+                        str(datadir),
+                        "-l",
+                        str(workdir / "postgres.log"),
+                        "-o",
+                        f"-p {port} -F -c listen_addresses=127.0.0.1",
+                        "-w",
+                        "start",
+                    ],
+                    sink=workdir / "pg_ctl.log",
+                )
+                started = True
+                _wait_until_ready(port)
+                break
+            except RuntimeError:
+                if started:
+                    _stop_cluster_immediately(binaries, datadir)
+                    started = False
+                if attempt == PORT_ATTEMPTS - 1:
+                    raise
+        yield {"host": "127.0.0.1", "port": port, "user": SUPERUSER}
+    finally:
+        if started:
+            _stop_cluster_immediately(binaries, datadir)
+        shutil.rmtree(workdir, ignore_errors=True)
+
+
+@pytest.fixture(scope="session")
+def django_db_modify_db_settings(ephemeral_postgres):
+    """Point Django at the ephemeral cluster before the test database is built.
+
+    pytest-django's own `django_db_setup` depends on this fixture by name, so
+    overriding it here is all that is needed to get the ordering right. The
+    settings are mutated in place, which is what pytest-django's own xdist
+    variant does, and happens before any connection is opened.
+    """
+    from django.conf import settings
+
+    settings.DATABASES["default"].update(
+        {
+            "ENGINE": "django.db.backends.postgresql",
+            "NAME": DATABASE_NAME,
+            "USER": ephemeral_postgres["user"],
+            "PASSWORD": "",
+            "HOST": ephemeral_postgres["host"],
+            "PORT": ephemeral_postgres["port"],
+        }
+    )
+
+
+@pytest.fixture
+def csp_page(page):
+    """A Playwright page that records CSP violations from before the first byte."""
+    page.add_init_script(CSP_VIOLATION_RECORDER)
+    return page

--- a/tests/e2e/test_csp_nonce.py
+++ b/tests/e2e/test_csp_nonce.py
@@ -1,0 +1,90 @@
+"""End-to-end regression test for the Content Security Policy nonce.
+
+Django 6.0 keeps the nonce private on the request as `_csp_nonce` and publishes
+it to templates as `{{ csp_nonce }}`. The django-csp spelling this project used
+to carry, `{{ request.csp_nonce }}`, is a missing attribute - and Django
+resolves a missing attribute to the empty string rather than raising. Every
+inline script then renders `nonce=""` and is refused by a script-src that
+lists a nonce: Alpine never initialises, the htmx wiring never binds, and the
+page loads and does nothing.
+
+Nothing else in this repository catches it. It passes `git apply`, compileall,
+ruff, `manage.py check` and the entire unit suite, and it cannot be reproduced
+against the dev or test settings, which run the policy report-only - where a
+violating script is reported and then executed anyway.
+
+Two levels, deliberately:
+
+  * the served bytes, which needs no browser and localises a failure to the
+    template layer;
+  * a real browser under an enforcing policy, which is the only thing that
+    proves the page actually works.
+"""
+
+import re
+import urllib.request
+
+#: Anonymous, always present, and rendered through templates/base.html - so it
+#: carries the inline scripts the nonce has to cover.
+NONCE_BEARING_PAGE_PATH = "/accounts/login/"
+
+NONCED_SCRIPT_TAG_RE = re.compile(r"<script[^>]*\snonce=\"([^\"]*)\"", re.IGNORECASE)
+
+
+def _fetch(url: str) -> str:
+    with urllib.request.urlopen(url, timeout=30) as response:
+        return response.read().decode("utf-8", errors="replace")
+
+
+def test_inline_scripts_carry_a_non_empty_nonce(live_server):
+    """The bytes on the wire carry a real nonce.
+
+    Checked here rather than in the browser because browsers strip the nonce
+    attribute from the DOM - it is observable only in the response body.
+    """
+    html = _fetch(live_server.url + NONCE_BEARING_PAGE_PATH)
+    nonces = NONCED_SCRIPT_TAG_RE.findall(html)
+
+    assert nonces, "no <script nonce=...> in the response at all"
+    empty = [value for value in nonces if not value.strip()]
+    assert not empty, f'{len(empty)} of {len(nonces)} inline scripts rendered nonce=""'
+    assert len(set(nonces)) == 1, f"one response must carry one nonce, saw {len(set(nonces))}"
+
+
+#: django-ninja renders this page from its own template, loaded by absolute
+#: path, rather than through a view that calls render(request, ...). Whether
+#: the csp context processor runs for it is therefore a property of ninja's
+#: internals, not of this codebase - which makes it the one nonce site that
+#: reading the diff cannot settle. Guessing it is how `{{ request.csp_nonce }}`
+#: survived into a tree where it renders empty, which is the defect this module
+#: exists to catch.
+API_DOCS_PAGE_PATH = "/api/v1/docs"
+
+
+def test_the_api_docs_page_carries_a_real_nonce(live_server):
+    html = _fetch(live_server.url + API_DOCS_PAGE_PATH)
+    nonces = NONCED_SCRIPT_TAG_RE.findall(html)
+
+    assert nonces, f"no <script nonce=...> at {API_DOCS_PAGE_PATH} at all"
+    empty = [value for value in nonces if not value.strip()]
+    assert not empty, (
+        f'{len(empty)} of {len(nonces)} inline scripts on {API_DOCS_PAGE_PATH} rendered nonce="". '
+        f"django-ninja renders this template outside the normal view path, so the csp "
+        f"context processor did not run for it - which blocks every script on the docs "
+        f"page under an enforcing policy."
+    )
+
+
+def test_browser_reports_no_csp_violations(live_server, csp_page):
+    """A real browser executes the page without the policy refusing anything.
+
+    Waiting on window.Alpine is a positive control: it proves scripts genuinely
+    ran, so an empty violation list cannot be mistaken for a page that never
+    loaded.
+    """
+    csp_page.goto(live_server.url + NONCE_BEARING_PAGE_PATH, wait_until="domcontentloaded")
+    csp_page.wait_for_function("window.Alpine !== undefined", timeout=15000)
+
+    violations = csp_page.evaluate("window.__cspViolations || []")
+
+    assert violations == [], f"the browser refused {len(violations)} resource(s): {violations}"

--- a/tests/e2e/test_csp_policy.py
+++ b/tests/e2e/test_csp_policy.py
@@ -1,0 +1,58 @@
+"""A per-view CSP override must not shrink the policy to a single directive.
+
+`@csp_override` does not override a DIRECTIVE - it replaces the WHOLE policy.
+django/middleware/csp.py reads the decorator's dict INSTEAD of SECURE_CSP and
+merges nothing:
+
+    if (csp_config := getattr(response, "_csp_config", sentinel)) is sentinel:
+        csp_config = settings.SECURE_CSP
+
+So a decorator carrying only `form-action` serves a page with no `script-src`
+and no `default-src` - which restricts scripts not at all, on exactly the pages
+that hand control to a third party.
+
+Nothing else catches it. The page renders, every static gate passes, the unit
+suite passes, and the header is wrong only in the direction of being too
+permissive - so no browser complains either.
+"""
+
+import urllib.error
+import urllib.request
+
+#: django-oauth-toolkit's consent view. It carries a csp_override widening
+#: form-action to Claude's callback hosts. Anonymous, so it answers with a
+#: redirect to login - and the decorator sets the policy on that response too.
+CONSENT_VIEW_PATH = "/oauth/authorize/"
+
+#: Every directive the base policy defines. Losing any of them on an overridden
+#: view is the defect.
+REQUIRED_DIRECTIVES = ("default-src", "script-src", "style-src", "img-src", "form-action")
+
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Stop at the view's own response; the header we want is on that one."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
+def _fetch_without_following_redirects(url):
+    opener = urllib.request.build_opener(_NoRedirect)
+    try:
+        with opener.open(url, timeout=30) as response:
+            return response.status, response.headers
+    except urllib.error.HTTPError as exc:
+        return exc.code, exc.headers
+
+
+def test_a_csp_override_view_still_serves_the_whole_policy(live_server):
+    status, headers = _fetch_without_following_redirects(live_server.url + CONSENT_VIEW_PATH)
+    policy = headers.get("Content-Security-Policy", "")
+
+    assert status != 404, f"{CONSENT_VIEW_PATH} did not route to the consent view"
+    # Proves the DECORATED view was reached: only its override adds this host,
+    # so an undecorated page or a 404 cannot satisfy this and pass vacuously.
+    assert "https://claude.ai" in policy, f"not the overridden view, or the widening was lost: {policy}"
+
+    missing = [directive for directive in REQUIRED_DIRECTIVES if directive not in policy]
+    assert not missing, f"the override dropped {missing}; this page would restrict scripts not at all: {policy}"

--- a/tests/e2e/test_publish_path.py
+++ b/tests/e2e/test_publish_path.py
@@ -1,0 +1,523 @@
+"""End-to-end: a scheduled post actually reaches the platform.
+
+Publishing is the application's reason to exist, and nothing exercised it end
+to end. The queue tests prove work runs; the CSP tests prove pages render.
+Neither proves that scheduling a post causes a post to be published.
+
+What is real here, and what is not.
+
+REAL: the production command (manage.py run_tasks --once), the declarative
+schedule deciding run_publish_cycle is due, the engine's due-query and its
+ThreadPoolExecutor fan-out, credential resolution through
+_resolve_publish_credentials, the Bluesky provider's own request building and
+response parsing, and every database transition the engine performs.
+
+FAKED: the wire, and only the wire. httpx's own MockTransport answers the two
+AT Protocol calls the provider makes.
+
+That seam is deliberately LOWER than the unit tests use.
+apps/api/tests/test_e2e.py patches PublishEngine._dispatch_to_provider, so the
+provider is never exercised and a malformed payload would pass unnoticed. Here
+the provider builds a real request and the test asserts on what it put on the
+wire - the record type, the text, the parsed facets, and the bearer token.
+
+Bluesky is the platform under test because its auth is session-based, so no app
+credentials have to be invented, and its publish path is two documented XRPC
+calls: com.atproto.server.getSession and com.atproto.repo.createRecord.
+
+transaction=True is REQUIRED, not incidental. poll_and_publish fans out over a
+ThreadPoolExecutor, and those threads open their own database connections. Under
+the default transactional wrapping they would see an empty database and the
+engine would find nothing to publish - the test would pass while proving
+nothing.
+"""
+
+import json
+import os
+from datetime import timedelta
+
+import httpx
+import pytest
+from background_task.models import Task
+from django.core.management import call_command
+from django.utils import timezone
+
+from apps.composer.models import PlatformPost, Post
+from apps.organizations.models import Organization
+from apps.publisher.engine import FIRST_COMMENT_DELAY
+from apps.publisher.models import PublishLog
+from apps.social_accounts.models import SocialAccount
+from apps.workspaces.models import Workspace
+
+DID = "did:plc:e2epublishtest"
+HANDLE = "brightbean-e2e.bsky.social"
+POST_URI = f"at://{DID}/app.bsky.feed.post/3ke2epublish"
+ACCESS_TOKEN = "e2e-access-jwt"
+CAPTION = "shipped by the worker #brightbean"
+BLOB_LINK = "bafye2eblobref"
+
+
+class RecordingBlueskyApi:
+    """A stand-in PDS that answers the two calls publish_post makes.
+
+    Records every request so the test can assert on what the REAL provider
+    code decided to send, rather than on a stub's arguments.
+    """
+
+    def __init__(self):
+        self.requests: list[httpx.Request] = []
+        self.unexpected: list[str] = []
+        self.uploaded_blobs: list[bytes] = []
+        self.create_record_status = 200
+
+    def fail_create_record(self, status: int = 502) -> None:
+        """Make the next publish attempt fail at the platform.
+
+        One handler serves both the success and failure cases deliberately.
+        Stacking a second monkeypatch over the fixture's does NOT work: the
+        replacement client re-injects its own transport over whatever the
+        caller passed, so the second handler is silently discarded and the
+        test passes while proving the opposite of what it claims.
+        """
+        self.create_record_status = status
+
+    def handle(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        path = request.url.path
+        if path.endswith("com.atproto.server.getSession"):
+            return httpx.Response(200, json={"did": DID, "handle": HANDLE})
+        if path.endswith("app.bsky.actor.getProfile"):
+            # The health check reaches this. Tasks are claimed one at a time, so
+            # work enqueued during a tick - schedule_all_health_checks enqueues
+            # check_social_account_health - drains in that same tick rather than
+            # waiting for the next one.
+            return httpx.Response(
+                200,
+                json={"did": DID, "handle": HANDLE, "displayName": "Brightbean E2E", "followersCount": 7},
+            )
+        if path.endswith("com.atproto.repo.uploadBlob"):
+            self.uploaded_blobs.append(request.content)
+            return httpx.Response(
+                200,
+                json={
+                    "blob": {
+                        "$type": "blob",
+                        "ref": {"$link": BLOB_LINK},
+                        "mimeType": "image/png",
+                        "size": len(request.content),
+                    }
+                },
+            )
+        if path.endswith("com.atproto.repo.createRecord"):
+            if self.create_record_status >= 400:
+                return httpx.Response(self.create_record_status, json={"error": "UpstreamFailure"})
+            return httpx.Response(200, json={"uri": POST_URI, "cid": "bafye2etestcid"})
+        # Anything else is a call this test did not predict. Record it rather
+        # than answering it, so an unexpected dependency surfaces instead of
+        # being quietly satisfied.
+        self.unexpected.append(path)
+        return httpx.Response(404, json={"error": "NotFound", "message": path})
+
+    def call(self, suffix: str) -> httpx.Request | None:
+        for request in self.requests:
+            if request.url.path.endswith(suffix):
+                return request
+        return None
+
+    def created_record(self) -> dict:
+        request = self.call("com.atproto.repo.createRecord")
+        assert request is not None, "the provider never called createRecord"
+        return json.loads(request.content)
+
+
+#: How long to let the worker live. It has no --once: `process_tasks` loops
+#: until killed, so a duration is the only way to get it to return. Five
+#: seconds is comfortably more than a mocked publish needs and short enough
+#: that six tests do not dominate the suite.
+WORKER_SECONDS = "5"
+
+
+def run_the_worker():
+    """Enqueue the publish cycle and run the REAL worker until it drains.
+
+    The cycle is enqueued explicitly rather than waited for. `post_migrate`
+    registers it at repeat=15, so a test COULD sit and hope the recurring row
+    comes due inside the worker's lifetime - but that makes every assertion
+    below depend on wall-clock timing against a fifteen-second cadence, which
+    is how a suite becomes intermittently red for reasons nobody can reproduce.
+
+    Calling a @background function IS the enqueue, so this is the same row the
+    scheduler would have produced; only its arrival is made deterministic.
+    """
+    from apps.publisher.tasks import run_publish_cycle
+
+    run_publish_cycle()
+    call_command("process_tasks", "--duration", WORKER_SECONDS)
+
+
+@pytest.fixture
+def bluesky_api(monkeypatch):
+    """Route every httpx request through a MockTransport.
+
+    providers/base.py builds `httpx.Client(timeout=...)` inline per request, so
+    there is no transport to inject - the client class itself is replaced. The
+    substitution is process-wide, which is what the engine's worker threads
+    need, since they build their own clients.
+    """
+    api = RecordingBlueskyApi()
+    real_client = httpx.Client
+
+    def client_with_mock_transport(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(api.handle)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "Client", client_with_mock_transport)
+    return api
+
+
+@pytest.fixture
+def scheduled_post(db):
+    """One Bluesky post, due a minute ago.
+
+    instance_url is deliberately left empty: _resolve_publish_credentials only
+    consults it to override pds_url, and doing so would run the SSRF check,
+    which resolves DNS. token_expires_at is None so the engine's refresh branch
+    is not taken - token refresh is a different path with its own coverage.
+    """
+    organization = Organization.objects.create(name="E2E Publish Org")
+    workspace = Workspace.objects.create(name="E2E Publish WS", organization=organization)
+    account = SocialAccount.objects.create(
+        workspace=workspace,
+        platform="bluesky",
+        account_platform_id=DID,
+        account_name="Brightbean E2E",
+        account_handle=HANDLE,
+        oauth_access_token=ACCESS_TOKEN,
+        connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+    )
+    post = Post.objects.create(workspace=workspace, caption=CAPTION)
+    platform_post = PlatformPost.objects.create(
+        post=post,
+        social_account=account,
+        status=PlatformPost.Status.SCHEDULED,
+        scheduled_at=timezone.now() - timedelta(minutes=1),
+    )
+    return platform_post
+
+
+@pytest.mark.django_db(transaction=True)
+def test_a_due_post_is_published_by_the_worker(bluesky_api, scheduled_post):
+    """The whole chain, driven by the command production actually runs."""
+    run_the_worker()
+
+    scheduled_post.refresh_from_db()
+    assert scheduled_post.status == PlatformPost.Status.PUBLISHED, (
+        f"still {scheduled_post.status!r}; publish_error={scheduled_post.publish_error!r}"
+    )
+    assert scheduled_post.platform_post_id == POST_URI
+    assert scheduled_post.published_at is not None
+
+    # The parent's published_at is maintained for dashboards that show
+    # "last published" without aggregating children at read time.
+    scheduled_post.post.refresh_from_db()
+    assert scheduled_post.post.published_at is not None
+
+    # One attempt, logged. A second row here would mean a double publish.
+    assert PublishLog.objects.filter(platform_post=scheduled_post).count() == 1
+
+
+@pytest.mark.django_db(transaction=True)
+def test_the_provider_put_a_real_at_protocol_record_on_the_wire(bluesky_api, scheduled_post):
+    """What reached the wire is the point.
+
+    Patching _dispatch_to_provider - which the unit suite does - cannot catch a
+    provider that builds the wrong payload, because it never runs one.
+    """
+    run_the_worker()
+
+    assert bluesky_api.unexpected == [], f"unpredicted API calls: {bluesky_api.unexpected}"
+
+    session = bluesky_api.call("com.atproto.server.getSession")
+    assert session is not None, "the provider never opened a session"
+    # Proves the token travelled the whole way: account row ->
+    # _resolve_publish_credentials -> get_provider -> publish_post -> header.
+    assert session.headers["Authorization"] == f"Bearer {ACCESS_TOKEN}"
+
+    body = bluesky_api.created_record()
+    assert body["repo"] == DID
+    assert body["collection"] == "app.bsky.feed.post"
+
+    record = body["record"]
+    assert record["$type"] == "app.bsky.feed.post"
+    assert record["text"] == CAPTION
+    assert record["createdAt"].endswith("Z")
+
+    # The provider parsed "#brightbean" into an AT Protocol facet. A stubbed
+    # dispatch would never have run this code at all.
+    tags = [
+        feature["tag"]
+        for facet in record.get("facets", [])
+        for feature in facet["features"]
+        if feature["$type"] == "app.bsky.richtext.facet#tag"
+    ]
+    assert tags == ["brightbean"], f"facets were not parsed: {record.get('facets')}"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_a_platform_failure_leaves_the_post_retryable(bluesky_api, scheduled_post):
+    """A refused publish must not be marked published, and must not be lost.
+
+    providers.exceptions.APIError carries retryable=True by default and
+    _request raises it without overriding that, so the engine schedules
+    backoff rather than failing the post outright. The row goes back to
+    SCHEDULED so the next _process_retries tick picks it up.
+    """
+    bluesky_api.fail_create_record(502)
+
+    run_the_worker()
+
+    scheduled_post.refresh_from_db()
+    assert scheduled_post.status == PlatformPost.Status.SCHEDULED
+    assert scheduled_post.platform_post_id == ""
+    assert scheduled_post.published_at is None
+    assert scheduled_post.next_retry_at is not None
+    assert "502" in scheduled_post.publish_error
+
+    # AT LEAST one, not exactly one, and the difference is a real property of
+    # the worker rather than test slack.
+    #
+    # `post_migrate` registers run_publish_cycle at repeat=15, so that recurring
+    # row can come due inside the worker's lifetime alongside the one this test
+    # enqueues. Each cycle re-attempts the post, because the engine's due query
+    # filters on `scheduled_at`, NOT on `next_retry_at` - the backoff is honoured
+    # by _process_retries, but a post whose scheduled_at is already past is due
+    # again immediately on the ordinary path.
+    #
+    # Pre-existing, and invisible while a tick ran exactly one cycle. Pinning
+    # this to == 1 would be pinning the number of cycles that happened to fit in
+    # five seconds, which is a clock-speed assertion wearing a behaviour's
+    # clothes.
+    assert scheduled_post.retry_count >= 1
+    assert PublishLog.objects.filter(platform_post=scheduled_post).count() == scheduled_post.retry_count
+
+
+# ---------------------------------------------------------------------------
+# Media: downloaded to a temp file by the engine, uploaded by the provider,
+# and - the part nothing asserted - cleaned up afterwards.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db(transaction=True)
+def test_media_is_uploaded_and_the_temp_file_is_removed(bluesky_api, scheduled_post, monkeypatch):
+    """The engine downloads every attachment to a temp file and unlinks it in a
+    finally. If that ever stops happening a long-lived worker fills its disk,
+    and nothing else in the suite would notice.
+
+    _upload_blob is wrapped rather than replaced - the real implementation still
+    runs, and the wrapper only records which path the engine handed it, so the
+    paths can be checked for existence after the tick.
+    """
+    from django.core.files.base import ContentFile
+
+    from apps.composer.models import PostMedia
+    from apps.media_library.models import MediaAsset
+    from providers.bluesky import BlueskyProvider
+
+    workspace = scheduled_post.social_account.workspace
+    asset = MediaAsset.objects.create(
+        organization=workspace.organization,
+        workspace=workspace,
+        filename="e2e.png",
+        media_type="image",
+        mime_type="image/png",
+    )
+    # The bytes never leave the harness - nothing sniffs content, and the
+    # provider guesses its mime type from the filename - so plain ASCII keeps
+    # escape sequences out of a file that is itself generated from a string.
+    asset.file.save("e2e.png", ContentFile(b"pretend this is a png" * 4), save=True)
+    PostMedia.objects.create(post=scheduled_post.post, media_asset=asset, position=0)
+
+    handed_to_provider: list[str] = []
+    real_upload_blob = BlueskyProvider._upload_blob
+
+    def recording_upload_blob(self, access_token, media_path):
+        handed_to_provider.append(media_path)
+        return real_upload_blob(self, access_token, media_path)
+
+    monkeypatch.setattr(BlueskyProvider, "_upload_blob", recording_upload_blob)
+
+    run_the_worker()
+
+    scheduled_post.refresh_from_db()
+    assert scheduled_post.status == PlatformPost.Status.PUBLISHED, scheduled_post.publish_error
+
+    assert len(handed_to_provider) == 1, "the engine never handed the provider a downloaded file"
+    assert bluesky_api.uploaded_blobs, "no blob reached the platform"
+
+    record = bluesky_api.created_record()["record"]
+    assert record["embed"]["$type"] == "app.bsky.embed.images"
+    assert record["embed"]["images"][0]["image"]["ref"]["$link"] == BLOB_LINK
+
+    leftover = [path for path in handed_to_provider if os.path.exists(path)]
+    assert leftover == [], f"temp files were left behind: {leftover}"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_a_retry_publishes_on_a_later_tick(bluesky_api, scheduled_post):
+    """Scheduling a retry is only half the promise; this is the other half.
+
+    test_a_platform_failure_leaves_the_post_retryable proves the backoff is
+    recorded. Nothing proved the post then actually goes out, which is the part
+    a user cares about.
+    """
+    bluesky_api.fail_create_record(502)
+    run_the_worker()
+
+    scheduled_post.refresh_from_db()
+    assert scheduled_post.retry_count >= 1, "the failure was not recorded as an attempt"
+
+    # The platform recovers, and the post's backoff window elapses. Only ONE
+    # clock has to move now: run_the_worker enqueues the cycle itself, so there
+    # is no scheduler anchor to wind forward - which is one fewer thing this
+    # test depends on than when the queue was ours.
+    bluesky_api.create_record_status = 200
+    PlatformPost.objects.filter(pk=scheduled_post.pk).update(next_retry_at=timezone.now() - timedelta(seconds=1))
+
+    run_the_worker()
+
+    scheduled_post.refresh_from_db()
+    assert scheduled_post.status == PlatformPost.Status.PUBLISHED, scheduled_post.publish_error
+    assert scheduled_post.platform_post_id == POST_URI
+    # Both attempts are on the record: the platform's refusal is not erased by
+    # the eventual success.
+    assert PublishLog.objects.filter(platform_post=scheduled_post).count() >= 2, (
+        "the platform's refusal was erased by the eventual success"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Threads: the first comment, the one DEFERRED hand-off inside the publish path
+# ---------------------------------------------------------------------------
+
+THREADS_USER_ID = "9876543210"
+THREADS_POST_ID = "thread-e2e-1"
+THREADS_REPLY_ID = "thread-e2e-reply"
+FIRST_COMMENT = "and the link is in this reply"
+
+
+class RecordingThreadsApi:
+    """A stand-in Threads Graph API.
+
+    Threads publishes in two steps - create a container, then publish it - and
+    replies exactly the same way with reply_to_id set. Recording the container
+    payloads is therefore enough to tell a post from its reply.
+    """
+
+    def __init__(self):
+        self.requests: list[httpx.Request] = []
+        self.unexpected: list[str] = []
+
+    @staticmethod
+    def form(request: httpx.Request) -> dict:
+        from urllib.parse import parse_qs
+
+        return {key: values[0] for key, values in parse_qs(request.content.decode()).items()}
+
+    def handle(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        path = request.url.path
+        if path.endswith("/me"):
+            return httpx.Response(200, json={"id": THREADS_USER_ID, "username": "brightbean"})
+        if path.endswith("/threads_publish"):
+            is_reply = self.form(request).get("creation_id") == "reply-container"
+            return httpx.Response(200, json={"id": THREADS_REPLY_ID if is_reply else THREADS_POST_ID})
+        if path.endswith("/threads"):
+            reply_to = self.form(request).get("reply_to_id")
+            return httpx.Response(200, json={"id": "reply-container" if reply_to else "post-container"})
+        self.unexpected.append(path)
+        return httpx.Response(404, json={"error": {"message": path}})
+
+    def containers(self) -> list[dict]:
+        return [self.form(r) for r in self.requests if r.url.path.endswith("/threads")]
+
+
+@pytest.fixture
+def threads_api(monkeypatch):
+    api = RecordingThreadsApi()
+    real_client = httpx.Client
+
+    def client_with_mock_transport(*args, **kwargs):
+        kwargs["transport"] = httpx.MockTransport(api.handle)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(httpx, "Client", client_with_mock_transport)
+    return api
+
+
+@pytest.fixture
+def threads_post_with_first_comment(db):
+    organization = Organization.objects.create(name="E2E Threads Org")
+    workspace = Workspace.objects.create(name="E2E Threads WS", organization=organization)
+    account = SocialAccount.objects.create(
+        workspace=workspace,
+        platform="threads",
+        account_platform_id=THREADS_USER_ID,
+        account_name="Brightbean Threads",
+        oauth_access_token=ACCESS_TOKEN,
+        connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+    )
+    post = Post.objects.create(
+        workspace=workspace,
+        caption="threads post from the worker",
+        first_comment=FIRST_COMMENT,
+    )
+    return PlatformPost.objects.create(
+        post=post,
+        social_account=account,
+        status=PlatformPost.Status.SCHEDULED,
+        scheduled_at=timezone.now() - timedelta(minutes=1),
+    )
+
+
+@pytest.mark.django_db(transaction=True)
+def test_the_first_comment_is_deferred_then_posted(threads_api, threads_post_with_first_comment):
+    """The publish path's only deferred hand-off, driven end to end.
+
+    The engine does not post the first comment inline: it enqueues
+    _post_first_comment_task with run_after set FIRST_COMMENT_DELAY seconds out.
+    So this asserts three things no status check can - that the tick which
+    published did NOT also reply, that the deferred row carries a real future
+    run_after, and that a later tick posts the reply against the thread that was
+    actually published.
+
+    It is also the only end-to-end exercise of `schedule=`, which every other
+    deferred call site in the application depends on - the intelligence backoff
+    ladder and the fourteen-day organization deletion among them.
+    """
+    platform_post = threads_post_with_first_comment
+
+    run_the_worker()
+
+    platform_post.refresh_from_db()
+    assert platform_post.status == PlatformPost.Status.PUBLISHED, platform_post.publish_error
+    assert platform_post.platform_post_id == THREADS_POST_ID
+
+    deferred = Task.objects.get(task_name="apps.publisher.engine._post_first_comment_task")
+    assert str(platform_post.id) in deferred.task_params, "the reply was queued for the wrong post"
+    seconds_out = (deferred.run_at - timezone.now()).total_seconds()
+    assert 60 < seconds_out <= FIRST_COMMENT_DELAY + 5, f"run_at is {seconds_out}s out"
+
+    assert [c for c in threads_api.containers() if c.get("reply_to_id")] == [], "replied too early"
+
+    # Let its moment arrive, and run the worker again. `run_the_worker` also
+    # enqueues a publish cycle, which finds nothing left to publish - harmless,
+    # and cheaper than a second helper that differs by one line.
+    Task.objects.filter(pk=deferred.pk).update(run_at=timezone.now() - timedelta(seconds=1))
+    run_the_worker()
+
+    assert not Task.objects.filter(pk=deferred.pk).exists(), "the deferred reply was never consumed"
+
+    replies = [c for c in threads_api.containers() if c.get("reply_to_id")]
+    assert len(replies) == 1, f"expected exactly one reply container, got {replies}"
+    assert replies[0]["reply_to_id"] == THREADS_POST_ID
+    assert replies[0]["text"] == FIRST_COMMENT

--- a/tests/e2e/test_publish_wire.py
+++ b/tests/e2e/test_publish_wire.py
@@ -1,0 +1,240 @@
+"""End-to-end: each supported platform puts the RIGHT BYTES on the wire.
+
+Rule 8 - every supported platform must be tested end to end where possible,
+preferring official testing aids, then community ones, and falling back to
+tests written from the official API documentation.
+
+WHY THIS IS SEPARATE FROM test_publish_path.py. That module proves the whole
+chain for one platform in depth: the schedule fires, the engine claims, media
+is downloaded and cleaned up, retries land, the first comment defers. This one
+proves a SINGLE property for MANY platforms - that the provider builds the
+request the platform's API actually documents - and is shaped so that adding a
+platform is adding a case, not a file.
+
+WHAT IS REAL AND WHAT IS NOT. Real: the production command, the schedule, the
+engine, credential resolution, and the provider's own request building and
+response parsing. Faked: the wire, and only the wire, via httpx's MockTransport.
+
+The seam is at the wire on purpose. A test that patches
+PublishEngine._dispatch_to_provider never runs the provider at all, so a
+malformed payload passes unnoticed - which is why deleting the facet parsing
+from the Bluesky provider left every status-level test green.
+
+transaction=True is REQUIRED, not incidental: poll_and_publish fans out over a
+ThreadPoolExecutor whose threads open their own connections, so under the
+default wrapping they would see an empty database and publish nothing - the
+test would pass while proving nothing.
+"""
+
+from datetime import timedelta
+from urllib.parse import parse_qs
+
+import httpx
+import pytest
+from django.core.management import call_command
+from django.utils import timezone
+
+from apps.composer.models import PlatformPost, Post
+from apps.organizations.models import Organization
+from apps.social_accounts.models import SocialAccount
+from apps.workspaces.models import Workspace
+
+CAPTION = "shipped by the worker"
+
+
+class WireRecorder:
+    """Answers the calls a provider makes, and keeps every request it made.
+
+    `routes` maps a URL-path SUFFIX to a handler taking the request and
+    returning an httpx.Response. Anything unrouted is recorded as unexpected
+    and answered 404 rather than quietly satisfied, so a provider reaching for
+    an endpoint this test did not predict SHOWS UP instead of passing silently.
+    """
+
+    def __init__(self, routes):
+        self.routes = routes
+        self.requests: list[httpx.Request] = []
+        self.unexpected: list[str] = []
+
+    def handle(self, request: httpx.Request) -> httpx.Response:
+        self.requests.append(request)
+        for suffix, responder in self.routes.items():
+            if request.url.path.endswith(suffix):
+                return responder(request)
+        self.unexpected.append(f"{request.method} {request.url.path}")
+        return httpx.Response(404, json={"error": "unrouted in this test"})
+
+    def call(self, suffix: str) -> httpx.Request | None:
+        for request in self.requests:
+            if request.url.path.endswith(suffix):
+                return request
+        return None
+
+    def form(self, suffix: str) -> dict:
+        """The form body of the first request to `suffix`, as a flat dict."""
+        request = self.call(suffix)
+        assert request is not None, f"the provider never called {suffix}"
+        return {k: v[0] for k, v in parse_qs(request.content.decode()).items()}
+
+
+@pytest.fixture
+def wire(monkeypatch):
+    """Install a WireRecorder over every httpx.Client this process builds.
+
+    providers/base.py constructs `httpx.Client(timeout=...)` inline per request,
+    so there is no transport to inject - the class itself is replaced. That is
+    deliberately process-wide, because the engine's worker threads build their
+    own clients.
+    """
+    real_client = httpx.Client
+
+    def install(routes) -> WireRecorder:
+        recorder = WireRecorder(routes)
+
+        def client_with_mock_transport(*args, **kwargs):
+            kwargs["transport"] = httpx.MockTransport(recorder.handle)
+            return real_client(*args, **kwargs)
+
+        monkeypatch.setattr(httpx, "Client", client_with_mock_transport)
+        return recorder
+
+    return install
+
+
+#: The worker has no --once; `process_tasks` loops until killed, so a duration
+#: is the only way to get it to return.
+WORKER_SECONDS = "5"
+
+
+def run_the_worker():
+    """Enqueue the publish cycle and run the REAL worker until it drains.
+
+    Enqueued explicitly rather than waited for. `post_migrate` registers the
+    cycle at repeat=15, so a test COULD sit and hope the recurring row comes
+    due inside the worker's lifetime - which makes every assertion below depend
+    on wall-clock timing against a fifteen-second cadence, and that is how a
+    suite becomes intermittently red for reasons nobody can reproduce.
+
+    Calling a @background function IS the enqueue, so this is the same row the
+    scheduler would have written; only its arrival is made deterministic.
+    """
+    from apps.publisher.tasks import run_publish_cycle
+
+    run_publish_cycle()
+    call_command("process_tasks", "--duration", WORKER_SECONDS)
+
+
+def schedule_a_post(*, platform, platform_id, token, instance_url="", caption=CAPTION):
+    """One account on `platform` with one post due a minute ago."""
+    organization = Organization.objects.create(name=f"E2E {platform} Org")
+    workspace = Workspace.objects.create(name=f"E2E {platform} WS", organization=organization)
+    account = SocialAccount.objects.create(
+        workspace=workspace,
+        platform=platform,
+        account_platform_id=platform_id,
+        account_name=f"Brightbean {platform}",
+        oauth_access_token=token,
+        instance_url=instance_url,
+        connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+    )
+    post = Post.objects.create(workspace=workspace, caption=caption)
+    return PlatformPost.objects.create(
+        post=post,
+        social_account=account,
+        status=PlatformPost.Status.SCHEDULED,
+        scheduled_at=timezone.now() - timedelta(minutes=1),
+    )
+
+
+def assert_published(platform_post, expected_id):
+    platform_post.refresh_from_db()
+    assert platform_post.status == PlatformPost.Status.PUBLISHED, (
+        f"still {platform_post.status!r}; publish_error={platform_post.publish_error!r}"
+    )
+    assert platform_post.platform_post_id == expected_id
+    assert platform_post.published_at is not None
+
+
+# ---------------------------------------------------------------------------
+# Mastodon - https://docs.joinmastodon.org/methods/statuses/#create
+# ---------------------------------------------------------------------------
+
+MASTODON_INSTANCE = "https://mastodon.example"
+MASTODON_STATUS_ID = "109999999999999999"
+MASTODON_TOKEN = "mastodon-access-token"
+
+
+@pytest.mark.django_db(transaction=True)
+def test_mastodon_posts_a_status_to_its_own_instance(wire, monkeypatch):
+    """A Mastodon status is a form POST to the ACCOUNT'S OWN instance.
+
+    Two things here are specific to Mastodon, and are what this test is for.
+
+    The host is PER ACCOUNT, not a constant: the engine copies
+    `account.instance_url` into the credentials and the provider builds every
+    URL from it. A bug there publishes to the wrong server - or, if the value
+    is dropped, to a relative URL that never leaves the process.
+
+    And the body is FORM-encoded, not JSON. The API documents
+    application/x-www-form-urlencoded for POST /api/v1/statuses, so asserting
+    on parsed form fields is asserting the documented contract.
+
+    `is_safe_url` is patched because it calls socket.getaddrinfo - a real DNS
+    lookup. It is our own SSRF validator and has its own tests; leaving it live
+    would make this a network-dependent test of somebody else's nameserver.
+    """
+    monkeypatch.setattr("apps.common.validators.is_safe_url", lambda url: True)
+
+    recorder = wire(
+        {
+            "/api/v1/statuses": lambda request: httpx.Response(
+                200,
+                json={
+                    "id": MASTODON_STATUS_ID,
+                    "url": f"{MASTODON_INSTANCE}/@brightbean/{MASTODON_STATUS_ID}",
+                    "content": CAPTION,
+                },
+            ),
+            # NOT publishing, and routed anyway. The worker runs the WHOLE
+            # recurring schedule, not just the publish cycle, so this account
+            # also gets an inbox poll and an OAuth health check inside the same
+            # window. Leaving them unrouted makes the recorder report them as
+            # unpredicted and fails a test about publishing for a reason that
+            # has nothing to do with publishing.
+            "/api/v1/notifications": lambda request: httpx.Response(200, json=[]),
+            "/api/v1/accounts/verify_credentials": lambda request: httpx.Response(
+                200,
+                json={
+                    "id": "110000000000000001",
+                    "username": "brightbean",
+                    "acct": "brightbean",
+                    "display_name": "Brightbean",
+                    "followers_count": 7,
+                },
+            ),
+        }
+    )
+    platform_post = schedule_a_post(
+        platform="mastodon",
+        platform_id="110000000000000001",
+        token=MASTODON_TOKEN,
+        instance_url=MASTODON_INSTANCE,
+    )
+
+    run_the_worker()
+
+    assert recorder.unexpected == [], f"unpredicted API calls: {recorder.unexpected}"
+    assert_published(platform_post, MASTODON_STATUS_ID)
+
+    request = recorder.call("/api/v1/statuses")
+    assert str(request.url).startswith(MASTODON_INSTANCE), (
+        f"published to {request.url}, not to the account's own instance - the "
+        f"per-account instance_url did not reach the provider"
+    )
+    assert request.headers["Authorization"] == f"Bearer {MASTODON_TOKEN}"
+
+    body = recorder.form("/api/v1/statuses")
+    assert body["status"] == CAPTION
+    # The API defaults visibility to the account's own setting when the field
+    # is absent, so sending it explicitly is what makes the outcome predictable.
+    assert body["visibility"] == "public"

--- a/tests/e2e/test_task_queue.py
+++ b/tests/e2e/test_task_queue.py
@@ -1,0 +1,57 @@
+"""End-to-end: the background worker still works on Django 6.0.7.
+
+THIS IS THE GATE CARRYING THIS MIGRATION'S LARGEST SINGLE ASSUMPTION.
+
+`django-background-tasks` 1.2.8 predates Django 5 entirely, and this migration
+moves the framework from 5.1 to 6.0.7 while KEEPING it. Everything deferred in
+this application runs through it - publishing, inbox sync, notification
+retries, media processing, analytics, scheduled organization deletions. If its
+ORM paths break on 6.0, none of that happens, and the web application stays
+perfectly green while it does not happen.
+
+That risk was carried for a long time on an import smoke test, which
+established only that the package LOADS and that `manage.py check` passes, and
+which said so in its own limits. This is that check promoted from a workspace
+probe that does not ship into a gate that runs on every push.
+
+It uses the real worker command, and lets it find the work on its own.
+"""
+
+import pytest
+from background_task import background
+from background_task.models import CompletedTask, Task
+from django.core.management import call_command
+
+#: Appended to by the task below, IN THIS PROCESS, so the test can prove the
+#: function body ran rather than only that a row moved between tables. A worker
+#: that marks work done without doing it is the failure that matters.
+MARKERS_RECORDED_BY_THE_TASK: list[str] = []
+
+
+@background(schedule=0)
+def record_that_it_ran(marker):
+    MARKERS_RECORDED_BY_THE_TASK.append(marker)
+
+
+@pytest.mark.django_db(transaction=True)
+def test_the_worker_executes_enqueued_work_on_django_6():
+    """Enqueue through the decorator, run the worker, prove the body ran.
+
+    `--duration` bounds the worker's life. There is no `--once`: `process_tasks`
+    loops until it is killed, which is also why nothing in this repository can
+    check its exit code for a failed pass - it does not have one.
+    """
+    MARKERS_RECORDED_BY_THE_TASK.clear()
+    record_that_it_ran("e2e")
+
+    assert Task.objects.filter(task_name__endswith="record_that_it_ran").exists(), (
+        "the @background call wrote no row - the decorator is not reaching the database"
+    )
+
+    call_command("process_tasks", "--duration", "5")
+
+    assert MARKERS_RECORDED_BY_THE_TASK == ["e2e"], "the row was consumed, but the function never ran"
+
+    completed = CompletedTask.objects.filter(task_name__endswith="record_that_it_ran").first()
+    assert completed is not None, "the task never reached CompletedTask"
+    assert completed.failed_at is None, f"the worker recorded a failure: {completed.last_error}"

--- a/tests/test_csp_overrides.py
+++ b/tests/test_csp_overrides.py
@@ -1,0 +1,134 @@
+"""Every @csp_override in this application still serves the WHOLE policy.
+
+`csp_override` does not override a DIRECTIVE - it replaces the entire policy.
+django/middleware/csp.py reads the decorator dict INSTEAD of SECURE_CSP and
+merges nothing, so a decorator carrying only `form-action` leaves that page
+with no `script-src` and no `default-src` - which places no restriction on
+scripts at all, on exactly the pages that hand control to a third party.
+
+tests/e2e/test_csp_policy.py holds that down for ONE view, /oauth/authorize/,
+because it is the only override site reachable without a login and a fixture.
+The others are account-connection flows behind auth, and a site added next
+year is covered by nothing at all.
+
+This finds the sites itself, so the property holds for every one of them -
+present and future - with no browser, no auth and no fixtures.
+
+HOW. django/views/decorators/csp.py closes its wrapper over `config_attr_name`
+and `config_attr_value`, and `@wraps` leaves `__wrapped__` pointing at what it
+wrapped, so the dict a site WILL serve is readable straight off the closure.
+Cells are read BY NAME off `co_freevars`; reading them positionally would
+quietly return the wrong one if those were ever reordered.
+
+Reaching into another package's closure is unusual and it is deliberate: the
+alternative is authenticating and driving every flow, which is precisely what
+left these sites uncovered. If a future Django renames those free variables
+this stops finding anything - and the first test fails and says so, rather
+than the rest passing vacuously against an empty list.
+
+Only the ENFORCING slot is examined. Nothing here uses
+`csp_report_only_override`, which stores `_csp_ro_config`; if that changes it
+needs its own pass.
+"""
+
+from django.conf import settings
+from django.urls import get_resolver
+
+#: The OAuth consent screen and the two account-connection flows. A FLOOR, not
+#: an equality - adding a fourth site should not fail a test about whether the
+#: existing three are correct.
+KNOWN_OVERRIDE_SITES = 3
+
+
+def _free_variables(func):
+    """The closure of `func`, by name. Empty for anything that has no closure."""
+    code = getattr(func, "__code__", None)
+    closure = getattr(func, "__closure__", None)
+    if code is None or not closure:
+        return {}
+    return dict(zip(code.co_freevars, closure, strict=True))
+
+
+def _read_csp_override_config(view):
+    """The policy dict a csp_override on `view` will serve, or None.
+
+    Walks the `__wrapped__` chain, so an override sitting UNDER another
+    decorator - `@login_required` above `@csp_override` - is still found.
+    """
+    seen = set()
+    while view is not None and id(view) not in seen:
+        seen.add(id(view))
+        cells = _free_variables(view)
+        name, config = cells.get("config_attr_name"), cells.get("config_attr_value")
+        if name is not None and config is not None:
+            try:
+                if name.cell_contents == "_csp_config":
+                    return config.cell_contents
+            except ValueError:
+                pass  # an empty cell is not the decorator we are looking for
+        view = getattr(view, "__wrapped__", None)
+    return None
+
+
+def _routes(resolver, prefix=""):
+    """Every routed callable, descending through include()."""
+    for entry in resolver.url_patterns:
+        route = prefix + str(entry.pattern)
+        if hasattr(entry, "url_patterns"):
+            yield from _routes(entry, route)
+        else:
+            yield route, entry.callback
+
+
+def find_routed_csp_override_sites():
+    """Every routed view carrying a csp_override, as (route, config) pairs."""
+    sites = []
+    for route, callback in _routes(get_resolver()):
+        config = _read_csp_override_config(callback)
+        if config is not None:
+            sites.append((route, config))
+    return sites
+
+
+def test_the_override_sites_are_still_discoverable():
+    """Guards the assertion below against passing vacuously.
+
+    If Django changes how csp_override stores its config, or the last override
+    is deleted, the next test has nothing to check and would report success.
+    """
+    sites = find_routed_csp_override_sites()
+
+    assert len(sites) >= KNOWN_OVERRIDE_SITES, (
+        f"found {len(sites)} csp_override site(s), expected at least {KNOWN_OVERRIDE_SITES}. "
+        f"Either a site was removed, or the way csp_override stores its config changed "
+        f"and this file can no longer see any of them - in which case the policy check "
+        f"below proves nothing."
+    )
+
+
+def test_every_override_serves_the_whole_policy():
+    """An override must WIDEN the base policy, never replace or narrow it.
+
+    A directive being present is not enough: a config that keeps the key and
+    empties it is just as broken. Every source the base policy allows must
+    survive, which is what splatting it and widening one directive produces.
+
+    A page that genuinely needs to TIGHTEN a directive fails here. For a
+    security policy that is the intended outcome - narrowing one should be a
+    deliberate, visible act, not something that arrives as a green test.
+    """
+    base = settings.CSP_POLICY
+
+    for route, config in find_routed_csp_override_sites():
+        absent = [directive for directive in base if directive not in config]
+        assert not absent, (
+            f"/{route} overrides the CSP and drops {absent} entirely. csp_override "
+            f"replaces the whole policy, so this page would be served with no "
+            f"restriction on scripts at all. Splat settings.CSP_POLICY and replace "
+            f"only the directive being widened."
+        )
+        for directive, allowed in base.items():
+            dropped = [value for value in allowed if value not in config[directive]]
+            assert not dropped, (
+                f"/{route} overrides the CSP and drops {dropped} from {directive!r}, which the base policy allows."
+            )

--- a/tests/test_e2e_harness_is_contained.py
+++ b/tests/test_e2e_harness_is_contained.py
@@ -1,0 +1,52 @@
+"""The e2e harness must not change how the UNIT suite behaves.
+
+`DJANGO_ALLOW_ASYNC_UNSAFE` tells Django to permit synchronous ORM calls from
+an async context. The e2e harness genuinely needs it - Playwright's synchronous
+API drives the browser from a greenlet on an asyncio loop - and sets it from an
+autouse fixture scoped to tests/e2e, so it is armed only while those tests run.
+
+It was once set at MODULE level in that conftest instead. pytest imports every
+conftest it walks past during COLLECTION and applies mark deselection
+afterwards, so a plain `pytest` run - which is what `make test` and CI both run
+- imported the file and disarmed Django's async-safety guard for the entire
+unit suite. A real SynchronousOnlyOperation in application code would have
+passed the suite and raised only in production.
+
+Nothing could catch that by running tests, because the variable can only ever
+REMOVE failures: every gate stayed green precisely because it was broken.
+
+So this checks the source instead of the behaviour. That is deliberate. An
+assertion about `os.environ` cannot distinguish "leaked at import" from "a
+legitimate e2e fixture is active in this session", and would be flaky the first
+time somebody ran both suites together. The regression has one shape - an
+assignment at module level - and this pins that shape exactly.
+"""
+
+from pathlib import Path
+
+E2E_CONFTEST_PATH = Path(__file__).parent / "e2e" / "conftest.py"
+
+ASYNC_SAFETY_OVERRIDE_ENV_VAR = "DJANGO_ALLOW_ASYNC_UNSAFE"
+
+
+def test_the_e2e_conftest_does_not_disarm_async_safety_at_import_time():
+    source = E2E_CONFTEST_PATH.read_text(encoding="utf-8")
+
+    assert ASYNC_SAFETY_OVERRIDE_ENV_VAR in source, (
+        f"{ASYNC_SAFETY_OVERRIDE_ENV_VAR} is not mentioned in {E2E_CONFTEST_PATH.name} at all. Either the harness "
+        f"stopped needing it - in which case delete this test - or the file moved "
+        f"and this test now guards nothing."
+    )
+
+    at_module_level = [
+        line
+        for line in source.splitlines()
+        if ASYNC_SAFETY_OVERRIDE_ENV_VAR in line and line[:1] not in {" ", "\t", "#"}
+    ]
+
+    assert not at_module_level, (
+        f"{E2E_CONFTEST_PATH.name} touches {ASYNC_SAFETY_OVERRIDE_ENV_VAR} at module level: {at_module_level}. "
+        f"pytest imports this conftest during collection of ANY run, so that "
+        f"disarms Django's async-safety guard for the whole unit suite. Set it "
+        f"from a fixture scoped to tests/e2e instead."
+    )


### PR DESCRIPTION
Moves the framework from Django 5.1, which left extended support in December 2025, to 6.0.7. Generated by a script; every edit is precondition-asserted, so a drifted anchor stops the run rather than silently half-migrating.

Python floor 3.13, declared in .python-version and now conformed to in seven places: Dockerfile, ruff target-version, mypy python_version, three setup-python jobs, and pre-commit. The repository front page declared 3.12 and Django 5.x, which would have told a new contributor to install an interpreter pre-commit then refuses.

CSP moves from django-csp to core Django, and the dependency is removed. Two hazards here are quiet and neither is caught by any static check:

  request.csp_nonce does not exist in core Django. The nonce is private, at
  request._csp_nonce, and reaches templates as {{ csp_nonce }} through the csp
  context processor. Django resolves a missing attribute to "", so the old
  spelling renders nonce="" and script-src blocks every inline script - in
  production only, because dev and test run the policy report-only. 27 template
  sites plus one comment. tests/e2e/test_csp_nonce.py is the only thing in this
  repository that detects it.

  csp_override replaces the WHOLE policy, not one directive. A converted
  decorator carrying only form-action would serve the OAuth consent screen with
  no script-src at all - erring permissive, so no browser complains either. The
  three surviving overrides splat settings.CSP_POLICY and widen one key;
  tests/test_csp_overrides.py discovers every routed override site from the
  URLconf and asserts none of them narrows the base.

  A fourth @csp_update is deleted rather than converted: all ten hosts it
  appended are already in the base form-action list, so under django-csp's
  append semantics it served the base policy. Settled by set membership.

django-background-tasks is RETAINED. Measured on 6.0.7 against a real cluster with this requirements.txt: migrations apply, a @background call enqueues, and process_tasks executed all eleven recurring jobs with zero failures. The worker command is unchanged, so no deployment file needs editing.

Adds an end-to-end suite - 12 tests - which this repository did not have. It stands up its own PostgreSQL cluster per session and drives a real browser under the policy production enforces, because config/settings/test.py runs CSP report-only and cannot reproduce a blocked-script defect. Deselected by default so the unit suite stays as fast as it was.

Two changes are NOT framework work and are included deliberately:

  apps/publisher/engine.py - pool threads release their database connection.
  Django opens one per thread and frees it on garbage collection; a worker
  fires none of the signals that call close_old_connections(), and both pools
  rebuild every tick. Surfaced by the new publish-path test, which could not
  drop its own database afterwards.

  apps/calendar/holidays.py - a data-file read names encoding="utf-8" instead
  of inheriting the platform's, which would raise in production on any host
  whose default encoding is not UTF-8.

Also adds design/ and requirements/ documents recording the decisions and the obligations they create, and changelog.md.

READ THIS BEFORE MERGING. ci.yml gains an e2e job and build now needs it. That job has never executed anywhere - this push is its first run - and build is also what produces the Docker image, so the 3.13 interpreter change is behind the same gate. If e2e comes up red for an environmental reason, take it out of build.needs, fix it, and put it back once it has been green once. Do not debug it with main blocked.

Verified locally: 1044 unit tests, 12 e2e tests, ruff check, ruff format, mypy over 467 source files, manage.py check, makemigrations --check.

## What does this PR do?

<!-- A brief description of the change. -->

## Why?

<!-- What problem does this solve or what feature does it add? Link to an issue if applicable. -->

## How to test

<!-- Steps to verify this works correctly. -->

## Checklist

- [ ] Tests pass (`pytest`)
- [ ] Lint passes (`ruff check .` and `ruff format --check .`)
- [ ] Documentation updated (if applicable)
