### PR TITLE
fix(instagram): stop duplicate first comments, poll comments into the inbox, hide raw API errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,12 @@ Facebook and Instagram share the same Meta app credentials. Threads runs on the 
    - After verification, subscribe to the `feed`, `mention`, and `messages` fields. `feed` is what carries comments on your Page's posts.
 
    > **This step is easy to miss and fails silently.** Connecting a Page subscribes it to your app automatically, so the account shows as healthy either way — but without the callback URL configured here, Meta never delivers anything. Comments then arrive only through the 5-minute polling fallback, and mentions not at all. Run `python manage.py diagnose_facebook --account-id <uuid>` to check.
+
+   **If you connect Instagram through this Facebook app, also subscribe to the `Instagram` object** on the same Webhooks page:
+   - **Callback URL:** `{APP_URL}/webhooks/facebook/` (the same endpoint — it handles both platforms)
+   - Subscribe to the `comments` and `mentions` fields.
+
+   > `comments` and `mentions` belong to the **Instagram** object, not the Page — a Page accepts only its own fields (`feed`, `mention`, `messages`, …). Studio subscribes the Instagram *account* automatically on connect, but the object-level configuration here can only be done in the dashboard. Without it, Instagram comments arrive only via the 5-minute poll and mentions not at all.
 6. Set the environment variables:
    ```
    PLATFORM_FACEBOOK_APP_ID=your-app-id

--- a/apps/inbox/tests/test_webhooks.py
+++ b/apps/inbox/tests/test_webhooks.py
@@ -389,6 +389,129 @@ class TestInstagramCommentEvents:
     @override_settings(
         PLATFORM_CREDENTIALS_FROM_ENV={"instagram_login": {"app_secret": "ig-secret"}},
     )
+    def test_an_instagram_comment_is_linked_to_the_media_it_belongs_to(self, client, ig_login_account):
+        """Instagram nests the media id where a Page sends a flat ``post_id``.
+
+        Without lifting it out, related_post is NULL for every Instagram comment
+        even though PlatformPost holds that exact id — IG media ids carry no
+        page prefix to strip, so the two match directly.
+        """
+        from apps.composer.models import PlatformPost, Post
+
+        post = Post.objects.create(workspace=ig_login_account.workspace, caption="hi")
+        platform_post = PlatformPost.objects.create(
+            post=post,
+            social_account=ig_login_account,
+            status=PlatformPost.Status.PUBLISHED,
+            platform_post_id="media-1",
+            published_at=timezone.now(),
+        )
+
+        payload = {
+            "entry": [
+                {
+                    "id": "ig-login-123",
+                    "changes": [
+                        {
+                            "field": "comments",
+                            "value": {
+                                "id": "ig-comment-3",
+                                "text": "Test from a different account",
+                                "from": {"id": "igsid-9", "username": "lenasorensen"},
+                                "media": {"id": "media-1", "media_product_type": "FEED"},
+                            },
+                        }
+                    ],
+                }
+            ]
+        }
+        body = json.dumps(payload).encode()
+        response = client.post(
+            reverse("inbox_webhooks:webhook_instagram_login"),
+            data=body,
+            content_type="application/json",
+            HTTP_X_HUB_SIGNATURE_256=_sign_body(body, "ig-secret"),
+        )
+
+        assert response.status_code == 200
+        msg = InboxMessage.objects.get(platform_message_id="ig-comment-3")
+        assert msg.related_post_id == platform_post.id
+        assert msg.extra["post_id"] == "media-1"
+        assert msg.extra["stored_post_id"] == "media-1"
+
+    @override_settings(
+        PLATFORM_CREDENTIALS_FROM_ENV={"instagram_login": {"app_secret": "ig-secret"}},
+    )
+    def test_an_instagram_reply_keeps_its_parent_comment_id(self, client, ig_login_account):
+        payload = {
+            "entry": [
+                {
+                    "id": "ig-login-123",
+                    "changes": [
+                        {
+                            "field": "comments",
+                            "value": {
+                                "id": "ig-reply-1",
+                                "text": "Answering you",
+                                "from": {"id": "igsid-9", "username": "lenasorensen"},
+                                "parent_id": "ig-comment-1",
+                                "media": {"id": "media-1"},
+                            },
+                        }
+                    ],
+                }
+            ]
+        }
+        body = json.dumps(payload).encode()
+        client.post(
+            reverse("inbox_webhooks:webhook_instagram_login"),
+            data=body,
+            content_type="application/json",
+            HTTP_X_HUB_SIGNATURE_256=_sign_body(body, "ig-secret"),
+        )
+
+        msg = InboxMessage.objects.get(platform_message_id="ig-reply-1")
+        assert msg.extra["parent_id"] == "ig-comment-1"
+
+    @override_settings(
+        PLATFORM_CREDENTIALS_FROM_ENV={"instagram_login": {"app_secret": "ig-secret"}},
+    )
+    def test_a_parent_id_naming_the_media_is_not_stored(self, client, ig_login_account):
+        """Replying on the media publishes a new top-level comment instead of a
+        threaded reply."""
+        payload = {
+            "entry": [
+                {
+                    "id": "ig-login-123",
+                    "changes": [
+                        {
+                            "field": "comments",
+                            "value": {
+                                "id": "ig-comment-4",
+                                "text": "Top level",
+                                "from": {"id": "igsid-9", "username": "lenasorensen"},
+                                "parent_id": "media-1",
+                                "media": {"id": "media-1"},
+                            },
+                        }
+                    ],
+                }
+            ]
+        }
+        body = json.dumps(payload).encode()
+        client.post(
+            reverse("inbox_webhooks:webhook_instagram_login"),
+            data=body,
+            content_type="application/json",
+            HTTP_X_HUB_SIGNATURE_256=_sign_body(body, "ig-secret"),
+        )
+
+        msg = InboxMessage.objects.get(platform_message_id="ig-comment-4")
+        assert "parent_id" not in msg.extra
+
+    @override_settings(
+        PLATFORM_CREDENTIALS_FROM_ENV={"instagram_login": {"app_secret": "ig-secret"}},
+    )
     def test_comment_without_an_id_is_ignored(self, client, ig_login_account):
         payload = {
             "entry": [

--- a/apps/inbox/webhooks.py
+++ b/apps/inbox/webhooks.py
@@ -232,6 +232,32 @@ def _facebook_comment_extra(value: dict) -> dict:
     return extra
 
 
+def _instagram_comment_extra(value: dict, *, reply_edge: str) -> dict:
+    """Normalize an Instagram comment or mention payload for the inbox.
+
+    Instagram nests the media under ``value["media"]["id"]`` (flat ``media_id``
+    on a mention) where a Page sends a flat ``post_id``. ``_related_post_key``
+    only reads ``stored_post_id``/``post_id``, so without this every Instagram
+    comment stores a NULL related_post even though PlatformPost holds that exact
+    media id — Instagram ids carry no page prefix to strip, so the two match
+    directly and both keys are the same value.
+    """
+    media_id = str((value.get("media") or {}).get("id") or value.get("media_id") or "")
+    extra = {**value, "reply_edge": reply_edge, "source": "webhook"}
+    if media_id:
+        extra["post_id"] = media_id
+        extra["stored_post_id"] = media_id
+    # A parent_id naming the media or the comment itself is not a parent
+    # *comment*; replying on it would publish a new top-level comment instead of
+    # a threaded reply.
+    parent_id = str(value.get("parent_id") or "")
+    if parent_id and parent_id not in {str(value.get("id") or ""), media_id}:
+        extra["parent_id"] = parent_id
+    else:
+        extra.pop("parent_id", None)
+    return extra
+
+
 def _upsert_facebook_comment(account, value: dict):
     """Upsert a Facebook comment from a webhook event."""
     # Both default leniently: an older or variant payload shape that omits them
@@ -331,7 +357,7 @@ def _upsert_instagram_comment(account, value: dict):
         sender_name=from_data.get("username", "Unknown"),
         sender_id=from_data.get("id", ""),
         body=value.get("text", ""),
-        extra={**value, "reply_edge": "comment"},
+        extra=_instagram_comment_extra(value, reply_edge="comment"),
     )
 
 
@@ -361,7 +387,7 @@ def _upsert_instagram_mention(account, value: dict):
         sender_name="Instagram",
         sender_id="",
         body=INSTAGRAM_MENTION_PLACEHOLDER,
-        extra={**value, "reply_edge": "comment" if comment_id else "media"},
+        extra=_instagram_comment_extra(value, reply_edge="comment" if comment_id else "media"),
     )
 
 

--- a/apps/publisher/engine.py
+++ b/apps/publisher/engine.py
@@ -30,6 +30,14 @@ from django.utils import timezone
 
 from apps.composer.models import PlatformPost
 from apps.credentials.models import resolve_platform_credentials
+from apps.social_accounts.error_messages import (
+    FIRST_COMMENT_GENERIC_MESSAGE,
+    PUBLISH_EXHAUSTED_MESSAGE,
+    PUBLISH_GENERIC_MESSAGE,
+    PUBLISH_RATE_LIMIT_MESSAGE,
+    friendly_first_comment_error,
+    friendly_publish_error,
+)
 from providers import get_provider
 from providers.exceptions import ProviderError, RateLimitError
 from providers.types import PostType, PublishContent
@@ -88,6 +96,11 @@ def _resolve_publish_credentials(account):
         credentials["page_id"] = account.account_platform_id
     elif platform in ("instagram", "instagram_login"):
         credentials["ig_user_id"] = account.account_platform_id
+        # The comment poll and the first-comment reconciliation both match our
+        # own comments on handle as well as id: Instagram often returns a
+        # comment's ``username`` without a ``from`` object, and an unrecognised
+        # own comment lands in the inbox as an inbound message from ourselves.
+        credentials["account_handle"] = account.account_handle
 
     return credentials
 
@@ -299,7 +312,9 @@ class PublishEngine:
 
         if rate_state and rate_state.is_rate_limited:
             error_msg = f"Rate limited until {rate_state.window_resets_at}"
-            self._schedule_retry(platform_post, error_msg)
+            # Our own sentence, not a provider body — but routed through the
+            # same parameter so publish_error has exactly one writer.
+            self._schedule_retry(platform_post, error_msg, user_message=PUBLISH_RATE_LIMIT_MESSAGE)
             return {"success": False, "error": error_msg}
 
         try:
@@ -366,7 +381,11 @@ class PublishEngine:
                     duration_ms=duration_ms,
                 )
 
-                self._schedule_retry(platform_post, error_msg)
+                # A provider that reports failure in the result dict rather than
+                # raising gives us no exception to classify, and result["error"]
+                # may well be a response body — so this one always gets the
+                # generic sentence. The raw text is in the PublishLog row above.
+                self._schedule_retry(platform_post, error_msg, user_message=PUBLISH_GENERIC_MESSAGE)
                 return result
 
         except Exception as e:
@@ -380,10 +399,11 @@ class PublishEngine:
                 duration_ms=duration_ms,
             )
 
+            user_message = friendly_publish_error(e)
             if getattr(e, "retryable", True):
-                self._schedule_retry(platform_post, error_msg)
+                self._schedule_retry(platform_post, error_msg, user_message=user_message)
             else:
-                self._fail_permanently(platform_post, error_msg)
+                self._fail_permanently(platform_post, error_msg, user_message=user_message)
             return {"success": False, "error": error_msg}
 
     def _dispatch_to_provider(self, platform_post):
@@ -590,10 +610,17 @@ class PublishEngine:
             return PostType.IMAGE
         return PostType.TEXT
 
-    def _fail_permanently(self, platform_post, error_msg, *, reason="non-retryable"):
-        """Mark a post FAILED with no further retries."""
+    def _fail_permanently(self, platform_post, error_msg, *, user_message, reason="non-retryable"):
+        """Mark a post FAILED with no further retries.
+
+        ``error_msg`` is the diagnostic and stays in the log line below and in
+        the PublishLog row the caller already wrote. ``publish_error`` holds
+        what the composer and the calendar render, so it must never carry a raw
+        provider response body — which is why ``user_message`` has no default:
+        every caller has to decide, and a forgotten one is a leak.
+        """
         platform_post.status = PlatformPost.Status.FAILED
-        platform_post.publish_error = error_msg
+        platform_post.publish_error = (user_message or PUBLISH_GENERIC_MESSAGE)[:2000]
         platform_post.save()
         logger.warning(
             "PlatformPost %s failed (%s): %s",
@@ -602,10 +629,18 @@ class PublishEngine:
             error_msg,
         )
 
-    def _schedule_retry(self, platform_post, error_msg):
+    def _schedule_retry(self, platform_post, error_msg, *, user_message):
         """Schedule a retry with exponential backoff."""
         if platform_post.retry_count >= MAX_RETRIES:
-            self._fail_permanently(platform_post, error_msg, reason=f"after {MAX_RETRIES} retries")
+            # Not ``user_message``: everything that reaches this branch is a
+            # retryable failure whose copy promises "We'll retry shortly", and
+            # the post is about to be marked permanently failed.
+            self._fail_permanently(
+                platform_post,
+                error_msg,
+                user_message=PUBLISH_EXHAUSTED_MESSAGE,
+                reason=f"after {MAX_RETRIES} retries",
+            )
             return
 
         backoff_seconds = RETRY_BACKOFF[min(platform_post.retry_count, len(RETRY_BACKOFF) - 1)]
@@ -614,7 +649,7 @@ class PublishEngine:
         # Drop back to SCHEDULED so the next _process_retries tick picks it up
         # once next_retry_at passes.
         platform_post.status = PlatformPost.Status.SCHEDULED
-        platform_post.publish_error = error_msg
+        platform_post.publish_error = (user_message or PUBLISH_GENERIC_MESSAGE)[:2000]
         platform_post.save()
 
         logger.info(
@@ -702,6 +737,32 @@ def _is_ambiguous_submission_failure(exc) -> bool:
     return status is None or status >= 500
 
 
+def _is_retryable_first_comment_failure(exc) -> bool:
+    """Whether re-sending this exact comment could plausibly land differently.
+
+    A provider that already called the error permanent is believed. Past that: a
+    rate limit is a "not now", and a 5xx or a transport error is an unknown
+    outcome (the caller gates those on reconciliation). A clean 4xx is the
+    platform refusing *this request*, and re-sending it unchanged earns the same
+    refusal — Instagram made that concrete by answering a comment POST carrying
+    an unsupported ``fields`` param with a 400 while creating the comment
+    anyway, so three retries left four comments on a live account.
+
+    401 is the exception: ``_provider_and_access_token`` refreshes an expiring
+    token between attempts, so the next attempt really is a different request.
+    403 is not — Meta uses it for missing scopes and revoked grants, which need
+    a reconnect rather than a backoff.
+    """
+    if not getattr(exc, "retryable", True):
+        return False
+    if isinstance(exc, RateLimitError):
+        return True
+    status = getattr(exc, "status_code", None)
+    if status is None or status >= 500:
+        return True
+    return status == 401
+
+
 def _can_reconcile_comments(provider) -> bool:
     """Whether this provider can check for an already-posted comment.
 
@@ -741,6 +802,7 @@ def _record_first_comment_failure(
     error_msg: str,
     *,
     retryable: bool,
+    user_message: str = "",
     retry_after: int | None = None,
     unexpected: bool = False,
 ):
@@ -749,7 +811,14 @@ def _record_first_comment_failure(
     Every exit records state. The old version logged and returned, so a comment
     that 4xx'd left the post looking completely successful — the failure was
     only recoverable from worker logs.
+
+    ``error_msg`` is the diagnostic: raw provider text, logged, never stored.
+    ``user_message`` is what the composer and the calendar render, so it must
+    stay free of response bodies — the Graph payload that motivated this split
+    reached the UI as a wall of OAuthException and fbtrace noise. The log line
+    below is the only place the raw text survives, so it always emits.
     """
+    stored = (user_message or FIRST_COMMENT_GENERIC_MESSAGE)[:2000]
     exhausted = platform_post.first_comment_retry_count >= FIRST_COMMENT_MAX_RETRIES
 
     if not retryable or exhausted:
@@ -765,7 +834,7 @@ def _record_first_comment_failure(
         )
         PlatformPost.objects.filter(pk=platform_post.pk).update(
             first_comment_status=FirstCommentStatus.FAILED,
-            first_comment_error=error_msg[:2000],
+            first_comment_error=stored,
         )
         return
 
@@ -779,7 +848,7 @@ def _record_first_comment_failure(
     # and slip past FIRST_COMMENT_MAX_RETRIES.
     PlatformPost.objects.filter(pk=platform_post.pk).update(
         first_comment_status=FirstCommentStatus.PENDING,
-        first_comment_error=error_msg[:2000],
+        first_comment_error=stored,
         first_comment_retry_count=F("first_comment_retry_count") + 1,
     )
     _post_first_comment_task(str(platform_post.id), schedule=backoff)
@@ -817,6 +886,7 @@ def _post_first_comment_task(platform_post_id):
             platform_post,
             "No platform post id recorded; nothing to comment on.",
             retryable=False,
+            user_message="The post's id on the platform wasn't recorded, so the first comment couldn't be added.",
         )
         return
 
@@ -828,6 +898,7 @@ def _post_first_comment_task(platform_post_id):
             platform_post,
             str(exc),
             retryable=getattr(exc, "retryable", True),
+            user_message=friendly_first_comment_error(exc),
             unexpected=not isinstance(exc, ProviderError),
         )
         return
@@ -839,11 +910,22 @@ def _post_first_comment_task(platform_post_id):
             existing = provider.find_own_comment(access_token, platform_post.platform_post_id, comment_text)
         except NotImplementedError:
             existing = None
-        except Exception:
+        except Exception as exc:
+            # Whether the comment landed is unknown, so this attempt stops
+            # without posting — but it must still be recorded and re-queued, or
+            # the row sits PENDING forever with no task behind it and the post
+            # reads as fully successful. The retry budget bounds it: a lookup
+            # that never recovers ends FAILED and visible, never duplicated.
             logger.exception(
                 "Could not check for an existing first comment on PlatformPost %s; skipping this attempt "
                 "rather than risking a duplicate.",
                 platform_post.id,
+            )
+            _record_first_comment_failure(
+                platform_post,
+                f"Could not check for an existing first comment: {exc}",
+                retryable=True,
+                user_message=friendly_first_comment_error(exc),
             )
             return
         if existing:
@@ -865,13 +947,14 @@ def _post_first_comment_task(platform_post_id):
         # whether the comment landed; otherwise stop, because a duplicate
         # comment on a live post cannot be taken back.
         ambiguous = _is_ambiguous_submission_failure(exc)
-        retryable = getattr(exc, "retryable", True)
+        retryable = _is_retryable_first_comment_failure(exc)
         if ambiguous and not _can_reconcile_comments(provider):
             retryable = False
         _record_first_comment_failure(
             platform_post,
             str(exc),
             retryable=retryable,
+            user_message=friendly_first_comment_error(exc),
             # RateLimitError is a sibling of APIError, not a subclass, so branch
             # on the attributes rather than on the exception type.
             retry_after=getattr(exc, "retry_after", None),

--- a/apps/publisher/test_first_comment.py
+++ b/apps/publisher/test_first_comment.py
@@ -22,9 +22,14 @@ from apps.publisher.engine import (
     _is_ambiguous_submission_failure,
     _post_first_comment_task,
 )
+from apps.social_accounts.error_messages import (
+    FIRST_COMMENT_RECONNECT_MESSAGE,
+    FIRST_COMMENT_REJECTED_MESSAGE,
+    FIRST_COMMENT_TEMPORARY_MESSAGE,
+)
 from apps.social_accounts.models import SocialAccount
 from apps.workspaces.models import Workspace
-from providers.exceptions import APIError, RateLimitError
+from providers.exceptions import APIError, PublishError, RateLimitError
 from providers.types import CommentResult
 
 Status = PlatformPost.FirstCommentStatus
@@ -120,7 +125,9 @@ class FirstCommentTaskTest(TestCase):
         self.platform_post.refresh_from_db()
         self.assertEqual(self.platform_post.first_comment_status, Status.PENDING)
         self.assertEqual(self.platform_post.first_comment_retry_count, 1)
-        self.assertIn("transient", self.platform_post.first_comment_error)
+        # The stored text is what the composer renders, so it carries none of
+        # the platform's response body.
+        self.assertEqual(self.platform_post.first_comment_error, FIRST_COMMENT_TEMPORARY_MESSAGE)
         requeue.assert_called_once_with(str(self.platform_post.id), schedule=FIRST_COMMENT_RETRY_BACKOFF[0])
 
     def test_a_non_retryable_failure_is_not_requeued(self):
@@ -139,8 +146,103 @@ class FirstCommentTaskTest(TestCase):
 
         self.platform_post.refresh_from_db()
         self.assertEqual(self.platform_post.first_comment_status, Status.FAILED)
-        self.assertIn("pages_manage_engagement", self.platform_post.first_comment_error)
+        self.assertEqual(self.platform_post.first_comment_error, FIRST_COMMENT_RECONNECT_MESSAGE)
+        self.assertNotIn("pages_manage_engagement", self.platform_post.first_comment_error)
         requeue.assert_not_called()
+
+    def test_a_clean_4xx_is_not_retried(self):
+        """The regression test for four identical comments on one post.
+
+        Instagram answered a comment POST carrying an unsupported ``fields``
+        param with a 400 *after* creating the comment. Re-sending the identical
+        request earned the identical answer three more times.
+        """
+        provider = MagicMock()
+        provider.publish_comment.side_effect = APIError(
+            'Instagram API error 400: {"error":{"message":"This API call does not support the requested '
+            'response format","type":"OAuthException","code":20,"error_subcode":1772107}}',
+            status_code=400,
+            platform="Instagram",
+        )
+
+        with patch("apps.publisher.engine._post_first_comment_task") as requeue:
+            self._run(provider)
+
+        self.platform_post.refresh_from_db()
+        self.assertEqual(self.platform_post.first_comment_status, Status.FAILED)
+        requeue.assert_not_called()
+
+    def test_an_auth_rejection_is_retried_so_the_refreshed_token_can_be_used(self):
+        """_provider_and_access_token refreshes an expiring token between
+        attempts, so a 401 retry really is a different request."""
+        provider = MagicMock()
+        provider.publish_comment.side_effect = APIError("expired", status_code=401, platform="Instagram")
+
+        with patch("apps.publisher.engine._post_first_comment_task") as requeue:
+            self._run(provider)
+
+        self.platform_post.refresh_from_db()
+        self.assertEqual(self.platform_post.first_comment_status, Status.PENDING)
+        requeue.assert_called_once()
+
+    def test_a_permission_rejection_is_not_retried(self):
+        """403 means a missing scope or a revoked grant: a reconnect, not a
+        backoff."""
+        provider = MagicMock()
+        provider.publish_comment.side_effect = APIError("no scope", status_code=403, platform="Instagram")
+
+        with patch("apps.publisher.engine._post_first_comment_task") as requeue:
+            self._run(provider)
+
+        self.platform_post.refresh_from_db()
+        self.assertEqual(self.platform_post.first_comment_status, Status.FAILED)
+        requeue.assert_not_called()
+
+    def test_the_stored_error_never_contains_the_platform_response(self):
+        provider = MagicMock()
+        provider.publish_comment.side_effect = APIError(
+            'Instagram API error 400: {"error":{"message":"This API call does not support the requested '
+            'response format","type":"OAuthException","code":20,"error_subcode":1772107,'
+            '"error_user_msg":"Your Instagram comment was not added","fbtrace_id":"A4B_mFUQTXKx"}}',
+            status_code=400,
+            platform="Instagram",
+        )
+
+        self._run(provider)
+
+        self.platform_post.refresh_from_db()
+        stored = self.platform_post.first_comment_error
+        self.assertEqual(stored, FIRST_COMMENT_REJECTED_MESSAGE)
+        self.assertNotIn("OAuthException", stored)
+        self.assertNotIn("fbtrace_id", stored)
+
+    def test_the_raw_platform_error_still_reaches_the_logs(self):
+        """Storing friendly text must not cost operators the diagnostic."""
+        provider = MagicMock()
+        provider.publish_comment.side_effect = APIError(
+            'Instagram API error 400: {"error":{"code":20,"fbtrace_id":"A4B_mFUQTXKx"}}',
+            status_code=400,
+            platform="Instagram",
+        )
+
+        with self.assertLogs("apps.publisher.engine", level="WARNING") as logs:
+            self._run(provider)
+
+        self.assertIn("fbtrace_id", "\n".join(logs.output))
+
+    def test_a_message_we_wrote_ourselves_is_shown_as_is(self):
+        """PublishError text is authored for a human and is worth keeping."""
+        provider = MagicMock()
+        provider.publish_comment.side_effect = PublishError(
+            "Instagram container processing timed out",
+            platform="Instagram",
+            retryable=False,
+        )
+
+        self._run(provider)
+
+        self.platform_post.refresh_from_db()
+        self.assertEqual(self.platform_post.first_comment_error, "Instagram container processing timed out")
 
     def test_a_rate_limit_uses_the_platforms_retry_after(self):
         provider = MagicMock()
@@ -456,9 +558,13 @@ class AmbiguousFailureTest(TestCase):
 
     def test_only_providers_implementing_the_lookup_can_reconcile(self):
         from providers.facebook import FacebookProvider
+        from providers.instagram import InstagramProvider
+        from providers.instagram_login import InstagramLoginProvider
         from providers.tiktok import TikTokProvider
 
         self.assertTrue(_can_reconcile_comments(FacebookProvider({})))
+        self.assertTrue(_can_reconcile_comments(InstagramProvider({})))
+        self.assertTrue(_can_reconcile_comments(InstagramLoginProvider({})))
         self.assertFalse(_can_reconcile_comments(TikTokProvider({})))
 
     def test_a_retry_reconciles_before_posting_again(self):
@@ -497,9 +603,17 @@ class AmbiguousFailureTest(TestCase):
         provider = MagicMock()
         provider.find_own_comment.side_effect = APIError("cannot read", status_code=500, platform="Facebook")
 
-        self._run(provider)
+        with patch("apps.publisher.engine._post_first_comment_task") as requeue:
+            self._run(provider)
 
         provider.publish_comment.assert_not_called()
+        # The attempt still has to be recorded and re-queued. A bare return
+        # would leave the row PENDING with no task behind it, and the post would
+        # read as fully successful forever.
+        self.platform_post.refresh_from_db()
+        self.assertEqual(self.platform_post.first_comment_status, Status.PENDING)
+        self.assertEqual(self.platform_post.first_comment_retry_count, 2)
+        requeue.assert_called_once()
 
     def test_the_first_attempt_does_not_pay_for_reconciliation(self):
         provider = MagicMock()

--- a/apps/publisher/tests.py
+++ b/apps/publisher/tests.py
@@ -393,3 +393,91 @@ class PublishedPostLeavesQueueTest(TestCase):
         self.assertEqual(self.pp.status, PlatformPost.Status.PUBLISHED)
         self.assertEqual(self.pp.retry_count, 0)
         self.assertIsNone(self.pp.next_retry_at)
+
+
+class PublishErrorIsNeverRawTest(TestCase):
+    """publish_error renders in the composer and the calendar, so no path may
+    write a provider response body into it."""
+
+    def setUp(self):
+        from apps.composer.models import PlatformPost, Post
+        from apps.organizations.models import Organization
+        from apps.social_accounts.models import SocialAccount
+        from apps.workspaces.models import Workspace
+
+        org = Organization.objects.create(name="Org")
+        workspace = Workspace.objects.create(organization=org, name="WS")
+        account = SocialAccount.objects.create(
+            workspace=workspace,
+            platform="instagram",
+            account_platform_id="ig-1",
+            account_name="IG",
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+        post = Post.objects.create(workspace=workspace, caption="hi")
+        self.platform_post = PlatformPost.objects.create(
+            post=post,
+            social_account=account,
+            status=PlatformPost.Status.SCHEDULED,
+            scheduled_at=timezone.now(),
+        )
+
+    def test_a_rate_limited_account_does_not_show_an_internal_timestamp(self):
+        from apps.publisher.models import RateLimitState
+        from apps.social_accounts.error_messages import PUBLISH_RATE_LIMIT_MESSAGE
+
+        RateLimitState.objects.create(
+            social_account=self.platform_post.social_account,
+            platform="instagram",
+            requests_remaining=0,
+            window_resets_at=timezone.now() + timedelta(hours=1),
+        )
+
+        PublishEngine()._publish_platform_post(self.platform_post)
+
+        self.platform_post.refresh_from_db()
+        self.assertEqual(self.platform_post.publish_error, PUBLISH_RATE_LIMIT_MESSAGE)
+
+    def test_a_provider_reporting_failure_in_its_result_does_not_leak_the_body(self):
+        """This branch has no exception to classify, so it always gets the
+        generic sentence; the raw text lives in the PublishLog row."""
+        from apps.social_accounts.error_messages import PUBLISH_GENERIC_MESSAGE
+
+        raw = 'Instagram API error 400: {"error":{"fbtrace_id":"A4B_mFUQTXKx"}}'
+        with patch.object(
+            PublishEngine,
+            "_dispatch_to_provider",
+            return_value={"success": False, "error": raw, "status_code": 400},
+        ):
+            PublishEngine()._publish_platform_post(self.platform_post)
+
+        self.platform_post.refresh_from_db()
+        self.assertEqual(self.platform_post.publish_error, PUBLISH_GENERIC_MESSAGE)
+        self.assertNotIn("fbtrace_id", self.platform_post.publish_error)
+        self.assertIn("fbtrace_id", PublishLog.objects.get(platform_post=self.platform_post).error_message)
+
+    def test_an_exhausted_retry_budget_stops_promising_a_retry(self):
+        """The copy that got us here says "We'll retry shortly", which is true
+        only while attempts remain."""
+        from apps.composer.models import PlatformPost
+        from apps.social_accounts.error_messages import (
+            PUBLISH_EXHAUSTED_MESSAGE,
+            PUBLISH_TEMPORARY_MESSAGE,
+        )
+        from providers.exceptions import APIError
+
+        self.platform_post.retry_count = MAX_RETRIES
+        self.platform_post.save(update_fields=["retry_count"])
+
+        with patch.object(
+            PublishEngine,
+            "_dispatch_to_provider",
+            side_effect=APIError("upstream down", status_code=503, platform="Instagram"),
+        ):
+            PublishEngine()._publish_platform_post(self.platform_post)
+
+        self.platform_post.refresh_from_db()
+        self.assertEqual(self.platform_post.status, PlatformPost.Status.FAILED)
+        self.assertEqual(self.platform_post.publish_error, PUBLISH_EXHAUSTED_MESSAGE)
+        self.assertNotEqual(self.platform_post.publish_error, PUBLISH_TEMPORARY_MESSAGE)
+        self.assertNotIn("retry shortly", self.platform_post.publish_error)

--- a/apps/social_accounts/error_messages.py
+++ b/apps/social_accounts/error_messages.py
@@ -1,8 +1,16 @@
-"""User-facing error messages for social account health checks."""
+"""User-facing error messages for provider failures.
+
+Every string a provider failure can put in front of a user is written here, so
+"what do we actually show people?" is answerable by reading one file. The
+classification is shared and the copy is per-surface: the same four failure
+shapes need different advice when a health check fails than when a post's first
+comment fails.
+"""
 
 from providers.exceptions import (
     APIError,
     OAuthError,
+    PublishError,
     RateLimitError,
     TokenExpiredError,
 )
@@ -12,6 +20,26 @@ RATE_LIMIT_MESSAGE = "Rate limit reached. We'll retry this check shortly."
 PLATFORM_UNAVAILABLE_MESSAGE = "The platform is temporarily unavailable. We'll retry shortly."
 GENERIC_MESSAGE = "Connection check failed. Please try reconnecting."
 
+FIRST_COMMENT_RECONNECT_MESSAGE = (
+    "The account connection expired, so the first comment wasn't added. "
+    "Reconnect the account and add the comment manually."
+)
+FIRST_COMMENT_TEMPORARY_MESSAGE = "The platform was temporarily unavailable, so the first comment wasn't added."
+FIRST_COMMENT_REJECTED_MESSAGE = "The platform rejected the first comment. Add it manually on the post."
+FIRST_COMMENT_GENERIC_MESSAGE = "The first comment couldn't be added. Add it manually on the post."
+
+PUBLISH_RECONNECT_MESSAGE = "The account connection expired, so the post couldn't be published. Please reconnect it."
+PUBLISH_TEMPORARY_MESSAGE = "The platform was temporarily unavailable. We'll retry shortly."
+PUBLISH_RATE_LIMIT_MESSAGE = "The platform's rate limit was reached. We'll retry shortly."
+PUBLISH_REJECTED_MESSAGE = "The platform rejected this post."
+PUBLISH_GENERIC_MESSAGE = "Publishing failed. Please try again."
+# The two messages above promise a retry, which is true only while attempts
+# remain. Once the budget is spent the post is permanently failed and the
+# composer must not keep telling the user to sit tight.
+PUBLISH_EXHAUSTED_MESSAGE = (
+    "Publishing kept failing, so we stopped retrying. Try again, or reconnect the account if it keeps happening."
+)
+
 _EXPIRED_TOKEN_ERRORS = {
     "ExpiredToken",
     "invalid_token",
@@ -19,26 +47,128 @@ _EXPIRED_TOKEN_ERRORS = {
     "invalid_grant",
 }
 
+_RECONNECT = "reconnect"
+_RATE_LIMITED = "rate_limited"
+_UNAVAILABLE = "unavailable"
+_REJECTED = "rejected"
+_UNKNOWN = "unknown"
 
-def friendly_health_check_error(exc: Exception) -> str:
-    """Map a provider exception to a short, user-facing message."""
+
+def _classify(exc: Exception) -> str:
+    """Reduce a provider exception to one of the failure shapes above."""
     if isinstance(exc, TokenExpiredError):
-        return RECONNECT_MESSAGE
+        return _RECONNECT
 
     if isinstance(exc, RateLimitError):
-        return RATE_LIMIT_MESSAGE
+        return _RATE_LIMITED
 
     if isinstance(exc, APIError):
         if exc.status_code in (401, 403):
-            return RECONNECT_MESSAGE
+            return _RECONNECT
+        # ``raw_response["error"]`` is a bare string on OAuth token endpoints
+        # ("invalid_grant") but a *dict* on every Graph API error. Hashing a
+        # dict against this set raises TypeError, which would escape whatever
+        # ``except`` block called us — guard the type, don't assume the shape.
         error_code = (exc.raw_response or {}).get("error")
-        if error_code in _EXPIRED_TOKEN_ERRORS:
-            return RECONNECT_MESSAGE
+        if isinstance(error_code, str) and error_code in _EXPIRED_TOKEN_ERRORS:
+            return _RECONNECT
         if exc.status_code is not None and exc.status_code >= 500:
-            return PLATFORM_UNAVAILABLE_MESSAGE
-        return GENERIC_MESSAGE
+            return _UNAVAILABLE
+        return _REJECTED
 
     if isinstance(exc, OAuthError):
-        return RECONNECT_MESSAGE
+        return _RECONNECT
 
-    return GENERIC_MESSAGE
+    return _UNKNOWN
+
+
+# The unmistakable openings of a serialized JSON object and a Python dict repr.
+# A provider message containing either is quoting a response body rather than
+# describing the failure.
+_PAYLOAD_MARKERS = ('{"', "{'")
+# No sentence we write about a publish failure comes close to this.
+_MAX_PASSTHROUGH_LENGTH = 300
+
+
+def _is_user_safe(message: str) -> bool:
+    """Whether a provider-authored message can be shown as-is.
+
+    Belt and braces around the pass-through below. Providers are supposed to
+    put response bodies in ``raw_response`` and keep the message a sentence, but
+    that is a convention a new provider can break silently, and the cost of
+    breaking it is the platform's JSON rendered into the composer.
+    """
+    return (
+        bool(message)
+        and len(message) <= _MAX_PASSTHROUGH_LENGTH
+        and not any(marker in message for marker in _PAYLOAD_MARKERS)
+    )
+
+
+def _friendly(exc: Exception, copy: dict[str, str], fallback: str) -> str:
+    """Map ``exc`` to user-facing text, preserving messages we authored.
+
+    Only ``PublishError`` passes through, and only when it still looks like
+    prose. Its messages are written by us for a human and are frequently the
+    most useful thing we could say — "TikTok only supports VIDEO posts", "Trim
+    the video and try again", "DEV.to requires a title" — so rewriting them
+    generically would lose real information.
+
+    Everything else is rewritten. ``APIError``/``RateLimitError`` messages are
+    built by ``SocialProvider._request`` from ``response.text``, so they carry
+    the platform's JSON — OAuthException types, fbtrace ids, internal subcodes.
+    ``OAuthError`` interpolates a token-exchange body on some providers, and an
+    auth failure maps to better advice than its own wording anyway.
+    """
+    if type(exc) is PublishError:
+        message = str(exc).strip()
+        if _is_user_safe(message):
+            return message
+    return copy.get(_classify(exc), fallback)
+
+
+def friendly_health_check_error(exc: Exception) -> str:
+    """Map a provider exception to a short, user-facing message."""
+    return {
+        _RECONNECT: RECONNECT_MESSAGE,
+        _RATE_LIMITED: RATE_LIMIT_MESSAGE,
+        _UNAVAILABLE: PLATFORM_UNAVAILABLE_MESSAGE,
+    }.get(_classify(exc), GENERIC_MESSAGE)
+
+
+def friendly_first_comment_error(exc: Exception) -> str:
+    """Map a failed first-comment attempt to a message safe to show a user.
+
+    Deliberately drops the platform's own wording for API errors. Meta's
+    ``error_user_msg`` reads well but says nothing actionable — the payload
+    behind this function's existence offered "Your Instagram comment was not
+    added" — and the rest of the body is trace ids and internal type names.
+    """
+    return _friendly(
+        exc,
+        {
+            _RECONNECT: FIRST_COMMENT_RECONNECT_MESSAGE,
+            _RATE_LIMITED: FIRST_COMMENT_TEMPORARY_MESSAGE,
+            _UNAVAILABLE: FIRST_COMMENT_TEMPORARY_MESSAGE,
+            _REJECTED: FIRST_COMMENT_REJECTED_MESSAGE,
+        },
+        FIRST_COMMENT_GENERIC_MESSAGE,
+    )
+
+
+def friendly_publish_error(exc: Exception) -> str:
+    """Map a failed publish to a message safe to show a user.
+
+    The raw text is not lost: every publish failure writes a PublishLog row
+    carrying ``error_message`` before the post is marked failed.
+    """
+    return _friendly(
+        exc,
+        {
+            _RECONNECT: PUBLISH_RECONNECT_MESSAGE,
+            _RATE_LIMITED: PUBLISH_RATE_LIMIT_MESSAGE,
+            _UNAVAILABLE: PUBLISH_TEMPORARY_MESSAGE,
+            _REJECTED: PUBLISH_REJECTED_MESSAGE,
+        },
+        PUBLISH_GENERIC_MESSAGE,
+    )

--- a/apps/social_accounts/tests/test_error_messages.py
+++ b/apps/social_accounts/tests/test_error_messages.py
@@ -1,15 +1,25 @@
-"""Tests for the health check error message translator."""
+"""Tests for the user-facing provider error translators."""
 
 from apps.social_accounts.error_messages import (
+    FIRST_COMMENT_GENERIC_MESSAGE,
+    FIRST_COMMENT_RECONNECT_MESSAGE,
+    FIRST_COMMENT_REJECTED_MESSAGE,
+    FIRST_COMMENT_TEMPORARY_MESSAGE,
     GENERIC_MESSAGE,
     PLATFORM_UNAVAILABLE_MESSAGE,
+    PUBLISH_GENERIC_MESSAGE,
+    PUBLISH_RECONNECT_MESSAGE,
+    PUBLISH_REJECTED_MESSAGE,
     RATE_LIMIT_MESSAGE,
     RECONNECT_MESSAGE,
+    friendly_first_comment_error,
     friendly_health_check_error,
+    friendly_publish_error,
 )
 from providers.exceptions import (
     APIError,
     OAuthError,
+    PublishError,
     RateLimitError,
     TokenExpiredError,
 )
@@ -58,3 +68,109 @@ def test_generic_api_error_maps_to_generic_message():
 
 def test_bare_exception_maps_to_generic_message():
     assert friendly_health_check_error(Exception("boom")) == GENERIC_MESSAGE
+
+
+def test_a_meta_error_payload_does_not_crash_the_classifier():
+    """``raw_response["error"]`` is a dict on every Graph error and a bare
+    string only on OAuth token endpoints. Hashing the dict against the
+    expired-token set raises TypeError, which escapes the caller's own except."""
+    exc = APIError(
+        "boom",
+        status_code=400,
+        raw_response={"error": {"code": 20, "type": "OAuthException", "error_subcode": 1772107}},
+    )
+
+    assert friendly_health_check_error(exc) == GENERIC_MESSAGE
+
+
+def test_first_comment_reconnect_on_an_auth_rejection():
+    assert friendly_first_comment_error(APIError("nope", status_code=401)) == FIRST_COMMENT_RECONNECT_MESSAGE
+    assert friendly_first_comment_error(TokenExpiredError("gone")) == FIRST_COMMENT_RECONNECT_MESSAGE
+    # TokenExpiredError text is not passed through: an auth failure maps to
+    # better advice than whatever the provider happened to say.
+    assert "gone" not in friendly_first_comment_error(TokenExpiredError("gone"))
+
+
+def test_first_comment_temporary_on_a_rate_limit_or_server_error():
+    assert friendly_first_comment_error(RateLimitError("slow")) == FIRST_COMMENT_TEMPORARY_MESSAGE
+    assert friendly_first_comment_error(APIError("boom", status_code=502)) == FIRST_COMMENT_TEMPORARY_MESSAGE
+
+
+def test_first_comment_rejected_drops_the_platform_response_body():
+    exc = APIError(
+        'Instagram API error 400: {"error":{"type":"OAuthException","fbtrace_id":"A4B_mFUQTXKx"}}',
+        status_code=400,
+    )
+
+    message = friendly_first_comment_error(exc)
+
+    assert message == FIRST_COMMENT_REJECTED_MESSAGE
+    assert "fbtrace_id" not in message
+
+
+def test_first_comment_keeps_a_message_we_wrote_ourselves():
+    """PublishError is the one class whose message is always written by us for
+    a human, so it is the one class that passes through."""
+    exc = PublishError("Instagram container processing timed out")
+
+    assert friendly_first_comment_error(exc) == "Instagram container processing timed out"
+
+
+def test_first_comment_generic_for_a_non_provider_exception():
+    assert friendly_first_comment_error(ValueError("boom")) == FIRST_COMMENT_GENERIC_MESSAGE
+
+
+def test_publish_error_drops_the_platform_response_body():
+    exc = APIError('TikTok API error 400: {"error":{"code":"spam_risk_too_many_posts"}}', status_code=400)
+
+    message = friendly_publish_error(exc)
+
+    assert message == PUBLISH_REJECTED_MESSAGE
+    assert "spam_risk_too_many_posts" not in message
+
+
+def test_publish_error_keeps_a_message_we_wrote_ourselves():
+    """The TikTok audit and container-timeout messages tell a user exactly what
+    happened; a blanket rewrite would throw that away."""
+    exc = PublishError("TikTok rejected the post: audit pending", retryable=False)
+
+    assert friendly_publish_error(exc) == "TikTok rejected the post: audit pending"
+
+
+def test_publish_error_reconnect_on_an_auth_rejection():
+    assert friendly_publish_error(APIError("nope", status_code=403)) == PUBLISH_RECONNECT_MESSAGE
+
+
+def test_publish_error_generic_for_a_non_provider_exception():
+    assert friendly_publish_error(RuntimeError("boom")) == PUBLISH_GENERIC_MESSAGE
+
+
+def test_an_oauth_error_body_is_never_shown():
+    """instagram_login interpolates the token-exchange body into OAuthError,
+    and a reconnect prompt is better advice than that body anyway."""
+    exc = OAuthError('Instagram token exchange failed: {"error_message":"Invalid platform app"}')
+
+    assert friendly_publish_error(exc) == PUBLISH_RECONNECT_MESSAGE
+    assert friendly_first_comment_error(exc) == FIRST_COMMENT_RECONNECT_MESSAGE
+
+
+def test_a_publish_error_quoting_a_json_body_is_not_passed_through():
+    """Providers are meant to put bodies in raw_response, but that is a
+    convention a new provider can break silently."""
+    exc = PublishError('Threads container creation failed: {"error":{"fbtrace_id":"A4B"}}')
+
+    message = friendly_publish_error(exc)
+
+    assert message == PUBLISH_GENERIC_MESSAGE
+    assert "fbtrace_id" not in message
+
+
+def test_a_publish_error_quoting_a_dict_repr_is_not_passed_through():
+    exc = PublishError("DEV.to article creation returned no id: {'error': 'unauthorized', 'status': 401}")
+
+    assert friendly_publish_error(exc) == PUBLISH_GENERIC_MESSAGE
+
+
+def test_an_overlong_publish_error_is_not_passed_through():
+    assert friendly_publish_error(PublishError("x" * 301)) == PUBLISH_GENERIC_MESSAGE
+    assert friendly_publish_error(PublishError("x" * 300)) == "x" * 300

--- a/apps/social_accounts/tests/test_webhook_subscription.py
+++ b/apps/social_accounts/tests/test_webhook_subscription.py
@@ -98,24 +98,29 @@ def test_instagram_remembers_the_linked_page_as_its_webhook_target(workspace):
         )
 
     assert account.webhook_target_id == "page-77"
-    assert _webhook_target(account) == "page-77"
+    # Stored for _is_own_activity, but NOT what we subscribe: comments/mentions
+    # are Instagram-object fields and a Page rejects them outright.
+    assert _webhook_target(account) == "ig-99"
 
 
-def test_webhook_target_defaults_to_the_account_itself(workspace):
+def test_webhook_target_is_always_the_account_itself(workspace):
     assert _webhook_target(_account(workspace, account_platform_id="page-5")) == "page-5"
 
 
 # -------------------------------------------------------------- subscribing
 
 
-def test_subscribe_uses_the_webhook_target(workspace):
+def test_subscribe_targets_the_instagram_user_not_its_linked_page(workspace):
+    """Meta answers comments/mentions on a Page with "(#100) Param
+    subscribed_fields[0] must be one of {feed, mention, ...}", so every account
+    subscribed against the Page was left with a permanently deaf inbox."""
     account = _account(workspace, platform="instagram", account_platform_id="ig-99", webhook_target_id="page-77")
     provider = _WebhookProvider()
 
     with patch("apps.social_accounts.views._get_provider_for_platform", return_value=provider):
         assert _subscribe_account_webhooks(account) is True
 
-    assert provider.subscribe_calls == [("page-token", "page-77")]
+    assert provider.subscribe_calls == [("page-token", "ig-99")]
 
 
 def test_a_failed_subscription_is_recorded_on_the_account(workspace):
@@ -172,14 +177,14 @@ def test_supports_webhooks_distinguishes_real_implementations():
 # ------------------------------------------------------------ unsubscribing
 
 
-def test_unsubscribe_uses_the_stored_webhook_target(workspace):
+def test_unsubscribe_targets_the_same_object_subscribe_did(workspace):
     account = _account(workspace, platform="instagram", account_platform_id="ig-99", webhook_target_id="page-77")
     provider = _WebhookProvider()
 
     with patch("apps.social_accounts.views._get_provider_for_platform", return_value=provider):
         assert _unsubscribe_account_webhooks(account) is True
 
-    assert provider.unsubscribe_calls == [("page-token", "page-77")]
+    assert provider.unsubscribe_calls == [("page-token", "ig-99")]
 
 
 def test_unsubscribe_failure_is_swallowed_so_disconnect_still_happens(workspace):
@@ -318,7 +323,25 @@ def test_the_last_connection_does_unsubscribe(workspace, organization):
     assert provider.unsubscribe_calls == [("page-token", "page-solo")]
 
 
-def test_a_shared_instagram_page_target_is_also_protected(workspace, organization):
+def test_the_same_instagram_account_in_two_workspaces_is_protected(workspace, organization):
+    """The subscription belongs to the IG user, so a second workspace holding
+    the same account still depends on it."""
+    from apps.workspaces.models import Workspace
+
+    other_ws = Workspace.objects.create(name="Other WS", organization=organization)
+    account = _account(workspace, platform="instagram", account_platform_id="ig-1", webhook_target_id="page-77")
+    _account(other_ws, platform="instagram", account_platform_id="ig-1", webhook_target_id="page-77")
+    provider = _WebhookProvider()
+
+    with patch("apps.social_accounts.views._get_provider_for_platform", return_value=provider):
+        assert _unsubscribe_account_webhooks(account) is False
+
+    assert provider.unsubscribe_calls == []
+
+
+def test_two_instagram_accounts_sharing_a_page_do_not_share_a_subscription(workspace, organization):
+    """Each IG user carries its own subscription now, so disconnecting one must
+    not leave the other's dangling."""
     from apps.workspaces.models import Workspace
 
     other_ws = Workspace.objects.create(name="Other WS", organization=organization)
@@ -327,9 +350,9 @@ def test_a_shared_instagram_page_target_is_also_protected(workspace, organizatio
     provider = _WebhookProvider()
 
     with patch("apps.social_accounts.views._get_provider_for_platform", return_value=provider):
-        assert _unsubscribe_account_webhooks(account) is False
+        assert _unsubscribe_account_webhooks(account) is True
 
-    assert provider.unsubscribe_calls == []
+    assert provider.unsubscribe_calls == [("page-token", "ig-1")]
 
 
 # ------------------------------------------------------- the backfill command

--- a/apps/social_accounts/views.py
+++ b/apps/social_accounts/views.py
@@ -15,7 +15,6 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core import signing
 from django.core.exceptions import PermissionDenied
-from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.views.decorators.http import require_GET, require_POST
@@ -872,12 +871,20 @@ def _create_or_update_account(
 
 
 def _webhook_target(account):
-    """The object whose webhooks we subscribe for this account.
+    """The object whose webhooks we subscribe for this account: the account itself.
 
-    Usually the account itself; for Instagram connected through Facebook Login
-    it is the linked Page, which is what actually delivers the events.
+    This used to hand Instagram's linked Page (``webhook_target_id``) to
+    ``subscribe_webhooks`` on the theory that the Page delivers Instagram
+    events. Meta disagrees: ``comments``/``mentions`` are fields of the
+    *Instagram* object, and a Page answers them with "(#100) Param
+    subscribed_fields[0] must be one of {feed, mention, ...}" — so every
+    Instagram account ended up with ``webhooks_active=False`` and an inbox that
+    never saw a comment.
+
+    ``webhook_target_id`` is still stored: ``_is_own_activity`` uses it to
+    recognise the account's own Page-side activity.
     """
-    return account.webhook_target_id or account.account_platform_id
+    return account.account_platform_id
 
 
 def _supports_webhooks(provider) -> bool:
@@ -967,16 +974,12 @@ def _webhook_target_is_shared(account) -> bool:
     would silence the others' inboxes too, so we leave it in place and let the
     revoked token end our access.
     """
-    target = _webhook_target(account)
-    # Compare each candidate's *effective* target. Matching the raw column
-    # would treat every account with a blank webhook_target_id as sharing one.
-    same_target = Q(webhook_target_id=target) | Q(webhook_target_id="", account_platform_id=target)
     return (
         SocialAccount.objects.filter(
             platform=account.platform,
             connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+            account_platform_id=_webhook_target(account),
         )
-        .filter(same_target)
         .exclude(pk=account.pk)
         .exists()
     )

--- a/providers/devto.py
+++ b/providers/devto.py
@@ -146,7 +146,10 @@ class DevtoProvider(SocialProvider):
         article_id = data.get("id")
         if not article_id:
             raise PublishError(
-                f"DEV.to article creation returned no id: {data}",
+                # The body goes in raw_response, not the message: publish_error
+                # is rendered to users, and a ProviderError message is the one
+                # thing the sanitizer passes through verbatim.
+                "DEV.to accepted the request but returned no article id",
                 platform=self.platform_name,
                 raw_response=data,
             )

--- a/providers/facebook.py
+++ b/providers/facebook.py
@@ -8,6 +8,7 @@ from urllib.parse import urlencode, urlparse
 
 from .base import SocialProvider
 from .exceptions import APIError, OAuthError, PublishError
+from .meta_comments import parse_graph_time
 from .meta_insights import fetch_insights_safe, parse_insights_response
 from .meta_messaging import build_send_payload, resolve_recipient_id
 from .types import (
@@ -531,7 +532,14 @@ class FacebookProvider(SocialProvider):
                     access_token=access_token,
                     params={"fields": "id,message,from", "limit": FACEBOOK_COMMENTS_PER_POST},
                 )
-            except APIError:
+            except APIError as exc:
+                # Only "no such object" means this candidate target was the
+                # wrong guess and the next one deserves a try. Any other failure
+                # leaves the answer unknown, and returning None for it tells the
+                # caller it is safe to post again — the duplicate this whole
+                # lookup exists to prevent.
+                if exc.status_code not in (400, 404):
+                    raise
                 continue
 
             for comment in resp.json().get("data", []):
@@ -935,13 +943,7 @@ class FacebookProvider(SocialProvider):
         otherwise be compared against an aware cutoff (TypeError) and stored as
         a naive ``received_at``; Graph serves UTC, so assume it.
         """
-        if not value:
-            return None
-        try:
-            parsed = datetime.fromisoformat(str(value).replace("+0000", "+00:00"))
-        except ValueError:
-            return None
-        return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+        return parse_graph_time(value)
 
     def reply_to_message(
         self,

--- a/providers/instagram.py
+++ b/providers/instagram.py
@@ -13,12 +13,18 @@ from urllib.parse import urlencode
 
 from .base import SocialProvider
 from .exceptions import APIError, OAuthError, PublishError
+from .meta_comments import (
+    fetch_instagram_comments,
+    find_own_instagram_comment,
+    resolve_comment_reply_target,
+)
 from .meta_insights import fetch_insights_safe
 from .types import (
     AccountMetrics,
     AccountProfile,
     AuthType,
     CommentResult,
+    InboxMessage,
     MediaType,
     OAuthTokens,
     PostMetrics,
@@ -34,8 +40,18 @@ logger = logging.getLogger(__name__)
 BASE_URL = "https://graph.facebook.com/v25.0"
 OAUTH_URL = "https://www.facebook.com/v25.0/dialog/oauth"
 TOKEN_URL = f"{BASE_URL}/oauth/access_token"
-# Subscribed on the linked Facebook Page: Instagram comment events are delivered
-# through it. Without this the inbox never sees an IG comment.
+# Subscribed on the Instagram user, NOT on the linked Facebook Page. These are
+# fields of Meta's *Instagram* webhook object; a Page accepts only its own
+# ({feed, mention, messages, ...}) and answers anything else with
+# "(#100) Param subscribed_fields[0] must be one of {...}". Sending them to the
+# Page is what left every Instagram inbox deaf to comments.
+#
+# The Page is also the wrong object on permissions: POST /{page-id}/subscribed_apps
+# needs ``pages_manage_metadata``, which this OAuth flow never requests, while
+# the Instagram user's edge is covered by the ``instagram_*`` scopes it does.
+# And ``subscribed_apps`` *replaces* a field list rather than merging into it,
+# so writing the Page from here would silently drop the mention and message
+# subscriptions of a Facebook Page connected in the same workspace.
 #
 # ``messages`` is deliberately absent: this OAuth flow does not request
 # ``instagram_manage_messages``, so Meta would reject the subscription and any
@@ -419,15 +435,39 @@ class InstagramProvider(SocialProvider):
     # ------------------------------------------------------------------
 
     def publish_comment(self, access_token: str, post_id: str, text: str) -> CommentResult:
+        """Comment on a media item (used for the first comment).
+
+        No ``fields`` param: Meta answers a comment POST that carries one with
+        error code 20 / subcode 1772107 ("does not support the requested
+        response format") *after* creating the comment. The call then reads as a
+        clean 400, the retry queue re-sends it, and the account ends up with one
+        comment per attempt.
+        """
         resp = self._request(
             "POST",
             f"{BASE_URL}/{post_id}/comments",
             access_token=access_token,
-            params={"fields": "id"},
             json={"message": text},
         )
         data = resp.json()
         return CommentResult(platform_comment_id=data["id"], extra=data)
+
+    def find_own_comment(self, access_token: str, post_id: str, text: str) -> str | None:
+        """Find a comment this account already left on ``post_id``.
+
+        Called before retrying a first comment whose previous attempt failed —
+        the platform may have created it anyway.
+        """
+        return find_own_instagram_comment(
+            self._request,
+            api_base=BASE_URL,
+            access_token=access_token,
+            media_id=post_id,
+            text=text,
+            # Both set by _resolve_publish_credentials in apps/publisher/engine.py.
+            own_id=str(self.credentials.get("ig_user_id") or ""),
+            own_handle=str(self.credentials.get("account_handle") or ""),
+        )
 
     # ------------------------------------------------------------------
     # Analytics
@@ -505,22 +545,50 @@ class InstagramProvider(SocialProvider):
     # ------------------------------------------------------------------
 
     # Instagram DMs are not available on this connection: the Facebook-Login
-    # flow does not request ``instagram_manage_messages``, so ``get_messages``
-    # and ``reply_to_message`` stay unimplemented and the inbox skips this
-    # account for DMs. Accounts connected via Instagram Login do support them.
+    # flow does not request ``instagram_manage_messages``, so
+    # ``reply_to_message`` stays unimplemented and this account never appears in
+    # the DM surface. Accounts connected via Instagram Login do support them.
+
+    def get_messages(self, access_token: str, since: datetime | None = None) -> list[InboxMessage]:
+        """Poll comments on the account's recent media.
+
+        Instagram comments have only ever reached the inbox by webhook, and that
+        webhook is subscribed on the *linked Page* (see ``subscribe_webhooks``)
+        — an object this app cannot confirm is delivering anything. An account
+        whose subscription never took is deaf to comments permanently with no
+        way to backfill; this poll is the backstop, exactly as FacebookProvider
+        does for a Page feed.
+        """
+        ig_user_id = str(self.credentials.get("ig_user_id") or "")
+        if not ig_user_id:
+            # Deliberately not falling back to ``_get_ig_user_id``: it picks the
+            # first Page with a linked IG account, and on a multi-page login
+            # that is a different account whose media we would poll into this
+            # workspace's inbox.
+            logger.warning("Skipping Instagram comment poll: no ig_user_id in credentials")
+            return []
+
+        return fetch_instagram_comments(
+            self._request,
+            platform=self.platform_name,
+            host=BASE_URL,
+            media_url=f"{BASE_URL}/{ig_user_id}/media",
+            access_token=access_token,
+            since=since,
+            owner_id=ig_user_id,
+            owner_handle=str(self.credentials.get("account_handle") or ""),
+        )
 
     def reply_to_comment(self, access_token: str, comment_id: str, text: str, extra: dict | None = None) -> ReplyResult:
         """Reply to a comment, or comment on a media item.
 
-        A comment is answered on its ``replies`` edge, but a mention in a
-        caption gives us only the media ID, which has no ``replies`` edge —
-        that one is answered by commenting on the media itself. The inbox
-        records which applies as ``reply_edge``.
+        Which object and edge to post to depends on what the inbox item is —
+        see ``resolve_comment_reply_target``.
         """
-        edge = "comments" if (extra or {}).get("reply_edge") == "media" else "replies"
+        target, edge = resolve_comment_reply_target(comment_id, extra)
         resp = self._request(
             "POST",
-            f"{BASE_URL}/{comment_id}/{edge}",
+            f"{BASE_URL}/{target}/{edge}",
             access_token=access_token,
             json={"message": text},
         )
@@ -532,11 +600,12 @@ class InstagramProvider(SocialProvider):
     # ------------------------------------------------------------------
 
     def subscribe_webhooks(self, access_token: str, account_id: str) -> bool:
-        """Subscribe to Instagram webhooks via the linked Facebook Page.
+        """Subscribe to Instagram webhooks on the Instagram user.
 
-        Instagram accounts connected through Facebook Login receive comment and
-        message events through the Page they are linked to, so ``account_id``
-        here is the Page ID, not the IG user ID.
+        ``account_id`` is the IG user ID, not the ID of the Facebook Page the
+        account is linked to — see ``INSTAGRAM_WEBHOOK_FIELDS`` for why the Page
+        cannot carry these fields. The app must also be subscribed to the
+        Instagram object in the Meta App Dashboard; no API call can set that.
         """
         resp = self._request(
             "POST",

--- a/providers/instagram_login.py
+++ b/providers/instagram_login.py
@@ -20,6 +20,11 @@ from urllib.parse import urlencode
 
 from .base import SocialProvider
 from .exceptions import APIError, OAuthError, PublishError
+from .meta_comments import (
+    fetch_instagram_comments,
+    find_own_instagram_comment,
+    resolve_comment_reply_target,
+)
 from .meta_insights import fetch_insights_safe
 from .meta_messaging import build_send_payload, resolve_recipient_id
 from .types import (
@@ -413,6 +418,9 @@ class InstagramLoginProvider(SocialProvider):
     # ------------------------------------------------------------------
 
     def publish_comment(self, access_token: str, post_id: str, text: str) -> CommentResult:
+        # No ``fields`` param — see InstagramProvider.publish_comment: Meta
+        # creates the comment and *then* rejects the response format, so the
+        # retry queue duplicates it.
         resp = self._request(
             "POST",
             f"{API_BASE}/{post_id}/comments",
@@ -421,6 +429,22 @@ class InstagramLoginProvider(SocialProvider):
         )
         data = resp.json()
         return CommentResult(platform_comment_id=data["id"], extra=data)
+
+    def find_own_comment(self, access_token: str, post_id: str, text: str) -> str | None:
+        """Find a comment this account already left on ``post_id``.
+
+        Reconciliation before retrying a first comment — see
+        ``InstagramProvider.find_own_comment``.
+        """
+        return find_own_instagram_comment(
+            self._request,
+            api_base=API_BASE,
+            access_token=access_token,
+            media_id=post_id,
+            text=text,
+            own_id=str(self.credentials.get("ig_user_id") or ""),
+            own_handle=str(self.credentials.get("account_handle") or ""),
+        )
 
     # ------------------------------------------------------------------
     # Analytics
@@ -497,6 +521,47 @@ class InstagramLoginProvider(SocialProvider):
     # ------------------------------------------------------------------
 
     def get_messages(self, access_token: str, since: datetime | None = None) -> list[InboxMessage]:
+        """Poll DMs and comments, letting either half fail on its own.
+
+        The two need different permissions —
+        ``instagram_business_manage_messages`` and
+        ``instagram_business_manage_comments`` — so an account granted only one
+        of them must still get the half it can read. Only a poll that produced
+        nothing at all reports failure upward.
+        """
+        messages: list[InboxMessage] = []
+        failures: list[Exception] = []
+
+        for label, fetch in (("DM", self._fetch_direct_messages), ("comment", self._fetch_media_comments)):
+            try:
+                messages.extend(fetch(access_token, since))
+            except Exception as exc:
+                failures.append(exc)
+                logger.warning("Instagram Login %s poll failed: %s", label, exc)
+
+        if failures and not messages:
+            raise failures[0]
+        return messages
+
+    def _fetch_media_comments(self, access_token: str, since: datetime | None = None) -> list[InboxMessage]:
+        """Poll comments on the account's recent media.
+
+        The ``comments`` webhook is the fast path, but an account whose
+        subscription never took would otherwise never see a comment and have no
+        way to backfill.
+        """
+        return fetch_instagram_comments(
+            self._request,
+            platform=self.platform_name,
+            host=API_BASE,
+            media_url=f"{API_BASE}/me/media",
+            access_token=access_token,
+            since=since,
+            owner_id=str(self.credentials.get("ig_user_id") or ""),
+            owner_handle=str(self.credentials.get("account_handle") or ""),
+        )
+
+    def _fetch_direct_messages(self, access_token: str, since: datetime | None = None) -> list[InboxMessage]:
         params: dict = {"fields": "id,participants,messages{id,message,from,created_time}"}
         if since:
             params["since"] = int(since.timestamp())
@@ -572,10 +637,10 @@ class InstagramLoginProvider(SocialProvider):
         that one is answered by commenting on the media itself. The inbox
         records which applies as ``reply_edge``.
         """
-        edge = "comments" if (extra or {}).get("reply_edge") == "media" else "replies"
+        target, edge = resolve_comment_reply_target(comment_id, extra)
         resp = self._request(
             "POST",
-            f"{API_BASE}/{comment_id}/{edge}",
+            f"{API_BASE}/{target}/{edge}",
             access_token=access_token,
             json={"message": text},
         )

--- a/providers/meta_comments.py
+++ b/providers/meta_comments.py
@@ -1,0 +1,402 @@
+"""Comment reading shared by the two Instagram providers.
+
+Both Instagram connections read the same ``/{media-id}/comments`` edge and
+differ only in host — Facebook Login goes through ``graph.facebook.com``,
+Instagram Login through ``graph.instagram.com``. Everything else (field sets,
+cutoff arithmetic, the own-comment filter, the reply-target rules) is identical,
+so it lives here once rather than being copy-pasted into both modules.
+
+``FacebookProvider`` keeps its own versions: its comments edge answers with
+``message`` rather than ``text``, its post ids need page-scoping first, and it
+reads a ``/feed`` edge rather than ``/media``.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from urllib.parse import urlparse
+
+from .types import InboxMessage
+
+logger = logging.getLogger(__name__)
+
+# Comment-poll bounds. The poll is a backstop for the ``comments`` webhook, so
+# it trades completeness on very busy accounts for a predictable per-cycle cost:
+# one media call plus at most INSTAGRAM_COMMENT_PAGE_LIMIT follow-ups per item.
+INSTAGRAM_MEDIA_SCAN_LIMIT = 25
+# Lower than Facebook's 50: with ``replies`` nested this is a three-level
+# expansion, and Graph starts refusing large node counts outright.
+INSTAGRAM_COMMENTS_PER_MEDIA = 25
+INSTAGRAM_REPLIES_PER_COMMENT = 5
+INSTAGRAM_COMMENT_PAGE_LIMIT = 4
+# How far back the *media* scan reaches. Comments on older media are only
+# reachable via the webhook.
+INSTAGRAM_MEDIA_WINDOW_DAYS = 30
+# Overlap applied to the caller's ``since``. The inbox passes the newest
+# received_at across *all* message types for the account, so on an
+# Instagram-Login account a DM that arrived after a comment would otherwise hide
+# that comment forever. Re-fetching the overlap is free: _upsert_message only
+# notifies on create.
+INSTAGRAM_COMMENT_LOOKBACK_HOURS = 24
+
+# One page is enough for reconciliation: it runs minutes after publishing, on a
+# post whose only expected comment is ours.
+INSTAGRAM_RECONCILE_COMMENT_LIMIT = 50
+
+_ALWAYS_FIELDS = "id,text,timestamp,username"
+_AUTHOR_FIELD = "from{id,username}"
+
+
+def _field_set(*, author: bool, replies: bool) -> str:
+    """Build one comment field set, with or without each optional part."""
+    node = _ALWAYS_FIELDS + (f",{_AUTHOR_FIELD}" if author else "")
+    if not replies:
+        return node
+    return f"{node},replies.limit({INSTAGRAM_REPLIES_PER_COMMENT}){{{node}}}"
+
+
+# Graph fails the *whole* call on one unknown or unpermitted field, and ``from``
+# and ``replies`` are the two most likely to be refused. Degrade them one axis
+# at a time: dropping both together would lose every reply on an account that
+# could read replies perfectly well and only objected to ``from``, and a
+# customer answering our own first comment is exactly the message we cannot
+# afford to lose.
+#
+# ``from`` is given up last because it carries the author id the own-comment
+# filter prefers; ``username`` is requested at every level as the fallback
+# signal, so even the final set can still recognise our own comments by handle.
+INSTAGRAM_COMMENT_FIELD_SETS = (
+    _field_set(author=True, replies=True),
+    _field_set(author=True, replies=False),
+    _field_set(author=False, replies=True),
+    _field_set(author=False, replies=False),
+)
+
+
+def parse_graph_time(value: str | None) -> datetime | None:
+    """Parse Graph's ``2026-08-07T12:34:56+0000`` timestamps.
+
+    Always returns an aware datetime. A value without an offset would otherwise
+    be compared against an aware cutoff (TypeError) and stored as a naive
+    ``received_at``; Graph serves UTC, so assume it.
+    """
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("+0000", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=UTC)
+
+
+def _comment_text(comment: dict) -> str:
+    """Read a comment's body.
+
+    Instagram's read edge spells it ``text`` while the write edge takes
+    ``message``. Accept both: a response that ever used the write spelling would
+    otherwise silently read as an empty comment, which for ``find_own_comment``
+    means "not ours" and a duplicate on a live account.
+    """
+    return comment.get("text") or comment.get("message") or ""
+
+
+def _comment_author(comment: dict) -> tuple[str, str]:
+    """Return ``(author_id, author_username)`` for a comment, either possibly empty.
+
+    Instagram withholds ``from`` on third-party comments in some app and
+    permission combinations, returning only a bare ``username``, so both signals
+    have to be read and neither can be required. The username is returned as
+    Instagram spelled it — ``_same_handle`` normalizes for comparison, because a
+    value normalized here would end up stored and displayed that way.
+    """
+    author = comment.get("from") or {}
+    author_id = str(author.get("id") or "")
+    return author_id, str(author.get("username") or comment.get("username") or "")
+
+
+def _same_handle(left: str, right: str) -> bool:
+    """Compare two Instagram handles, ignoring a leading @ and casing."""
+    return bool(left and right and left.lstrip("@").lower() == right.lstrip("@").lower())
+
+
+def _is_own_comment(author_id: str, author_handle: str, owner_id: str, owner_handle: str) -> bool:
+    """True when the account itself wrote this comment.
+
+    Checked on id *and* handle because either can be missing from the payload.
+    An unrecognised own comment lands in the inbox as an inbound message from
+    ourselves — including every first comment we post.
+    """
+    if owner_id and author_id and author_id == owner_id:
+        return True
+    return _same_handle(author_handle, owner_handle)
+
+
+def find_own_instagram_comment(
+    request,
+    *,
+    api_base: str,
+    access_token: str,
+    media_id: str,
+    text: str,
+    own_id: str,
+    own_handle: str = "",
+) -> str | None:
+    """Return the id of a comment this account already left on ``media_id``.
+
+    Reconciliation hook for retrying a first comment whose previous attempt
+    failed: Instagram creates the comment before rejecting some malformed
+    requests, so a blind retry double-comments.
+
+    Errs toward reporting a match — a false positive costs one skipped comment,
+    a false negative posts a duplicate on a live account, which cannot be taken
+    back. So an author we cannot read at all counts as ours, and a read that
+    fails propagates rather than answering "not there": the caller treats
+    ``None`` as permission to post again.
+    """
+    resp = request(
+        "GET",
+        f"{api_base}/{media_id}/comments",
+        access_token=access_token,
+        params={"fields": "id,text,from", "limit": INSTAGRAM_RECONCILE_COMMENT_LIMIT},
+    )
+
+    for comment in resp.json().get("data", []):
+        author_id, author_handle = _comment_author(comment)
+        # Only skip on a *known* mismatch. An absent author is unreadable, not
+        # foreign, and Instagram omits ``from`` on third-party comments.
+        if (author_id or author_handle) and not _is_own_comment(author_id, author_handle, own_id, own_handle):
+            continue
+        if _comment_text(comment) == text:
+            return str(comment.get("id") or "")
+    return None
+
+
+def resolve_comment_reply_target(comment_id: str, extra: dict | None = None) -> tuple[str, str]:
+    """Return the ``(object_id, edge)`` a reply to this inbox item is posted to.
+
+    Three cases:
+
+    * A caption mention gives us only the media id, which has no ``replies``
+      edge — that one is answered by commenting on the media itself.
+    * A *reply* has no ``replies`` edge either. Instagram threads one level
+      deep, so a reply is answered on its parent comment's edge; posting to the
+      reply is rejected.
+    * A top-level comment is answered on its own ``replies`` edge.
+
+    A ``parent_id`` naming the media or the comment itself is not a parent
+    comment — targeting it would publish a new top-level comment instead of a
+    threaded reply — so it is ignored.
+    """
+    extra = extra or {}
+    if extra.get("reply_edge") == "media":
+        return str(comment_id), "comments"
+
+    parent_id = str(extra.get("parent_id") or "")
+    not_a_parent = {
+        str(comment_id),
+        str(extra.get("post_id") or ""),
+        str(extra.get("stored_post_id") or ""),
+        "",
+    }
+    if parent_id not in not_a_parent:
+        return parent_id, "replies"
+    return str(comment_id), "replies"
+
+
+def fetch_instagram_comments(
+    request,
+    *,
+    platform: str,
+    host: str,
+    media_url: str,
+    access_token: str,
+    since: datetime | None = None,
+    owner_id: str = "",
+    owner_handle: str = "",
+) -> list[InboxMessage]:
+    """Poll comments on the account's recent media.
+
+    The ``comments`` webhook delivers these in near real time, but only when the
+    subscription *and* the app's Webhooks config are both in place. An account
+    missing either is otherwise deaf to comments forever, with no way to
+    backfill — this poll is what makes that recoverable.
+    """
+    # Without an owner the own-comment filter below cannot recognise our own
+    # activity, which would ingest every first comment we post as an inbound
+    # customer message. Refuse to poll rather than do that.
+    if not owner_id and not owner_handle:
+        logger.warning("Skipping %s comment poll: no owner id or handle in credentials", platform)
+        return []
+
+    # ``since`` on the /media edge filters by MEDIA timestamp, not comment time
+    # — the same trap as Facebook's /feed. It can only bound how far back we
+    # look for *media*; passing the caller's ``since`` here would hide every new
+    # comment on an older post. Comments are filtered on their own timestamp.
+    media_floor = datetime.now(UTC) - timedelta(days=INSTAGRAM_MEDIA_WINDOW_DAYS)
+    media_items = _fetch_media(request, platform, media_url, access_token, media_floor)
+
+    # Normalize once here so the per-comment compare can never mix an aware
+    # Graph timestamp with a naive caller-supplied ``since``.
+    cutoff = None
+    if since:
+        cutoff = (since if since.tzinfo else since.replace(tzinfo=UTC)) - timedelta(
+            hours=INSTAGRAM_COMMENT_LOOKBACK_HOURS
+        )
+
+    messages: list[InboxMessage] = []
+    seen: set[str] = set()
+
+    for media in media_items:
+        # One unreadable or over-paginated media item must not discard the
+        # comments already collected from every earlier item in this poll.
+        try:
+            comments = media.get("comments") or {}
+            for comment in _iter_comments(request, host, access_token, comments):
+                messages.extend(_comment_to_messages(comment, media, owner_id, owner_handle, cutoff, seen))
+        except Exception as exc:
+            logger.warning("Skipping %s comments for media %s: %s", platform, media.get("id"), exc)
+
+    logger.debug("%s comment poll produced %d message(s)", platform, len(messages))
+    return messages
+
+
+def _fetch_media(request, platform: str, media_url: str, access_token: str, media_floor: datetime) -> list[dict]:
+    """Read recent media with their comments expanded, degrading the field set.
+
+    Only a 400 earns a shorter field set: an auth failure, a 5xx or a rate limit
+    fails identically however few fields are asked for, so a second request is
+    doomed and only costs quota.
+    """
+    last_error: Exception | None = None
+
+    for fields in INSTAGRAM_COMMENT_FIELD_SETS:
+        try:
+            resp = request(
+                "GET",
+                media_url,
+                access_token=access_token,
+                params={
+                    "fields": (f"id,timestamp,permalink,comments.limit({INSTAGRAM_COMMENTS_PER_MEDIA}){{{fields}}}"),
+                    "limit": INSTAGRAM_MEDIA_SCAN_LIMIT,
+                    "since": int(media_floor.timestamp()),
+                },
+            )
+        except Exception as exc:
+            if getattr(exc, "status_code", None) != 400:
+                raise
+            last_error = exc
+            logger.info("%s rejected the comment field set; retrying with fewer fields", platform)
+            continue
+        return resp.json().get("data", [])
+
+    # The field-set tuple is never empty, so a fall-through means every set was
+    # rejected with a 400 and last_error is set.
+    raise last_error  # type: ignore[misc]
+
+
+def _iter_comments(request, host: str, access_token: str, comments: dict):
+    """Yield a media item's comments, following at most a bounded number of pages."""
+    pages = 0
+    while comments:
+        yield from comments.get("data", [])
+
+        next_url = (comments.get("paging") or {}).get("next")
+        pages += 1
+        if not next_url or pages >= INSTAGRAM_COMMENT_PAGE_LIMIT:
+            if next_url:
+                logger.debug("Instagram comment pagination capped at %d pages", INSTAGRAM_COMMENT_PAGE_LIMIT)
+            return
+        # Pin the cursor to the provider's own host — this is a URL from a
+        # response body. And re-send the token: ``_request`` authenticates with
+        # an Authorization header, so Graph builds ``paging.next`` from a query
+        # string that never contained one.
+        if urlparse(next_url).netloc != urlparse(host).netloc:
+            logger.warning("Ignoring off-host Instagram comment paging URL")
+            return
+        comments = request("GET", next_url, access_token=access_token).json()
+
+
+def _comment_to_messages(
+    comment: dict,
+    media: dict,
+    owner_id: str,
+    owner_handle: str,
+    cutoff: datetime | None,
+    seen: set[str],
+) -> list[InboxMessage]:
+    """Convert one comment and its replies to inbox messages."""
+    messages = []
+    top = _to_message(comment, media, owner_id, owner_handle, cutoff, seen, parent_id="")
+    if top is not None:
+        messages.append(top)
+
+    # A skipped parent does not skip its replies: a customer answering our own
+    # first comment is exactly the message we must not lose.
+    for reply in (comment.get("replies") or {}).get("data", []):
+        message = _to_message(
+            reply,
+            media,
+            owner_id,
+            owner_handle,
+            cutoff,
+            seen,
+            parent_id=str(comment.get("id") or ""),
+        )
+        if message is not None:
+            messages.append(message)
+    return messages
+
+
+def _to_message(
+    comment: dict,
+    media: dict,
+    owner_id: str,
+    owner_handle: str,
+    cutoff: datetime | None,
+    seen: set[str],
+    *,
+    parent_id: str,
+) -> InboxMessage | None:
+    """Convert one comment to an InboxMessage, or None to skip it."""
+    comment_id = str(comment.get("id") or "")
+    if not comment_id or comment_id in seen:
+        return None
+
+    author_id, author_handle = _comment_author(comment)
+    if _is_own_comment(author_id, author_handle, owner_id, owner_handle):
+        return None
+
+    timestamp = parse_graph_time(comment.get("timestamp"))
+    if timestamp is None:
+        logger.debug("Skipping Instagram comment %s with unparseable timestamp", comment_id)
+        return None
+    if cutoff and timestamp < cutoff:
+        return None
+
+    seen.add(comment_id)
+    media_id = str(media.get("id") or "")
+    return InboxMessage(
+        platform_message_id=comment_id,
+        sender_id=author_id,
+        sender_name=author_handle or "Instagram user",
+        text=_comment_text(comment),
+        timestamp=timestamp,
+        message_type="comment",
+        extra={
+            "comment_id": comment_id,
+            # Instagram media ids carry no page prefix to strip, so
+            # PlatformPost.platform_post_id matches this value directly and the
+            # two keys the inbox tries are the same id.
+            "post_id": media_id,
+            "stored_post_id": media_id,
+            "parent_id": parent_id,
+            "post_permalink_url": media.get("permalink", ""),
+            # The platform user id, matching what the webhook path stores and
+            # what FacebookProvider's poll emits. Re-polling a comment the
+            # webhook already stored must not rewrite this column.
+            "sender_handle": author_id or author_handle,
+            "reply_edge": "comment",
+            "source": "poll",
+        },
+    )

--- a/providers/threads.py
+++ b/providers/threads.py
@@ -279,7 +279,10 @@ class ThreadsProvider(SocialProvider):
 
         if not creation_id:
             raise PublishError(
-                f"Threads container creation failed: {create_body}",
+                # The body goes in raw_response, not the message: publish_error
+                # is rendered to users, and a ProviderError message is the one
+                # thing the sanitizer passes through verbatim.
+                "Threads container creation failed",
                 platform=self.platform_name,
                 raw_response=create_body,
             )
@@ -373,7 +376,7 @@ class ThreadsProvider(SocialProvider):
             item_id = item_body.get("id")
             if not item_id:
                 raise PublishError(
-                    f"Threads carousel item creation failed: {item_body}",
+                    "Threads carousel item creation failed",
                     platform=self.platform_name,
                     raw_response=item_body,
                 )
@@ -398,7 +401,7 @@ class ThreadsProvider(SocialProvider):
         creation_id = carousel_body.get("id")
         if not creation_id:
             raise PublishError(
-                f"Threads carousel container creation failed: {carousel_body}",
+                "Threads carousel container creation failed",
                 platform=self.platform_name,
                 raw_response=carousel_body,
             )

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,11 @@ mypy>=1.11,<1.20
 django-stubs>=5.0,<6.0
 types-python-dateutil>=2.9,<3.0
 pytest>=8.3,<9.0
-pytest-django>=4.8,<5.0
+# Capped below 4.13: it errors every class-based test that uses the ``db``
+# fixture with "type object 'PytestDjangoTestCase' has no attribute
+# '_pre_setup_ran_eagerly'" — 509 of ours. CI resolves the newest match, so
+# every run since 2026-08-07 failed on this while local envs on 4.12 passed.
+pytest-django>=4.8,<4.13
 pytest-cov>=5.0,<6.0
 factory-boy>=3.3,<4.0
 

--- a/templates/composer/compose.html
+++ b/templates/composer/compose.html
@@ -389,7 +389,7 @@
                     {% for pp in failed_first_comments %}
                     <p class="text-xs text-amber-700 pl-5.5">
                         <span class="font-semibold">{{ pp.social_account.account_name|default:pp.social_account.account_handle }}:</span>
-                        {{ pp.first_comment_error|default:"the platform rejected the comment" }}
+                        {{ pp.first_comment_error|default:"The first comment couldn't be added. Add it manually on the post." }}
                     </p>
                     {% endfor %}
                     <p class="text-[11px] text-amber-600 pl-5.5">The post itself published successfully — only the comment failed.</p>

--- a/tests/providers/test_instagram.py
+++ b/tests/providers/test_instagram.py
@@ -1,9 +1,12 @@
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, call
 
+import pytest
+
 from providers.exceptions import APIError
 from providers.instagram import InstagramProvider
 from providers.instagram_login import InstagramLoginProvider
+from providers.meta_comments import INSTAGRAM_COMMENT_FIELD_SETS
 
 
 def _resp(data):
@@ -314,3 +317,594 @@ def test_account_metrics_followers_none_when_profile_fetch_fails():
 
     assert metrics.followers is None
     assert metrics.reach == 12
+
+
+# ----------------------------------------------------------------------
+# First comment
+# ----------------------------------------------------------------------
+
+IG_CREDS = {"client_id": "id", "client_secret": "secret", "ig_user_id": "ig-1", "account_handle": "pinklion.xyz"}
+IG_LOGIN_CREDS = {"client_id": "id", "client_secret": "secret", "ig_user_id": "ig-1", "account_handle": "pinklion.xyz"}
+
+# (provider factory, host, media edge) — the comment surface is identical on
+# both connections and differs only in where it lives.
+IG_PROVIDERS = [
+    pytest.param(
+        lambda: InstagramProvider(IG_CREDS),
+        "https://graph.facebook.com/v25.0",
+        "https://graph.facebook.com/v25.0/ig-1/media",
+        id="facebook-login",
+    ),
+    pytest.param(
+        lambda: InstagramLoginProvider(IG_LOGIN_CREDS),
+        "https://graph.instagram.com/v25.0",
+        "https://graph.instagram.com/v25.0/me/media",
+        id="instagram-login",
+    ),
+]
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_publish_comment_sends_no_fields_param(make_provider, host, media_url):
+    """Meta creates the comment and *then* rejects a ``fields`` param on this
+    edge (code 20 / subcode 1772107). The 400 reads as a clean rejection, the
+    retry queue re-sends it, and the account collects one comment per attempt.
+    """
+    provider = make_provider()
+    provider._request = MagicMock(return_value=_resp({"id": "comment-1"}))
+
+    result = provider.publish_comment("token", "media-1", "First!")
+
+    assert result.platform_comment_id == "comment-1"
+    provider._request.assert_called_once_with(
+        "POST",
+        f"{host}/media-1/comments",
+        access_token="token",
+        json={"message": "First!"},
+    )
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_find_own_comment_matches_the_accounts_own_comment_by_text(make_provider, host, media_url):
+    provider = make_provider()
+    provider._request = MagicMock(
+        return_value=_resp(
+            {
+                "data": [
+                    {"id": "c-1", "text": "Someone else", "from": {"id": "ig-2"}},
+                    {"id": "c-2", "text": "First!", "from": {"id": "ig-1"}},
+                ]
+            }
+        )
+    )
+
+    assert provider.find_own_comment("token", "media-1", "First!") == "c-2"
+    provider._request.assert_called_once_with(
+        "GET",
+        f"{host}/media-1/comments",
+        access_token="token",
+        params={"fields": "id,text,from", "limit": 50},
+    )
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_find_own_comment_ignores_the_same_text_from_someone_else(make_provider, host, media_url):
+    provider = make_provider()
+    provider._request = MagicMock(
+        return_value=_resp({"data": [{"id": "c-1", "text": "First!", "from": {"id": "ig-999"}}]})
+    )
+
+    assert provider.find_own_comment("token", "media-1", "First!") is None
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_find_own_comment_keeps_a_comment_whose_author_is_unreadable(make_provider, host, media_url):
+    """Instagram omits ``from`` on third-party comments in some permission
+    combinations. Erring toward "ours" costs one skipped comment; erring the
+    other way posts a duplicate on a live account, which cannot be taken back.
+    """
+    provider = make_provider()
+    provider._request = MagicMock(return_value=_resp({"data": [{"id": "c-1", "text": "First!"}]}))
+
+    assert provider.find_own_comment("token", "media-1", "First!") == "c-1"
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_find_own_comment_matches_on_handle_when_the_author_id_is_missing(make_provider, host, media_url):
+    provider = make_provider()
+    provider._request = MagicMock(
+        return_value=_resp({"data": [{"id": "c-1", "text": "First!", "from": {"username": "PinkLion.xyz"}}]})
+    )
+
+    assert provider.find_own_comment("token", "media-1", "First!") == "c-1"
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_find_own_comment_returns_none_when_nothing_matches(make_provider, host, media_url):
+    provider = make_provider()
+    provider._request = MagicMock(
+        return_value=_resp({"data": [{"id": "c-1", "text": "Other", "from": {"id": "ig-1"}}]})
+    )
+
+    assert provider.find_own_comment("token", "media-1", "First!") is None
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_find_own_comment_raises_when_the_comments_edge_cannot_be_read(make_provider, host, media_url):
+    """ "Unknown" is not "not there": returning None here would tell the caller
+    it is safe to post again."""
+    provider = make_provider()
+    provider._request = MagicMock(side_effect=APIError("boom", status_code=500, platform="Instagram"))
+
+    with pytest.raises(APIError):
+        provider.find_own_comment("token", "media-1", "First!")
+
+
+# ----------------------------------------------------------------------
+# Comment polling
+# ----------------------------------------------------------------------
+
+
+def _poll_comments(provider, since=None):
+    """Run just the comment half, whichever connection this is.
+
+    ``InstagramLoginProvider.get_messages`` also polls DMs, which would consume
+    the same ``_request`` mock and shift every call index below.
+    """
+    if isinstance(provider, InstagramLoginProvider):
+        return provider._fetch_media_comments("token", since)
+    return provider.get_messages("token", since=since)
+
+
+def _media(comments=None, media_id="media-1", **extra):
+    item = {"id": media_id, "timestamp": "2026-08-07T09:00:00+0000", "permalink": "https://instagr.am/p/abc/"}
+    item.update(extra)
+    if comments is not None:
+        item["comments"] = comments
+    return item
+
+
+def _ig_comment(comment_id="c-1", text="Nice one", author_id="ig-2", username="curious", **extra):
+    comment = {"id": comment_id, "text": text, "timestamp": "2026-08-07T10:00:00+0000", "username": username}
+    if author_id:
+        comment["from"] = {"id": author_id, "username": username}
+    comment.update(extra)
+    return comment
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_comment_poll_does_not_pass_the_callers_since_to_the_media_edge(make_provider, host, media_url):
+    """``since`` on /media filters by MEDIA timestamp, so passing the caller's
+    value would hide every new comment on an older post."""
+    provider = make_provider()
+    provider._request = MagicMock(return_value=_resp({"data": [_media({"data": [_ig_comment()]})]}))
+
+    since = datetime(2026, 8, 7, 9, 30, tzinfo=UTC)
+    messages = _poll_comments(provider, since)
+
+    assert [m.platform_message_id for m in messages] == ["c-1"]
+    args, kwargs = provider._request.call_args
+    assert args[1] == media_url
+    assert kwargs["params"]["since"] != int(since.timestamp())
+    assert "replies" in kwargs["params"]["fields"]
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_comment_poll_keeps_comments_older_than_since_within_the_lookback(make_provider, host, media_url):
+    """The inbox passes the newest received_at across all message types, so a
+    DM would otherwise hide every comment that arrived just before it."""
+    provider = make_provider()
+    provider._request = MagicMock(return_value=_resp({"data": [_media({"data": [_ig_comment()]})]}))
+
+    # 6h after the comment — inside the 24h overlap.
+    messages = _poll_comments(provider, datetime(2026, 8, 7, 16, 0, tzinfo=UTC))
+
+    assert [m.platform_message_id for m in messages] == ["c-1"]
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_comment_poll_drops_comments_older_than_the_lookback(make_provider, host, media_url):
+    provider = make_provider()
+    provider._request = MagicMock(return_value=_resp({"data": [_media({"data": [_ig_comment()]})]}))
+
+    messages = _poll_comments(provider, datetime(2026, 8, 9, 12, 0, tzinfo=UTC))
+
+    assert messages == []
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_comment_poll_accepts_a_naive_since(make_provider, host, media_url):
+    """A naive cutoff compared against an aware Graph timestamp is a TypeError."""
+    provider = make_provider()
+    provider._request = MagicMock(return_value=_resp({"data": [_media({"data": [_ig_comment()]})]}))
+
+    messages = _poll_comments(provider, datetime(2026, 8, 7, 16, 0))  # noqa: DTZ001
+
+    assert [m.platform_message_id for m in messages] == ["c-1"]
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_comment_poll_excludes_the_accounts_own_comments_by_id(make_provider, host, media_url):
+    """Our own first comment must not come back as an inbound customer message."""
+    provider = make_provider()
+    provider._request = MagicMock(
+        return_value=_resp(
+            {
+                "data": [
+                    _media(
+                        {
+                            "data": [
+                                _ig_comment("c-ours", "First!", author_id="ig-1", username="pinklion.xyz"),
+                                _ig_comment("c-theirs"),
+                            ]
+                        }
+                    )
+                ]
+            }
+        )
+    )
+
+    messages = _poll_comments(provider)
+
+    assert [m.platform_message_id for m in messages] == ["c-theirs"]
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_comment_poll_excludes_own_comments_by_username_when_from_is_withheld(make_provider, host, media_url):
+    provider = make_provider()
+    provider._request = MagicMock(
+        return_value=_resp(
+            {
+                "data": [
+                    _media(
+                        {
+                            "data": [
+                                _ig_comment("c-ours", "First!", author_id=None, username="PinkLion.xyz"),
+                                _ig_comment("c-theirs", author_id=None, username="curious"),
+                            ]
+                        }
+                    )
+                ]
+            }
+        )
+    )
+
+    messages = _poll_comments(provider)
+
+    assert [m.platform_message_id for m in messages] == ["c-theirs"]
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_comment_poll_carries_the_media_id_the_inbox_links_on(make_provider, host, media_url):
+    """PlatformPost stores the IG media id unprefixed, so both keys the inbox
+    tries are that same id."""
+    provider = make_provider()
+    provider._request = MagicMock(return_value=_resp({"data": [_media({"data": [_ig_comment()]})]}))
+
+    (message,) = _poll_comments(provider)
+
+    assert message.extra["post_id"] == "media-1"
+    assert message.extra["stored_post_id"] == "media-1"
+    assert message.extra["reply_edge"] == "comment"
+    assert message.extra["source"] == "poll"
+    assert message.message_type == "comment"
+    assert message.timestamp.tzinfo is not None
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_comment_poll_ingests_replies_and_records_their_parent(make_provider, host, media_url):
+    """A customer answering our own first comment is exactly the message we
+    must not lose, so a skipped parent does not skip its replies."""
+    provider = make_provider()
+    provider._request = MagicMock(
+        return_value=_resp(
+            {
+                "data": [
+                    _media(
+                        {
+                            "data": [
+                                _ig_comment(
+                                    "c-ours",
+                                    "First!",
+                                    author_id="ig-1",
+                                    username="pinklion.xyz",
+                                    replies={"data": [_ig_comment("r-1", "Answering you")]},
+                                )
+                            ]
+                        }
+                    )
+                ]
+            }
+        )
+    )
+
+    (message,) = _poll_comments(provider)
+
+    assert message.platform_message_id == "r-1"
+    assert message.extra["parent_id"] == "c-ours"
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_comment_poll_follows_paging_up_to_the_cap(make_provider, host, media_url):
+    provider = make_provider()
+    page = {"data": [_ig_comment("c-1")], "paging": {"next": f"{host}/media-1/comments?after=x"}}
+    provider._request = MagicMock(
+        side_effect=[
+            _resp({"data": [_media(page)]}),
+            _resp({"data": [_ig_comment("c-2")], "paging": {"next": f"{host}/media-1/comments?after=y"}}),
+            _resp({"data": [_ig_comment("c-3")], "paging": {"next": f"{host}/media-1/comments?after=z"}}),
+            _resp({"data": [_ig_comment("c-4")], "paging": {"next": f"{host}/media-1/comments?after=w"}}),
+        ]
+    )
+
+    messages = _poll_comments(provider)
+
+    assert [m.platform_message_id for m in messages] == ["c-1", "c-2", "c-3", "c-4"]
+    # The token is re-sent on every cursor: _request authenticates with a
+    # header, so Graph builds paging.next from a query string that has none.
+    for paged_call in provider._request.call_args_list[1:]:
+        assert paged_call.kwargs["access_token"] == "token"
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_comment_poll_ignores_an_off_host_paging_url(make_provider, host, media_url):
+    provider = make_provider()
+    page = {"data": [_ig_comment("c-1")], "paging": {"next": "https://evil.example.com/steal"}}
+    provider._request = MagicMock(return_value=_resp({"data": [_media(page)]}))
+
+    messages = _poll_comments(provider)
+
+    assert [m.platform_message_id for m in messages] == ["c-1"]
+    provider._request.assert_called_once()
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_comment_poll_skips_a_comment_with_an_unparseable_timestamp(make_provider, host, media_url):
+    provider = make_provider()
+    provider._request = MagicMock(
+        return_value=_resp(
+            {"data": [_media({"data": [_ig_comment("c-1", timestamp="not a date"), _ig_comment("c-2")]})]}
+        )
+    )
+
+    messages = _poll_comments(provider)
+
+    assert [m.platform_message_id for m in messages] == ["c-2"]
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_comment_poll_keeps_earlier_media_when_a_later_one_fails(make_provider, host, media_url):
+    provider = make_provider()
+    broken = _media({"data": [_ig_comment("c-2")], "paging": {"next": f"{host}/media-2/comments?after=x"}}, "media-2")
+    provider._request = MagicMock(
+        side_effect=[
+            _resp({"data": [_media({"data": [_ig_comment("c-1")]}), broken]}),
+            APIError("boom", status_code=500, platform="Instagram"),
+        ]
+    )
+
+    messages = _poll_comments(provider)
+
+    assert [m.platform_message_id for m in messages] == ["c-1", "c-2"]
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_comment_poll_degrades_the_field_set_when_graph_rejects_it(make_provider, host, media_url):
+    """Graph fails the whole call on one unknown or unpermitted field."""
+    provider = make_provider()
+    provider._request = MagicMock(
+        side_effect=[
+            APIError("(#100) unknown field replies", status_code=400, platform="Instagram"),
+            _resp({"data": [_media({"data": [_ig_comment()]})]}),
+        ]
+    )
+
+    messages = _poll_comments(provider)
+
+    assert [m.platform_message_id for m in messages] == ["c-1"]
+    assert "replies" in provider._request.call_args_list[0].kwargs["params"]["fields"]
+    assert "replies" not in provider._request.call_args_list[1].kwargs["params"]["fields"]
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_comment_poll_does_not_degrade_after_a_server_error(make_provider, host, media_url):
+    """A 5xx fails identically however few fields are asked for."""
+    provider = make_provider()
+    provider._request = MagicMock(side_effect=APIError("boom", status_code=500, platform="Instagram"))
+
+    with pytest.raises(APIError):
+        _poll_comments(provider)
+
+    provider._request.assert_called_once()
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_comment_poll_raises_when_every_field_set_is_rejected(make_provider, host, media_url):
+    provider = make_provider()
+    provider._request = MagicMock(side_effect=APIError("(#100) nope", status_code=400, platform="Instagram"))
+
+    with pytest.raises(APIError):
+        _poll_comments(provider)
+
+    assert provider._request.call_count == len(INSTAGRAM_COMMENT_FIELD_SETS)
+
+
+def test_comment_poll_refuses_to_run_without_an_owner():
+    """Without an owner the own-comment filter cannot recognise our own
+    activity, and every first comment we post would be ingested as inbound."""
+    provider = InstagramProvider({"client_id": "id", "client_secret": "secret"})
+    provider._request = MagicMock()
+
+    assert provider.get_messages("token") == []
+    provider._request.assert_not_called()
+
+
+def test_instagram_login_returns_dms_even_when_the_comment_poll_fails():
+    provider = InstagramLoginProvider(IG_LOGIN_CREDS)
+    provider._fetch_direct_messages = MagicMock(return_value=["a dm"])
+    provider._fetch_media_comments = MagicMock(side_effect=APIError("nope", status_code=403, platform="Instagram"))
+
+    assert provider.get_messages("token") == ["a dm"]
+
+
+def test_instagram_login_get_messages_raises_when_both_halves_fail():
+    provider = InstagramLoginProvider(IG_LOGIN_CREDS)
+    provider._fetch_direct_messages = MagicMock(side_effect=APIError("dm", status_code=403, platform="Instagram"))
+    provider._fetch_media_comments = MagicMock(side_effect=APIError("comment", status_code=403, platform="Instagram"))
+
+    with pytest.raises(APIError, match="dm"):
+        provider.get_messages("token")
+
+
+# ----------------------------------------------------------------------
+# Reply targeting
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_a_reply_is_answered_on_its_parent_comment(make_provider, host, media_url):
+    """A reply has no ``replies`` edge of its own — Instagram threads one level
+    deep, and posting to the reply is rejected."""
+    provider = make_provider()
+    provider._request = MagicMock(return_value=_resp({"id": "r-2"}))
+
+    provider.reply_to_comment("token", "r-1", "Thanks!", extra={"parent_id": "c-1", "reply_edge": "comment"})
+
+    assert provider._request.call_args.args[1] == f"{host}/c-1/replies"
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_a_parent_id_naming_the_media_is_ignored(make_provider, host, media_url):
+    """Targeting the media would publish a new top-level comment instead of a
+    threaded reply."""
+    provider = make_provider()
+    provider._request = MagicMock(return_value=_resp({"id": "r-2"}))
+
+    provider.reply_to_comment(
+        "token",
+        "c-1",
+        "Thanks!",
+        extra={"parent_id": "media-1", "post_id": "media-1", "reply_edge": "comment"},
+    )
+
+    assert provider._request.call_args.args[1] == f"{host}/c-1/replies"
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_a_caption_mention_is_answered_on_the_media(make_provider, host, media_url):
+    provider = make_provider()
+    provider._request = MagicMock(return_value=_resp({"id": "c-9"}))
+
+    provider.reply_to_comment("token", "media-1", "Thanks!", extra={"reply_edge": "media"})
+
+    assert provider._request.call_args.args[1] == f"{host}/media-1/comments"
+
+
+# ----------------------------------------------------------------------
+# Webhook subscription
+# ----------------------------------------------------------------------
+
+# The Page object's own field list, quoted from Meta's rejection of the old
+# call: "(#100) Param subscribed_fields[0] must be one of {feed, mention, ...}".
+PAGE_ONLY_WEBHOOK_FIELDS = {"feed", "mention", "name", "picture", "category", "conversations", "standby"}
+
+
+def test_subscribing_targets_the_instagram_user_with_instagram_fields():
+    """comments/mentions belong to Meta's Instagram object, not to a Page.
+
+    Sending them to a Page is rejected outright, which is what left every
+    Instagram inbox deaf to comments. Posting Page fields from here would be
+    just as wrong: subscribed_apps replaces a field list rather than merging,
+    so it would silently drop a co-connected Facebook Page's mention and
+    message subscriptions.
+    """
+    provider = InstagramProvider(IG_CREDS)
+    provider._request = MagicMock(return_value=_resp({"success": True}))
+
+    assert provider.subscribe_webhooks("token", "ig-1") is True
+
+    args, kwargs = provider._request.call_args
+    assert args[1] == "https://graph.facebook.com/v25.0/ig-1/subscribed_apps"
+    sent = set(kwargs["params"]["subscribed_fields"].split(","))
+    assert sent == {"comments", "mentions"}
+    assert not sent & PAGE_ONLY_WEBHOOK_FIELDS
+
+
+def test_instagram_never_subscribes_to_messages():
+    """This OAuth flow never requests instagram_manage_messages, so Meta would
+    reject the subscription outright."""
+    from providers.instagram import INSTAGRAM_WEBHOOK_FIELDS
+
+    assert "messages" not in INSTAGRAM_WEBHOOK_FIELDS
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_comment_poll_reports_the_author_id_as_the_handle(make_provider, host, media_url):
+    """The webhook path stores the platform user ID in sender_handle, and
+    _upsert_message rewrites that column on every re-poll — emitting the
+    username here would silently overwrite the IGSID a few minutes later."""
+    provider = make_provider()
+    provider._request = MagicMock(return_value=_resp({"data": [_media({"data": [_ig_comment()]})]}))
+
+    (message,) = _poll_comments(provider)
+
+    assert message.extra["sender_handle"] == "ig-2"
+    assert message.sender_id == "ig-2"
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_comment_poll_keeps_the_username_as_instagram_spelled_it(make_provider, host, media_url):
+    """Case-folding is for comparison only; it must not reach a display field."""
+    provider = make_provider()
+    provider._request = MagicMock(
+        return_value=_resp({"data": [_media({"data": [_ig_comment(username="LenaSorensen")]})]})
+    )
+
+    (message,) = _poll_comments(provider)
+
+    assert message.sender_name == "LenaSorensen"
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_comment_poll_keeps_replies_when_only_the_author_field_is_rejected(make_provider, host, media_url):
+    """Dropping ``from`` and ``replies`` together would lose every reply on an
+    account that could read replies perfectly well — including a customer
+    answering our own first comment."""
+    provider = make_provider()
+    reply = _ig_comment("r-1", "Answering you", author_id=None, username="curious")
+    parent = _ig_comment("c-1", "First!", author_id=None, username="pinklion.xyz", replies={"data": [reply]})
+    provider._request = MagicMock(
+        side_effect=[
+            APIError("(#100) unknown field from", status_code=400, platform="Instagram"),
+            APIError("(#100) unknown field from", status_code=400, platform="Instagram"),
+            _resp({"data": [_media({"data": [parent]})]}),
+        ]
+    )
+
+    messages = _poll_comments(provider)
+
+    # The parent is ours and skipped; its reply is not, and must survive.
+    assert [m.platform_message_id for m in messages] == ["r-1"]
+    sent = [c.kwargs["params"]["fields"] for c in provider._request.call_args_list]
+    assert "replies" in sent[2]
+    assert "from{" not in sent[2]
+
+
+@pytest.mark.parametrize(("make_provider", "host", "media_url"), IG_PROVIDERS)
+def test_comment_poll_keeps_the_author_when_only_replies_are_rejected(make_provider, host, media_url):
+    """``from`` carries the author id the own-comment filter prefers, so it is
+    given up last."""
+    provider = make_provider()
+    provider._request = MagicMock(
+        side_effect=[
+            APIError("(#100) unknown field replies", status_code=400, platform="Instagram"),
+            _resp({"data": [_media({"data": [_ig_comment()]})]}),
+        ]
+    )
+
+    (message,) = _poll_comments(provider)
+
+    assert message.sender_id == "ig-2"
+    sent = provider._request.call_args_list[1].kwargs["params"]["fields"]
+    assert "from{" in sent
+    assert "replies" not in sent

--- a/tests/providers/test_meta_replies.py
+++ b/tests/providers/test_meta_replies.py
@@ -146,13 +146,12 @@ def test_facebook_dm_reply_refuses_without_a_recipient():
 def test_instagram_via_facebook_offers_no_dm_surface():
     """That OAuth flow never requests instagram_manage_messages.
 
-    Leaving the methods in place would produce runtime API rejections instead
-    of a clear "this connection cannot do DMs".
+    Leaving the method in place would produce runtime API rejections instead of
+    a clear "this connection cannot do DMs". ``get_messages`` is not part of
+    this: it polls comments, which the connection *can* read.
     """
     provider = InstagramProvider({**CREDS, "ig_user_id": "ig-1"})
 
-    with pytest.raises(NotImplementedError):
-        provider.get_messages("token")
     with pytest.raises(NotImplementedError):
         provider.reply_to_message("token", "mid.in", "Hi", extra={"sender_id": "igsid-2"})
 
@@ -427,6 +426,11 @@ def test_instagram_login_polling_skips_the_accounts_own_replies():
         )
     )
 
+    # get_messages polls DMs and comments; this test is about the DM half, and
+    # the shared _request mock would otherwise feed the conversations payload to
+    # the comment half too.
+    provider._fetch_media_comments = MagicMock(return_value=[])
+
     messages = provider.get_messages("token")
 
     assert [m.platform_message_id for m in messages] == ["mid.customer"]
@@ -456,5 +460,6 @@ def test_instagram_login_without_its_own_id_keeps_every_message():
             }
         )
     )
+    provider._fetch_media_comments = MagicMock(return_value=[])
 
     assert len(provider.get_messages("token")) == 1


### PR DESCRIPTION
Publishing a post to Instagram with a first comment surfaced three defects at once: the comment posted **four times**, the composer showed the raw Graph payload, and a reply left on the post never reached the social inbox.

<img width="600" alt="Four identical first comments on the test post" src="https://github.com/user-attachments/assets/placeholder" />

## 1. The first comment posted four times

`InstagramProvider.publish_comment` was the only provider passing `params={"fields": "id"}` on the comment POST. Meta creates the comment and *then* rejects the response format:

```
code 20 / subcode 1772107 — "This API call does not support the requested response format"
```

So the call reads as a clean 400, the retry queue re-sends it, and the account collects one comment per attempt: `1 + FIRST_COMMENT_MAX_RETRIES = 4`, spaced by the `[120, 600, 1800]` backoff — matching the reported timings exactly.

Three layers now, any one of which caps it at one:

1. The `fields` param is gone.
2. `find_own_comment` is implemented for both Instagram providers. The engine already called it before every retry; Instagram inherited a stub that raised, got swallowed to `None`, and reposted blind.
3. A clean 4xx is no longer retried at all — 401 excepted, since `_provider_and_access_token` refreshes an expiring token between attempts so the next request genuinely differs. 403 stays terminal (missing scope / revoked grant needs a reconnect, not a backoff).

Also closes a stuck-PENDING hole: a failed reconciliation used to `return` silently, leaving a row with no task behind it that rendered as fully successful forever.

## 2. Comments never reached the inbox

Instagram had **no polling at all** — `InstagramProvider` had no `get_messages`, so `InboxSyncEngine` skipped the account entirely and comments depended solely on a webhook. That webhook has never worked: `subscribe_webhooks` sent Instagram-object fields to a **Page**, which Meta rejects:

```
(#100) Param subscribed_fields[0] must be one of {feed, mention, name, picture, ... messages, ...}
```

Every connected account carried `webhooks_active=False`.

**The Page was the wrong object, not just the wrong fields.** Three independent reasons:

- `comments`/`mentions` belong to Meta's Instagram object; the Page's field list has neither.
- `POST /{page-id}/subscribed_apps` requires `pages_manage_metadata`, which the Instagram OAuth flow never requests (Facebook's does). Even with valid Page fields it would have failed on permissions.
- `subscribed_apps` **replaces** a field list rather than merging. Writing the Page from the Instagram connector would silently drop `mention` and `messages` from a Facebook Page connected in the same workspace — `_webhook_target_is_shared` filters by `platform`, so it wouldn't catch the collision.

Instagram now subscribes on the **IG user**, which the `instagram_*` scopes already cover. `_webhook_target` collapses to `account_platform_id` for every platform as a result — Instagram was its only non-trivial caller, so this simplified the shared-subscription check rather than adding a special case.

Alongside that, mirroring the Facebook fix from a9df9c2:

- **A comment poller**, so a broken or absent subscription is recoverable and the existing backlog gets picked up. Same hard-won details: don't pass `since` to the media edge (it filters by *media* timestamp), bounded pagination that re-sends the token and rejects off-host cursors, per-media isolation, and a field-set ladder that degrades `from` and `replies` one axis at a time so a rejection of one doesn't lose the other.
- **`related_post` now links.** The Instagram webhook nests the media id under `value["media"]["id"]` where a Page sends a flat `post_id`, so every Instagram comment stored a NULL `related_post` despite `PlatformPost` holding that exact id.
- **Replies answer on their parent's edge.** Instagram threads one level deep and rejects a reply posted to the reply itself.

> [!IMPORTANT]
> The other half is not code. `comments`/`mentions` must also be subscribed on the **Instagram** object in the Meta App Dashboard — no API call can set that. Added to the README next to the Page step it was missing from.
>
> After deploy, re-run the subscription for the accounts that failed:
> ```
> python manage.py subscribe_webhooks --platform instagram --retry-failed
> ```

## 3. Raw provider errors reached the UI

`first_comment_error` and `publish_error` now store user-facing text; the raw body goes to the log and (for publishes) the `PublishLog` row that was already being written.

Only `PublishError` messages pass through — they're written for humans and often the most useful thing available ("TikTok only supports VIDEO posts", "Trim the video and try again"), so a blanket rewrite would lose real information. `APIError`/`RateLimitError` are built from `response.text` and always get replaced, as does `OAuthError` (`instagram_login` interpolates a token-exchange body into it).

Four providers that interpolated a response body into a `PublishError` now pass it as `raw_response` instead, with a length-and-payload-marker guard in the sanitizer as a backstop.

This also fixes a latent `TypeError: unhashable type: 'dict'` in the same module that fired on **every** Meta error (`raw_response["error"]` is a dict; hashing it against a set raised) and was escaping `run_health_check`.

## Also in here

- `FacebookProvider.find_own_comment` swallowed a 5xx on the comments read into `None`, which the engine reads as "safe to post" — the same duplicate-comment risk, on Facebook.
- A post whose retry budget is spent no longer tells the user "We'll retry shortly."

## Notes for review

- `publish_error` is exposed on the REST API (`apps/api/schemas.py`), so API consumers now receive friendly text. Raw remains in `PublishLog`.
- Historical FAILED rows keep their stored raw text — no data migration, by request.
- Known and accepted, matching what a9df9c2 accepted for Facebook: an account whose comment webhook worked and then stopped has `"comment"` in `seen_types`, so a large recovered backlog would notify rather than being suppressed.
- The Instagram `/media` edge's `since` semantics are not verified against a live account. If Graph rejects the param, the field-set ladder exhausts and the poll raises — degraded but safe, and the webhook path is unaffected.

## Testing

1375 tests pass; `ruff check` and `ruff format --check` clean. ~200 lines of new coverage, including exact-call assertions that pin the absence of the `fields` param on both Instagram connections, that the subscription targets the IG user and never sends Page-only fields, and that no stored error string contains `OAuthException` or `fbtrace_id`.

End-to-end verification on the live account (publish, comment from a second account, reply from the inbox) has **not** been run — it publishes to a real Instagram account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)