### PR TITLE
fix(social-accounts): stop leaking a template comment into the account card

### DIFF
--- a/templates/social_accounts/partials/_account_card.html
+++ b/templates/social_accounts/partials/_account_card.html
@@ -81,9 +81,11 @@ Usage: {% include "social_accounts/partials/_account_card.html" with account=acc
     </div>
     {% endif %}
 
-    {# The connection is healthy enough to publish and report, but the inbox is
-       deaf: comments and mentions arrive only by webhook, so say so here rather
-       than let the account look fine. #}
+    {% comment %}
+    The connection is healthy enough to publish and report, but the inbox is
+    deaf: comments and mentions arrive only by webhook, so say so here rather
+    than let the account look fine.
+    {% endcomment %}
     {% if account.webhooks_active is False %}
     <div class="mt-3 px-3 py-2 bg-amber-50 border border-amber-200 rounded-lg">
         <p class="text-xs text-amber-800">


### PR DESCRIPTION
## Problem

The raw developer note rendered as visible page text above the account card on `/social-accounts/<workspace_id>/`:

> `{# The connection is healthy enough to publish and report, but the inbox is deaf: comments and mentions arrive only by webhook, so say so here rather than let the account look fine. #}`

## Root cause

Django's `{# ... #}` comment syntax is **single-line only** — the template lexer's comment regex is not DOTALL, so a `{#` … newline … `#}` block never becomes a comment token and is emitted verbatim as literal template text. The note spanned three lines.

Demonstrated against the template engine directly:

```
single-line {# #}    -> 'AB'
multi-line  {# #}    -> 'A{# hi\nthere #}B'   <- leaks
{% comment %} block  -> 'AB'
```

## Fix

Converted the block to `{% comment %}` / `{% endcomment %}`, matching the idiom this same file already uses at lines 1–4. The note is preserved for developers and gone from the page. The `{% if account.webhooks_active is False %}` banner below it is untouched.

## Verification

- Rendered the real partial in all three webhook states:

  | `webhooks_active` | comment leaked | banner shown |
  | --- | --- | --- |
  | `False` | no | yes |
  | `True` | no | no |
  | `None` | no | no |

- `pytest apps/social_accounts/tests/` → **91 passed**
- `ruff check .` and `ruff format --check .` → both clean
- Scanned every `.html` under `templates/`, `apps/`, `theme/`, `providers/`, `config/`, `static/` — this was the **only** multi-line `{# #}` in the repo, so there is nothing else to clean up.

No browser screenshot: the change is only observable on a page listing a connected account, and a fresh dev DB has none — the render check above exercises the partial directly and is stronger proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)