### PR TITLE
fix(threads): use the Threads App ID and keep long-lived tokens refreshable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,11 @@ PLATFORM_FACEBOOK_APP_ID=
 PLATFORM_FACEBOOK_APP_SECRET=
 PLATFORM_INSTAGRAM_APP_ID=
 PLATFORM_INSTAGRAM_APP_SECRET=
+# Threads - NOT the Facebook App ID. A Meta app with the "Access the Threads API"
+# use case gets its own pair, shown as "Threads App ID" / "Threads App Secret"
+# under App settings -> Basic. Threads stays unconfigured until both are set.
+PLATFORM_THREADS_APP_ID=
+PLATFORM_THREADS_APP_SECRET=
 # LinkedIn - see README "LinkedIn" section. Choose Path A or Path B (or both).
 # Path B (Community Management API) credentials are automatically reused for
 # personal connections, giving refresh tokens + inbox.

--- a/README.md
+++ b/README.md
@@ -374,10 +374,10 @@ For example, if your `APP_URL` is `https://brightbean.example.com`, the Facebook
 
 ### Meta (Facebook, Instagram, Threads)
 
-Facebook, Instagram, and Threads all use the same Meta app credentials.
+Facebook and Instagram share the same Meta app credentials. Threads runs on the same Meta app but uses a **separate app identity** — its own App ID, App Secret, and redirect URI list (steps 5-6 below).
 
 1. Go to [Meta for Developers](https://developers.facebook.com/) and create a new app (type: **Business**)
-2. Under **App Settings → Basic**, copy your **App ID** and **App Secret**
+2. Under **App Settings → Basic**, copy your **App ID** and **App Secret** — the plain ones, for Facebook and Instagram. Once the Threads use case is added this page also lists a **Threads App ID** / **Threads App Secret**; those are a different app identity and belong in the Threads variables in step 6, not here.
 3. In the App Dashboard, go to **Use cases** and add the following four use cases. For each use case, click into it and go to **Permissions and features** to add the required optional permissions:
 
    **Use case: "Manage everything on your Page"** (Facebook)
@@ -399,13 +399,23 @@ Facebook, Instagram, and Threads all use the same Meta app credentials.
    ```
    {APP_URL}/social-accounts/callback/facebook/
    {APP_URL}/social-accounts/callback/instagram/
-   {APP_URL}/social-accounts/callback/threads/
    ```
+   > **Threads is separate.** Its callback does **not** belong here — the Threads use case keeps its own redirect URI list. See step 6.
 5. Set the environment variables:
    ```
    PLATFORM_FACEBOOK_APP_ID=your-app-id
    PLATFORM_FACEBOOK_APP_SECRET=your-app-secret
    ```
+6. **Threads:** the "Access the Threads API" use case gets its own App ID, App Secret, and redirect URIs. Go to **Use cases → Access the Threads API → Settings** and add the Threads redirect URI:
+   ```
+   {APP_URL}/social-accounts/callback/threads/
+   ```
+   Then copy the **Threads App ID** and **Threads App Secret** (also listed under **App settings → Basic**, alongside — and different from — your Facebook App ID) and set:
+   ```
+   PLATFORM_THREADS_APP_ID=your-threads-app-id
+   PLATFORM_THREADS_APP_SECRET=your-threads-app-secret
+   ```
+   These have no fallback: until both are set, Threads shows as **Not Configured** on the connect page. Sending the Facebook App ID to Threads fails with error `4476002`.
 
 ### Instagram (Direct, via Instagram Login)
 
@@ -684,6 +694,9 @@ Make sure the Tailwind watcher is running: `cd theme/static_src && npm run start
 
 **OAuth callback errors ("redirect URI mismatch")**
 The redirect URI registered on the platform must exactly match `{APP_URL}/social-accounts/callback/{platform}/`. Check that `APP_URL` in `.env` matches the URL you're accessing (including `http` vs `https` and port number).
+
+**Threads: "No app ID was provided in the request" (error `4476002`)**
+Threads uses its own App ID, not the Facebook one. Set `PLATFORM_THREADS_APP_ID` / `PLATFORM_THREADS_APP_SECRET` from **Use cases → Access the Threads API → Settings**, and register `{APP_URL}/social-accounts/callback/threads/` in that same panel — the Facebook Login redirect URI list does not cover Threads. See the [Meta](#meta-facebook-instagram-threads) section.
 
 **Background tasks not running (posts not publishing)**
 Make sure the worker is running: `python manage.py process_tasks`. In Docker: check `docker compose logs worker`.

--- a/apps/credentials/tests.py
+++ b/apps/credentials/tests.py
@@ -288,6 +288,45 @@ def test_resolve_incomplete_env_does_not_shadow_db(organization):
     assert result == {"client_id": "DB_ID", "client_secret": "DB_SECRET"}
 
 
+@pytest.mark.django_db
+@override_settings(
+    PLATFORM_CREDENTIALS_FROM_ENV={
+        "facebook": {"app_id": "FB_ID", "app_secret": "FB_SECRET"},
+        "threads": {"app_id": "", "app_secret": ""},
+    }
+)
+def test_threads_env_is_independent_of_facebook(organization):
+    """Threads must never inherit the Facebook app credentials.
+
+    Threads authorizes against its own App ID; the Facebook one fails with error
+    4476002. With no PLATFORM_THREADS_* set the env entry stays empty, so the
+    admin-entered row resolves instead of being shadowed by Meta's credentials.
+    """
+    PlatformCredential.objects.create(
+        organization=organization,
+        platform="threads",
+        credentials={"client_id": "TH_ID", "client_secret": "TH_SECRET"},
+    )
+    result = resolve_platform_credentials("threads", organization.id)
+    assert result == {"client_id": "TH_ID", "client_secret": "TH_SECRET"}
+
+
+def test_threads_settings_are_not_wired_to_the_meta_pair():
+    """Pin the wiring itself: threads must not alias the Facebook pair again.
+
+    Facebook and Instagram deliberately share one dict; Threads used to as well,
+    which is what produced error 4476002 on connect. Asserted against the active
+    settings rather than ``config.settings.base``, so a re-alias in any settings
+    module — not just the base one — is caught.
+    """
+    from django.conf import settings
+
+    env_creds = settings.PLATFORM_CREDENTIALS_FROM_ENV
+    assert env_creds["threads"] is not env_creds["facebook"]
+    assert env_creds["instagram"] is env_creds["facebook"]  # these two do share
+    assert set(env_creds["threads"]) == {"app_id", "app_secret"}
+
+
 # ---------------------------------------------------------------------------
 # resolve_app_secret — single per-org secret (.env dominant)
 # ---------------------------------------------------------------------------
@@ -345,7 +384,9 @@ def test_save_update_fields_persists_derived_flag(organization):
 REALISTIC_ENV = {
     "facebook": {"app_id": "fb-id", "app_secret": "fb-sec"},
     "instagram": {"app_id": "fb-id", "app_secret": "fb-sec"},
-    "threads": {"app_id": "fb-id", "app_secret": "fb-sec"},
+    # Threads has its own app identity - never the Facebook pair. See
+    # _THREADS_CREDENTIALS in config/settings/base.py.
+    "threads": {"app_id": "th-id", "app_secret": "th-sec"},
     "instagram_login": {"app_id": "ig-id", "app_secret": "ig-sec"},
     "linkedin_personal": {"client_id": "li-id", "client_secret": "li-sec", "_oauth_mode": "oidc"},
     "linkedin_company": {"client_id": "lic-id", "client_secret": "lic-sec"},

--- a/apps/social_accounts/migrations/0015_backfill_threads_refresh_token.py
+++ b/apps/social_accounts/migrations/0015_backfill_threads_refresh_token.py
@@ -1,0 +1,34 @@
+from django.db import migrations
+
+
+def backfill_threads_refresh_token(apps, schema_editor):
+    """Adopt the long-lived access token as the refresh credential for Threads.
+
+    Threads issues no separate refresh token — the access token is replayed
+    against ``th_refresh_token``. Until the provider started returning it as
+    ``OAuthTokens.refresh_token``, connects stored an empty ``oauth_refresh_token``,
+    and every refresh path skips accounts with an empty one. Those accounts would
+    keep sitting out the refresh cycle until their 60-day token lapsed, so seed
+    the credential they should have had.
+
+    Tokens are encrypted at rest, so this iterates instead of using .update():
+    the column holds ciphertext, so neither the empty-value filter nor the copy
+    can be expressed in SQL. ``.iterator()`` keeps the decrypted tokens from
+    piling up in memory on a large deployment.
+    """
+    SocialAccount = apps.get_model("social_accounts", "SocialAccount")
+    for account in SocialAccount.objects.filter(platform="threads").iterator():
+        if account.oauth_refresh_token or not account.oauth_access_token:
+            continue
+        account.oauth_refresh_token = account.oauth_access_token
+        account.save(update_fields=["oauth_refresh_token"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("social_accounts", "0014_socialaccount_webhook_error_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(backfill_threads_refresh_token, migrations.RunPython.noop),
+    ]

--- a/apps/social_accounts/tasks.py
+++ b/apps/social_accounts/tasks.py
@@ -8,6 +8,11 @@ from django.utils import timezone
 
 logger = logging.getLogger(__name__)
 
+# Platforms whose stored token is only usable for a bounded window and whose
+# refresh credential is the token itself, so an account with no recorded
+# expiry must still be refreshed. See the bootstrap in check_social_account_health.
+EXPIRY_BOOTSTRAP_PLATFORMS = ("bluesky", "threads")
+
 
 @background(schedule=0)
 def check_social_account_health(account_id: str):
@@ -41,11 +46,16 @@ def check_social_account_health(account_id: str):
         logger.error("Health check: no provider for platform %s", account.platform)
         return
 
-    # Bluesky accounts connected before we recorded token_expires_at need a
-    # one-shot refresh to populate it; without this, is_token_expiring_soon
-    # stays False forever and the short-lived accessJwt is never rotated.
-    needs_bluesky_bootstrap = account.platform == "bluesky" and account.token_expires_at is None
-    if (account.is_token_expiring_soon or needs_bluesky_bootstrap) and account.oauth_refresh_token:
+    # Accounts on these platforms that were connected before we recorded
+    # token_expires_at need a one-shot refresh to populate it; without this,
+    # is_token_expiring_soon stays False forever (it can't judge an unknown
+    # expiry) and the token is never rotated. Both platforms rotate on a fixed
+    # schedule — Bluesky's accessJwt within hours, Threads' long-lived token at
+    # 60 days — so a refresh is always the right move when expiry is unknown.
+    # Platforms whose refresh token outlives the access token are deliberately
+    # left out: for them an unknown expiry means nothing needs doing yet.
+    needs_expiry_bootstrap = account.platform in EXPIRY_BOOTSTRAP_PLATFORMS and account.token_expires_at is None
+    if (account.is_token_expiring_soon or needs_expiry_bootstrap) and account.oauth_refresh_token:
         try:
             new_tokens = provider.refresh_token(account.oauth_refresh_token)
             account.oauth_access_token = new_tokens.access_token

--- a/apps/social_accounts/tests/test_migration_0015.py
+++ b/apps/social_accounts/tests/test_migration_0015.py
@@ -1,0 +1,107 @@
+"""Regression tests for the ``0015_backfill_threads_refresh_token`` migration.
+
+Threads accounts connected before the provider returned the long-lived token as
+its own refresh credential sit with an empty ``oauth_refresh_token``, which every
+refresh path treats as "not refreshable". The backfill seeds it so those accounts
+rejoin the refresh cycle instead of lapsing at 60 days.
+
+Unlike ``apps/api_keys/tests/test_migration_0002.py``, which runs its migration
+against the live model, these drive the *historical* model the migration actually
+receives — the encrypted-token write is the part most likely to behave
+differently there, and the real migration never exercises it (the table is empty
+when the test database is built).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+from django.db.migrations.loader import MigrationLoader
+
+# Migration module names start with a digit, so a plain ``from … import``
+# doesn't work. ``importlib`` is the standard escape hatch.
+migration_module = importlib.import_module("apps.social_accounts.migrations.0015_backfill_threads_refresh_token")
+
+from apps.social_accounts.models import SocialAccount  # noqa: E402
+
+
+@pytest.fixture
+def organization(db):
+    from apps.organizations.models import Organization
+
+    return Organization.objects.create(name="Backfill Org")
+
+
+@pytest.fixture
+def workspace(db, organization):
+    from apps.workspaces.models import Workspace
+
+    return Workspace.objects.create(name="Backfill WS", organization=organization)
+
+
+def _account(workspace, *, platform, platform_id, access_token, refresh_token=""):
+    return SocialAccount.objects.create(
+        workspace=workspace,
+        platform=platform,
+        account_platform_id=platform_id,
+        account_name="Test",
+        oauth_access_token=access_token,
+        oauth_refresh_token=refresh_token,
+    )
+
+
+def _historical_apps():
+    """The model registry Django hands this migration at run time.
+
+    Built from the state after the migration's dependency, so ``get_model``
+    returns the historical ``SocialAccount`` — a plain manager and the field
+    classes frozen into the migration graph, rather than the live model's
+    manager and any behavior added since.
+    """
+    loader = MigrationLoader(None, ignore_no_migrations=True)
+    dependency = migration_module.Migration.dependencies[0]
+    return loader.project_state(dependency).apps
+
+
+@pytest.mark.django_db
+class TestBackfillThreadsRefreshToken:
+    def test_threads_account_adopts_its_access_token(self, workspace):
+        account = _account(workspace, platform="threads", platform_id="th-1", access_token="long_lived")
+
+        migration_module.backfill_threads_refresh_token(_historical_apps(), None)
+
+        account.refresh_from_db()
+        assert account.oauth_refresh_token == "long_lived"
+
+    def test_existing_refresh_token_is_not_overwritten(self, workspace):
+        account = _account(
+            workspace,
+            platform="threads",
+            platform_id="th-2",
+            access_token="long_lived",
+            refresh_token="already_set",
+        )
+
+        migration_module.backfill_threads_refresh_token(_historical_apps(), None)
+
+        account.refresh_from_db()
+        assert account.oauth_refresh_token == "already_set"
+
+    def test_account_without_access_token_is_skipped(self, workspace):
+        account = _account(workspace, platform="threads", platform_id="th-3", access_token="")
+
+        migration_module.backfill_threads_refresh_token(_historical_apps(), None)
+
+        account.refresh_from_db()
+        assert account.oauth_refresh_token == ""
+
+    def test_other_platforms_are_untouched(self, workspace):
+        """Only Threads replays its access token; copying it elsewhere would
+        hand the refresh flow a credential the platform rejects."""
+        account = _account(workspace, platform="facebook", platform_id="fb-1", access_token="fb_token")
+
+        migration_module.backfill_threads_refresh_token(_historical_apps(), None)
+
+        account.refresh_from_db()
+        assert account.oauth_refresh_token == ""

--- a/apps/social_accounts/tests/test_tasks.py
+++ b/apps/social_accounts/tests/test_tasks.py
@@ -262,3 +262,82 @@ class TestCheckSocialAccountHealth:
         assert account.oauth_refresh_token == "fresh_refresh"
         assert account.token_expires_at is not None
         assert account.connection_status == SocialAccount.ConnectionStatus.CONNECTED
+
+    @patch("providers.get_provider")
+    def test_threads_bootstrap_refresh_when_expires_at_null(self, mock_get_provider, db, workspace):
+        """Threads accounts with no recorded expiry must still refresh.
+
+        is_token_expiring_soon can't judge a NULL expiry, so without the
+        bootstrap these accounts sit out every refresh cycle and their 60-day
+        token lapses — the same trap the Bluesky bootstrap covers.
+        """
+        account = SocialAccount.objects.create(
+            workspace=workspace,
+            platform="threads",
+            account_platform_id="th-2",
+            account_name="Test",
+            oauth_access_token="long_lived",
+            oauth_refresh_token="long_lived",
+            token_expires_at=None,
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+
+        mock_provider = MagicMock()
+        mock_provider.refresh_token.return_value = OAuthTokens(
+            access_token="rotated",
+            refresh_token="rotated",
+            expires_in=5184000,
+        )
+        mock_provider.get_profile.return_value = _profile(follower_count=7)
+        mock_get_provider.return_value = mock_provider
+
+        check_social_account_health.now(str(account.id))
+
+        mock_provider.refresh_token.assert_called_once_with("long_lived")
+        account.refresh_from_db()
+        assert account.oauth_access_token == "rotated"
+        assert account.token_expires_at is not None
+
+    @patch("providers.get_provider")
+    def test_threads_expiring_account_rotates_its_long_lived_token(self, mock_get_provider, db, workspace):
+        """Threads replays its access token as its own refresh credential.
+
+        Runs the real provider (only the HTTP layer is stubbed) so this covers the
+        wiring end to end: a Threads account whose 60-day token is running out must
+        come back with a rotated token that is itself refreshable next cycle.
+        """
+        from providers.threads import ThreadsProvider
+
+        account = SocialAccount.objects.create(
+            workspace=workspace,
+            platform="threads",
+            account_platform_id="th-1",
+            account_name="Test",
+            oauth_access_token="long_lived",
+            oauth_refresh_token="long_lived",
+            token_expires_at=timezone.now() + timedelta(days=3),
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+
+        # Keyed by URL rather than call order, so an added provider call fails
+        # with a named assertion instead of a bare StopIteration.
+        responses = {
+            "/refresh_access_token": {"access_token": "rotated", "expires_in": 5184000},
+            "/me": {"id": "th-1", "username": "tester", "name": "Test"},
+        }
+
+        def _stub(method, url, **kwargs):
+            for fragment, body in responses.items():
+                if url.endswith(fragment):
+                    return MagicMock(json=MagicMock(return_value=body))
+            raise AssertionError(f"unexpected Threads request: {url}")
+
+        with patch.object(ThreadsProvider, "_request", side_effect=_stub):
+            mock_get_provider.return_value = ThreadsProvider({"app_id": "i", "app_secret": "s"})
+            check_social_account_health.now(str(account.id))
+
+        account.refresh_from_db()
+        assert account.oauth_access_token == "rotated"
+        assert account.oauth_refresh_token == "rotated"
+        assert account.token_expires_at > timezone.now() + timedelta(days=7)
+        assert account.connection_status == SocialAccount.ConnectionStatus.CONNECTED

--- a/apps/social_accounts/tests/test_views.py
+++ b/apps/social_accounts/tests/test_views.py
@@ -262,6 +262,51 @@ class TestOAuthCallbackView:
         response = authenticated_client.get(url, {"code": "abc123", "state": "invalid_state"})
         assert response.status_code == 302
 
+    def test_threads_callback_persists_a_refresh_credential(self, authenticated_client, workspace, user):
+        """A Threads connect must leave the account refreshable.
+
+        Threads returns no separate refresh token, so the provider hands back the
+        long-lived access token as one. Runs the real provider with only the HTTP
+        layer stubbed: if any link in that chain drops it, the account stores an
+        empty oauth_refresh_token, every refresh gate skips it, and the 60-day
+        token lapses silently — the original bug.
+        """
+        from providers.threads import ThreadsProvider
+
+        nonce = "nonce-threads"
+        state = _sign_state(workspace.id, "threads", user.id, nonce)
+        session = authenticated_client.session
+        session[OAUTH_SESSION_KEY] = {"nonce": nonce}
+        session.save()
+
+        responses = {
+            "oauth/access_token": {"access_token": "short-lived", "user_id": "th-1"},
+            "/access_token": {"access_token": "long-lived", "expires_in": 5184000},
+            "/me": {"id": "th-1", "username": "tester", "name": "Tester"},
+        }
+
+        def _stub(method, url, **kwargs):
+            for fragment, body in responses.items():
+                if url.endswith(fragment):
+                    return MagicMock(json=MagicMock(return_value=body))
+            raise AssertionError(f"unexpected Threads request: {url}")
+
+        url = reverse("social_accounts:oauth_callback", kwargs={"platform": "threads"})
+        with (
+            patch.object(ThreadsProvider, "_request", side_effect=_stub),
+            patch(
+                "apps.social_accounts.views._get_provider_for_platform",
+                return_value=ThreadsProvider({"app_id": "i", "app_secret": "s"}),
+            ),
+        ):
+            response = authenticated_client.get(url, {"code": "abc123", "state": state})
+
+        assert response.status_code == 302
+        account = SocialAccount.objects.get(workspace=workspace, platform="threads", account_platform_id="th-1")
+        assert account.oauth_access_token == "long-lived"
+        assert account.oauth_refresh_token == "long-lived"
+        assert account.token_expires_at is not None
+
     def test_instagram_redirects_to_account_selection(self, authenticated_client, workspace, user):
         nonce = "nonce-123"
         state = _sign_state(workspace.id, "instagram", user.id, nonce)

--- a/apps/social_accounts/tests/test_views.py
+++ b/apps/social_accounts/tests/test_views.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from django.core import signing
+from django.test import override_settings
 from django.urls import reverse
 
 from apps.social_accounts.models import SocialAccount
@@ -140,6 +141,54 @@ class TestConnectPlatformView:
         assert verifier  # non-empty
         _, kwargs = mock_provider.get_auth_url.call_args
         assert kwargs["code_verifier"] == verifier
+
+    @override_settings(
+        PLATFORM_CREDENTIALS_FROM_ENV={
+            "facebook": {"app_id": "FB_ID", "app_secret": "FB_SECRET"},
+            "threads": {"app_id": "", "app_secret": ""},
+        }
+    )
+    def test_threads_not_offered_on_meta_credentials_alone(self, authenticated_client, workspace):
+        """Threads authorizes against its own App ID, never the Facebook one.
+
+        With only Meta credentials set, offering a Connect button would dead-end
+        at Meta's error 4476002, so the platform must read as unconfigured.
+        """
+        url = reverse("social_accounts:connect", kwargs={"workspace_id": workspace.id})
+
+        # The grid renders Threads as "Not Configured" while Facebook stays live.
+        grid = authenticated_client.get(url)
+        assert "threads" not in grid.context["configured_platforms"]
+        assert "facebook" in grid.context["configured_platforms"]
+
+        response = authenticated_client.post(url, {"platform": "threads"})
+        assert response.status_code == 302
+        assert response.url == url  # bounced back to the grid, not off to Meta
+
+    @override_settings(PLATFORM_CREDENTIALS_FROM_ENV={"threads": {"app_id": "TH_ID", "app_secret": "TH_SECRET"}})
+    def test_threads_connect_uses_threads_app_id(self, authenticated_client, workspace):
+        url = reverse("social_accounts:connect", kwargs={"workspace_id": workspace.id})
+        response = authenticated_client.post(url, {"platform": "threads"})
+        assert response.status_code == 302
+        assert response.url.startswith("https://www.threads.com/oauth/authorize?")
+        assert "client_id=TH_ID" in response.url
+
+    @override_settings(PLATFORM_CREDENTIALS_FROM_ENV={"threads": {"app_id": "TH_ID", "app_secret": ""}})
+    def test_half_configured_platform_is_not_offered(self, authenticated_client, workspace):
+        """An app id without its secret must not render a Connect button.
+
+        The credential resolver requires both keys, so offering the button would
+        walk the user through the platform's consent screen only to fail at token
+        exchange with a generic "Failed to connect account".
+        """
+        url = reverse("social_accounts:connect", kwargs={"workspace_id": workspace.id})
+
+        grid = authenticated_client.get(url)
+        assert "threads" not in grid.context["configured_platforms"]
+
+        response = authenticated_client.post(url, {"platform": "threads"})
+        assert response.status_code == 302
+        assert response.url == url
 
     def test_non_pkce_connect_omits_verifier(self, authenticated_client, workspace):
         """A non-PKCE provider stores code_verifier=None and is called without it."""

--- a/apps/social_accounts/views.py
+++ b/apps/social_accounts/views.py
@@ -22,7 +22,7 @@ from django.views.decorators.http import require_GET, require_POST
 from django_ratelimit.decorators import ratelimit
 
 from apps.common.validators import is_safe_url as _is_safe_url
-from apps.credentials.models import PlatformCredential, resolve_platform_credentials
+from apps.credentials.models import PlatformCredential, derive_is_configured, resolve_platform_credentials
 from apps.members.decorators import require_permission
 
 from .models import MastodonAppRegistration, PlatformVisibility, SocialAccount
@@ -83,7 +83,12 @@ def _get_configured_platforms(org_id):
     )
     env_creds = getattr(settings, "PLATFORM_CREDENTIALS_FROM_ENV", {})
     for platform, creds in env_creds.items():
-        if any(v for v in creds.values()):
+        # Same completeness rule the credential resolver applies, so the grid can
+        # never offer a Connect button that resolution will reject. A truthiness
+        # check here would let a half-filled pair (app id set, secret missing)
+        # render as connectable, walk the user through the platform's consent
+        # screen, and only fail at token exchange with a generic error.
+        if derive_is_configured(platform, creds):
             configured.add(platform)
 
     # Session-auth platforms (e.g. Bluesky) don't need app-level credentials —

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -369,6 +369,17 @@ _INSTAGRAM_LOGIN_CREDENTIALS = {
     "app_id": env("PLATFORM_INSTAGRAM_APP_ID", default=""),
     "app_secret": env("PLATFORM_INSTAGRAM_APP_SECRET", default=""),
 }
+# Threads has its own app identity: a Meta app carrying the "Access the Threads
+# API" use case gets a Threads App ID / Secret distinct from the Facebook pair
+# (App settings -> Basic -> Threads App ID). Sending the Facebook App ID to
+# threads.com/oauth/authorize fails with error 4476002 ("No app ID was provided
+# in the request"), so these deliberately do NOT fall back to _META_CREDENTIALS.
+# Left unset, Threads stays unconfigured and resolves through the org's
+# admin-entered PlatformCredential row instead.
+_THREADS_CREDENTIALS = {
+    "app_id": env("PLATFORM_THREADS_APP_ID", default=""),
+    "app_secret": env("PLATFORM_THREADS_APP_SECRET", default=""),
+}
 _LINKEDIN_LEGACY_CLIENT_ID = env("PLATFORM_LINKEDIN_CLIENT_ID", default="")
 _LINKEDIN_LEGACY_CLIENT_SECRET = env("PLATFORM_LINKEDIN_CLIENT_SECRET", default="")
 
@@ -399,17 +410,20 @@ elif _LINKEDIN_COMPANY_CREDENTIALS["client_id"]:
         "_oauth_mode": "community_management",
     }
 else:
-    # No LinkedIn env vars set. Keep `_oauth_mode` out so the dict's values are all
-    # falsy and `_get_configured_platforms()` doesn't false-positive (it treats any
-    # truthy credential value as "configured"). The provider defaults to OIDC mode
+    # No LinkedIn env vars set. Keep `_oauth_mode` out so the dict carries nothing
+    # but the empty required keys — `_get_configured_platforms()` and
+    # `resolve_platform_credentials()` both gate on `derive_is_configured`, which
+    # reads only client_id / client_secret. The provider defaults to OIDC mode
     # via `_is_oidc_mode` if it ever sees an empty credentials dict.
     _LINKEDIN_PERSONAL_CREDENTIALS = {"client_id": "", "client_secret": ""}
 
 PLATFORM_CREDENTIALS_FROM_ENV = {
-    # Meta platforms - Facebook, Instagram, and Threads share the same app
+    # Meta platforms - Facebook and Instagram share the same app
     "facebook": _META_CREDENTIALS,
     "instagram": _META_CREDENTIALS,
-    "threads": _META_CREDENTIALS,
+    # Threads runs on the same Meta app but a different app identity - see
+    # _THREADS_CREDENTIALS above and the README "Meta" section.
+    "threads": _THREADS_CREDENTIALS,
     # Instagram (Direct) - uses Instagram Login with separate Instagram App credentials.
     # Despite the platform key, this targets Professional (Business/Creator) IG accounts
     # without requiring a linked Facebook Page. See providers/instagram_login.py.

--- a/providers/threads.py
+++ b/providers/threads.py
@@ -33,6 +33,10 @@ API_BASE = "https://graph.threads.net/v1.0"
 CONTAINER_POLL_INTERVAL = 3  # seconds
 CONTAINER_POLL_MAX_ATTEMPTS = 40  # up to ~2 min for video processing
 
+# Meta issues long-lived Threads tokens with a 60-day TTL. Used as the fallback
+# when a token response omits ``expires_in`` — see ``_tokens_from``.
+LONG_LIVED_TOKEN_TTL = 60 * 24 * 60 * 60
+
 
 class ThreadsProvider(SocialProvider):
     """Threads API provider using OAuth 2.0."""
@@ -144,9 +148,28 @@ class ThreadsProvider(SocialProvider):
                 platform=self.platform_name,
                 raw_response=body,
             )
+        return self._tokens_from(body)
+
+    @staticmethod
+    def _tokens_from(body: dict) -> OAuthTokens:
+        """Build OAuthTokens from a long-lived-token response.
+
+        Threads issues no separate refresh token: the long-lived access token is
+        replayed as its own refresh credential (see ``refresh_token``). Returning
+        it in ``refresh_token`` is what lets the refresh machinery — which skips
+        accounts whose ``oauth_refresh_token`` is empty — ever run, and carries
+        the rotated token forward so an account keeps refreshing rather than
+        replaying the stale original.
+
+        ``expires_in`` falls back to the documented 60-day TTL: consumers only
+        advance ``token_expires_at`` when it is truthy, so a response without it
+        would leave a stale past expiry in place and re-trigger a refresh on
+        every health check.
+        """
         return OAuthTokens(
             access_token=body["access_token"],
-            expires_in=body.get("expires_in"),
+            refresh_token=body["access_token"],
+            expires_in=body.get("expires_in") or LONG_LIVED_TOKEN_TTL,
             token_type=body.get("token_type", "Bearer"),
             raw_response=body,
         )
@@ -173,12 +196,7 @@ class ThreadsProvider(SocialProvider):
                 platform=self.platform_name,
                 raw_response=body,
             )
-        return OAuthTokens(
-            access_token=body["access_token"],
-            expires_in=body.get("expires_in"),
-            token_type=body.get("token_type", "Bearer"),
-            raw_response=body,
-        )
+        return self._tokens_from(body)
 
     # ------------------------------------------------------------------
     # Profile

--- a/tests/providers/test_threads.py
+++ b/tests/providers/test_threads.py
@@ -1,0 +1,84 @@
+"""Tests for Threads provider OAuth token handling.
+
+Threads issues no separate refresh token: the long-lived access token is its own
+refresh credential, replayed against ``th_refresh_token``. The provider therefore
+has to return it as ``OAuthTokens.refresh_token`` — every refresh path in the app
+skips accounts whose ``oauth_refresh_token`` is empty.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from providers.threads import LONG_LIVED_TOKEN_TTL, ThreadsProvider
+
+CREDENTIALS = {"app_id": "th-id", "app_secret": "th-sec"}
+
+
+def _response(body: dict) -> MagicMock:
+    return MagicMock(json=MagicMock(return_value=body))
+
+
+class TestExchangeCode:
+    @patch.object(ThreadsProvider, "_request")
+    def test_returns_long_lived_token_as_its_own_refresh_credential(self, mock_request):
+        mock_request.side_effect = [
+            _response({"access_token": "short-lived", "user_id": "1"}),
+            _response({"access_token": "long-lived", "expires_in": 5184000, "token_type": "bearer"}),
+        ]
+
+        tokens = ThreadsProvider(CREDENTIALS).exchange_code("code", "https://example.com/cb/")
+
+        assert tokens.access_token == "long-lived"
+        # Without this the connect callback stores oauth_refresh_token="" and the
+        # 60-day token expires unrefreshed. It must be the long-lived token, not
+        # the short-lived one the first leg returned.
+        assert tokens.refresh_token == "long-lived"
+        assert tokens.expires_in == 5184000
+
+    @patch.object(ThreadsProvider, "_request")
+    def test_missing_expires_in_falls_back_to_the_60_day_ttl(self, mock_request):
+        mock_request.side_effect = [
+            _response({"access_token": "short-lived", "user_id": "1"}),
+            _response({"access_token": "long-lived"}),
+        ]
+
+        tokens = ThreadsProvider(CREDENTIALS).exchange_code("code", "https://example.com/cb/")
+
+        # A None here leaves token_expires_at unset, which keeps the account out
+        # of the refresh cycle entirely.
+        assert tokens.expires_in == LONG_LIVED_TOKEN_TTL
+
+
+class TestRefreshToken:
+    @patch.object(ThreadsProvider, "_request")
+    def test_rotated_token_carries_forward_as_the_next_refresh_credential(self, mock_request):
+        mock_request.return_value = _response({"access_token": "rotated", "expires_in": 5184000})
+
+        tokens = ThreadsProvider(CREDENTIALS).refresh_token("current-long-lived")
+
+        assert tokens.access_token == "rotated"
+        # Otherwise the account refreshes once, then replays the stale original.
+        assert tokens.refresh_token == "rotated"
+        assert tokens.expires_in == 5184000
+
+    @patch.object(ThreadsProvider, "_request")
+    def test_missing_expires_in_falls_back_to_the_60_day_ttl(self, mock_request):
+        mock_request.return_value = _response({"access_token": "rotated"})
+
+        tokens = ThreadsProvider(CREDENTIALS).refresh_token("current-long-lived")
+
+        # Consumers only advance token_expires_at when expires_in is truthy, so a
+        # None would leave the stale past expiry in place and re-trigger a
+        # refresh on every single health check.
+        assert tokens.expires_in == LONG_LIVED_TOKEN_TTL
+
+    @patch.object(ThreadsProvider, "_request")
+    def test_replays_the_access_token_against_th_refresh_token(self, mock_request):
+        mock_request.return_value = _response({"access_token": "rotated", "expires_in": 5184000})
+
+        ThreadsProvider(CREDENTIALS).refresh_token("current-long-lived")
+
+        _, kwargs = mock_request.call_args
+        assert kwargs["params"] == {
+            "grant_type": "th_refresh_token",
+            "access_token": "current-long-lived",
+        }


### PR DESCRIPTION
Supersedes #47 (thanks @tro2789 for the diagnosis and the original patch) and fixes #45.

## Two Threads bugs

**1. Connect failed with error `4476002`.** A Meta app carrying the "Access the Threads API" use case has two identities — the Facebook App ID and a separate Threads App ID — and Threads OAuth accepts only the latter. `PLATFORM_FACEBOOK_APP_ID` was being sent to `threads.com/oauth/authorize`, so no self-hoster could connect Threads at all.

**2. Every Threads connection died after 60 days.** Threads issues no separate refresh token: the long-lived access token is replayed against `th_refresh_token`. The provider never returned it as `OAuthTokens.refresh_token`, so connects stored an empty `oauth_refresh_token`, and both refresh gates skip accounts with an empty one. `ThreadsProvider.refresh_token` was unreachable — the token just expired.

## Notable decisions

- **No fallback to the Meta credentials.** #47 fell back per-key. Because `.env` is dominant in `resolve_platform_credentials`, a fallback keeps the env dict complete and silently shadows an admin-entered Threads credential row — leaving the platform unfixable through the one UI that could fix it. Unset, Threads now resolves through `PlatformCredential` and the grid shows it as Not Configured.
- **The connect grid now gates on `derive_is_configured`**, not a truthiness check. A half-filled pair (app id set, secret missing) used to render a Connect button that walked the user through Meta's consent screen and then failed at token exchange with a generic error. Applies to every platform, not just Threads.
- **The README misrouted the Threads callback.** It belongs in the Threads use case's own redirect URI list, not under Facebook Login — following the old instructions left the connect broken even with the right App ID.
- **Migration `0015` backfills existing accounts**, which are the population the token bug actually affects. Tokens are encrypted at rest, so it iterates rather than filtering in SQL.
- **The health check's expiry bootstrap** (Bluesky-only until now) covers Threads, so accounts with no recorded expiry rejoin the refresh cycle.

## Verification

1129 tests pass; `ruff check` and `ruff format --check` clean. Each behavioural fix was mutation-checked — reverting the gate, the bootstrap set, the TTL fallback, or either `refresh_token=` line fails the tests that cover it.

New coverage: Threads OAuth token handling (`tests/providers/test_threads.py`), an end-to-end callback test proving a connect persists a refresh credential, the half-configured gate, the expiry bootstrap, and migration `0015` driven through the real historical model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)