### PR TITLE
fix(analytics): stop hiding accounts the page can't serve

### DIFF
--- a/apps/analytics/constants.py
+++ b/apps/analytics/constants.py
@@ -6,11 +6,19 @@ from __future__ import annotations
 # page renders a per-platform "not available" variant instead of zeroed-
 # out KPI cards and charts.
 #
-# Each entry MUST also have ``BACKFILL_DAYS_PER_PLATFORM[<platform>] = 0``
-# in ``apps/analytics/tasks.py`` — otherwise the background cron will
-# still try to fetch metrics that don't exist.
+# The cron skips these because ``sync_all_account_analytics`` filters on
+# ``services.analytics_availability``. Each entry MUST *also* have
+# ``BACKFILL_DAYS_PER_PLATFORM[<platform>] = 0`` in ``apps/analytics/tasks.py``
+# — that guard alone is not sufficient (it only skips the per-post loop, after
+# the account-level fetch has already run), but it keeps the per-post window
+# honest for any caller that reads the table directly.
 NO_ANALYTICS_PLATFORMS: dict[str, str] = {
     "linkedin_personal": ("LinkedIn doesn't expose personal-profile analytics. Only Company Pages have analytics."),
     "bluesky": ("Bluesky's AT Protocol doesn't surface aggregate post analytics."),
     "mastodon": ("The Mastodon API doesn't expose aggregate post analytics."),
+    # DevtoProvider implements no metrics methods, so the sync would call into
+    # SocialProvider's NotImplementedError. Listed here rather than left to
+    # AnalyticsPlatformConfig: a missing config row now reads as *enabled*, and
+    # this is a capability gap, not an admin decision.
+    "devto": ("Publishing to DEV.to is supported, but its analytics aren't wired up yet."),
 }

--- a/apps/analytics/services.py
+++ b/apps/analytics/services.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 from collections.abc import Iterable
 from datetime import date as dt_date
 from datetime import timedelta
-from typing import Any
+from typing import Any, NamedTuple
 
 from django.utils import timezone
 
@@ -39,39 +39,78 @@ from .models import AccountInsightsSnapshot, PostInsightsSnapshot
 _POST_FALLBACK_DENYLIST: frozenset[str] = frozenset({"reach"})
 
 
-def unavailable_reason(platform: str, enabled_platforms: list[str] | None = None) -> str | None:
+class Unavailable(NamedTuple):
+    """Why a platform has no live analytics: a machine-readable cause + copy.
+
+    ``cause`` exists so callers can branch on *which* gate fired without
+    re-deriving it. A UI that only knows "unavailable" can't tell the user
+    whether there is anything they can do about it, and re-testing
+    ``NO_ANALYTICS_PLATFORMS`` at the call site to find out would silently
+    mislabel every gate added later as an admin toggle.
+    """
+
+    cause: str
+    message: str
+
+
+# ``cause`` values. NO_API and UNSUPPORTED are dead ends for the user;
+# DISABLED is the only one an admin can do something about.
+CAUSE_NO_API = "no_api"
+CAUSE_DISABLED = "disabled"
+CAUSE_UNSUPPORTED = "unsupported"
+
+
+def analytics_availability(platform: str, enabled_platforms: list[str] | None = None) -> Unavailable | None:
     """Why ``platform`` has no live analytics, or ``None`` if it does.
 
-    Combines the two independent gates that the analytics stack honors:
+    Combines every gate the analytics stack honors:
 
-    * :data:`apps.analytics.constants.NO_ANALYTICS_PLATFORMS` — the
-      platform's API exposes no aggregate analytics at all (LinkedIn
-      Personal, Bluesky, Mastodon).
-    * :class:`apps.social_accounts.models.AnalyticsPlatformConfig` — an
-      admin has switched the platform off (e.g. provider app-review for
+    * ``CAUSE_UNSUPPORTED`` — the slug isn't a platform this version knows
+      about (a retired slug left behind on an old account row). The admin
+      list is built from the same choices, so it can't be switched on
+      there; reporting it as an admin toggle would send the user after a
+      row that cannot exist.
+    * ``CAUSE_NO_API`` — :data:`apps.analytics.constants.NO_ANALYTICS_PLATFORMS`:
+      the platform exposes no aggregate analytics we can read (LinkedIn
+      Personal, Bluesky, Mastodon, DEV.to).
+    * ``CAUSE_DISABLED`` — :class:`apps.social_accounts.models.AnalyticsPlatformConfig`:
+      an admin has switched the platform off (e.g. provider app-review for
       analytics scopes is still pending), so the background sync skips it.
 
     Lives in ``services.py`` (not the agent-API builders) so the web view
     (``apps/analytics/views.py``), the sync cron
     (``apps/analytics/tasks.py``) and the agent-API surface all import
-    the same predicate — if a third gate ever lands, only this function
+    the same predicate — if a fourth gate ever lands, only this function
     needs to know.
 
     ``enabled_platforms`` may be supplied (e.g. in a per-request cache)
     to avoid re-querying ``AnalyticsPlatformConfig`` once per call.
     """
+    # Lazy imports to avoid pulling these apps at module load time —
+    # services.py is imported by URL config.
+    from apps.credentials.models import PlatformCredential
+
+    if platform not in PlatformCredential.Platform.values:
+        return Unavailable(CAUSE_UNSUPPORTED, "This account is on a platform this version no longer supports.")
     inherent = NO_ANALYTICS_PLATFORMS.get(platform)
     if inherent is not None:
-        return inherent
+        return Unavailable(CAUSE_NO_API, inherent)
     if enabled_platforms is None:
-        # Lazy import to avoid pulling the social_accounts app at module
-        # load time — services.py is imported by URL config.
         from apps.social_accounts.models import AnalyticsPlatformConfig
 
         enabled_platforms = AnalyticsPlatformConfig.enabled_platforms()
     if platform not in enabled_platforms:
-        return "Analytics is not currently enabled for this platform."
+        return Unavailable(CAUSE_DISABLED, "Analytics is not currently enabled for this platform.")
     return None
+
+
+def unavailable_reason(platform: str, enabled_platforms: list[str] | None = None) -> str | None:
+    """The message half of :func:`analytics_availability`, or ``None``.
+
+    For callers that only render the copy (the agent-API builders).
+    """
+    verdict = analytics_availability(platform, enabled_platforms)
+    return verdict.message if verdict else None
 
 
 def _series_for(

--- a/apps/analytics/tasks.py
+++ b/apps/analytics/tasks.py
@@ -72,12 +72,14 @@ BACKFILL_DAYS_PER_PLATFORM: dict[str, int] = {
     "threads": 90,
     "google_business": 90,
     "tiktok": 60,
-    # Bluesky / Mastodon / LinkedIn-Personal have no analytics surface — skip.
-    # LinkedIn only exposes share statistics for Organization URNs, not
-    # personal Person URNs, regardless of granted scopes.
+    # Bluesky / Mastodon / LinkedIn-Personal / DEV.to have no analytics surface
+    # — skip. LinkedIn only exposes share statistics for Organization URNs, not
+    # personal Person URNs, regardless of granted scopes. Each of these must
+    # also appear in ``NO_ANALYTICS_PLATFORMS``.
     "bluesky": 0,
     "mastodon": 0,
     "linkedin_personal": 0,
+    "devto": 0,
 }
 DEFAULT_BACKFILL_DAYS = 90
 
@@ -254,32 +256,24 @@ def _account_metrics_to_dict(metrics, platform: str) -> dict[str, float]:
 
 
 def _resolve_provider(account):
-    """Mirror apps.social_accounts.tasks.check_social_account_health's credential
-    resolution so platforms with org-level creds (Meta apps, etc.) work."""
-    from apps.credentials.models import resolve_platform_credentials
+    """Build the provider for ``account`` with the same credentials the publish
+    engine and the health check use.
+
+    This used to be a hand-copy of ``_resolve_publish_credentials`` and had
+    drifted: no ``instagram_login`` branch (so Instagram Direct providers were
+    built with no ``ig_user_id`` / ``account_handle``) and no Bluesky
+    ``pds_url``. Calling the shared resolver is the only way that stays fixed.
+
+    Adopting it deliberately changes two Mastodon behaviours to match
+    publishing: ``MastodonAppRegistration``'s client_id/secret now apply only
+    when the org's own credentials don't already carry one, and an
+    ``instance_url`` that fails the SSRF check is dropped rather than passed
+    through (analytics for such an account fails instead of dialling it).
+    """
+    from apps.publisher.engine import _resolve_publish_credentials
     from providers import get_provider
 
-    # .env is dominant; admin-entered org credentials are the fallback.
-    credentials = resolve_platform_credentials(account.platform, account.workspace.organization_id)
-
-    if account.platform == "mastodon" and account.instance_url:
-        from apps.social_accounts.models import MastodonAppRegistration
-
-        try:
-            reg = MastodonAppRegistration.objects.get(instance_url=account.instance_url)
-            credentials = {
-                **credentials,
-                "instance_url": account.instance_url,
-                "client_id": reg.client_id,
-                "client_secret": reg.client_secret,
-            }
-        except MastodonAppRegistration.DoesNotExist:
-            pass
-    elif account.platform == "facebook":
-        credentials = {**credentials, "page_id": account.account_platform_id}
-    elif account.platform == "instagram":
-        credentials = {**credentials, "ig_user_id": account.account_platform_id}
-    return get_provider(account.platform, credentials)
+    return get_provider(account.platform, _resolve_publish_credentials(account))
 
 
 def _is_insufficient_scope(exc: Exception) -> bool:
@@ -641,14 +635,15 @@ def backfill_account_analytics(account_id: str, days: int | None = None) -> None
     its current cumulative metrics and write today's snapshot rows.
     """
     from apps.composer.models import PlatformPost
-    from apps.social_accounts.models import AnalyticsPlatformConfig, SocialAccount
+    from apps.social_accounts.models import SocialAccount
+
+    from . import services
 
     try:
         account = SocialAccount.objects.get(id=account_id)
     except SocialAccount.DoesNotExist:
         return
-    enabled = set(AnalyticsPlatformConfig.enabled_platforms())
-    if account.platform not in enabled:
+    if services.analytics_availability(account.platform) is not None:
         return
     cap = BACKFILL_DAYS_PER_PLATFORM.get(account.platform, DEFAULT_BACKFILL_DAYS)
     if cap == 0:
@@ -675,14 +670,24 @@ def sync_all_account_analytics() -> None:
     from apps.composer.models import PlatformPost
     from apps.social_accounts.models import AnalyticsPlatformConfig, SocialAccount
 
-    enabled = set(AnalyticsPlatformConfig.enabled_platforms())
-    if not enabled:
+    from . import services
+
+    # Filter on the same predicate the page and the agent API use, not just the
+    # admin toggle. A platform with no analytics API at all (DEV.to, Bluesky,
+    # ...) is "enabled" as far as AnalyticsPlatformConfig is concerned, and the
+    # ``cap_days == 0`` guard below only skips the per-post loop — so without
+    # this those accounts reached _sync_account_metrics every single hour, built
+    # a provider, and failed. They never write a snapshot row, so ``has_today_rows``
+    # never became True and the waste repeated forever.
+    enabled = AnalyticsPlatformConfig.enabled_platforms()
+    syncable = [p for p in enabled if services.analytics_availability(p, enabled) is None]
+    if not syncable:
         return
     today = timezone.now().date()
 
     accounts = SocialAccount.objects.filter(
         connection_status=SocialAccount.ConnectionStatus.CONNECTED,
-        platform__in=enabled,
+        platform__in=syncable,
     ).select_related("workspace")
     from .models import AccountInsightsSnapshot
 

--- a/apps/analytics/tests/test_tasks.py
+++ b/apps/analytics/tests/test_tasks.py
@@ -198,3 +198,39 @@ def test_sync_account_metrics_refreshes_empty_follower_count_when_today_rows_exi
 
     account.refresh_from_db()
     assert account.follower_count == 1234
+
+
+@pytest.mark.django_db
+def test_resolve_provider_carries_instagram_login_credentials(workspace):
+    """``_resolve_provider`` was a hand-copy of the publish engine's resolver and
+    had drifted: no ``instagram_login`` branch, so Instagram Direct providers
+    were built with neither ``ig_user_id`` nor ``account_handle``.
+    """
+    from apps.analytics.tasks import _resolve_provider
+
+    account = SocialAccount.objects.create(
+        workspace=workspace,
+        platform="instagram_login",
+        account_platform_id="ig-direct-1",
+        account_name="Direct IG",
+        account_handle="direct.ig",
+        oauth_access_token="token",
+        connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+    )
+
+    provider = _resolve_provider(account)
+
+    assert provider.credentials["ig_user_id"] == "ig-direct-1"
+    assert provider.credentials["account_handle"] == "direct.ig"
+
+
+def test_no_analytics_platforms_all_have_a_zero_backfill_window():
+    """``NO_ANALYTICS_PLATFORMS``'s docstring mandates the pairing: without a
+    0-day window the cron still tries to fetch metrics the platform can't give.
+    """
+    from apps.analytics.constants import NO_ANALYTICS_PLATFORMS
+    from apps.analytics.tasks import BACKFILL_DAYS_PER_PLATFORM
+
+    assert {p: BACKFILL_DAYS_PER_PLATFORM.get(p) for p in NO_ANALYTICS_PLATFORMS} == dict.fromkeys(
+        NO_ANALYTICS_PLATFORMS, 0
+    )

--- a/apps/analytics/tests/test_views.py
+++ b/apps/analytics/tests/test_views.py
@@ -1,0 +1,201 @@
+"""HTTP-level tests for the analytics page's account list.
+
+Regression cover for accounts disappearing from the account switcher. A
+platform switched off in ``AnalyticsPlatformConfig`` used to be filtered out of
+the queryset feeding the switcher, so a connected Instagram (Direct) account
+simply wasn't there and nothing anywhere said why.
+"""
+
+import pytest
+from django.urls import reverse
+from django.utils import timezone
+
+from apps.accounts.models import User
+from apps.members.models import OrgMembership, WorkspaceMembership
+from apps.organizations.models import Organization
+from apps.social_accounts.models import AnalyticsPlatformConfig, SocialAccount
+from apps.workspaces.models import Workspace
+
+
+@pytest.fixture
+def workspace(db):
+    org = Organization.objects.create(name="Analytics Views Org")
+    return Workspace.objects.create(organization=org, name="Analytics Views WS")
+
+
+@pytest.fixture
+def owner_client(client, workspace):
+    user = User.objects.create_user(
+        email="analytics-views@example.com",
+        password="testpass123",
+        tos_accepted_at=timezone.now(),
+    )
+    OrgMembership.objects.create(
+        user=user,
+        organization=workspace.organization,
+        org_role=OrgMembership.OrgRole.OWNER,
+    )
+    WorkspaceMembership.objects.create(
+        user=user,
+        workspace=workspace,
+        workspace_role=WorkspaceMembership.WorkspaceRole.OWNER,
+    )
+    client.force_login(user)
+    return client
+
+
+def _account(workspace, platform, name):
+    return SocialAccount.objects.create(
+        workspace=workspace,
+        platform=platform,
+        account_platform_id=f"{platform}-1",
+        account_name=name,
+        oauth_access_token="token",
+        connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+    )
+
+
+def _disable_analytics(platform):
+    AnalyticsPlatformConfig.objects.update_or_create(platform=platform, defaults={"is_enabled": False})
+
+
+def _account_url(workspace, account):
+    return reverse("analytics:account", kwargs={"workspace_id": workspace.id, "account_id": account.id})
+
+
+@pytest.mark.django_db
+def test_instagram_direct_account_is_listed_and_available(owner_client, workspace):
+    account = _account(workspace, "instagram_login", "Direct IG")
+
+    response = owner_client.get(_account_url(workspace, account))
+
+    assert response.status_code == 200
+    assert [a.id for a in response.context["accounts"]] == [account.id]
+    assert response.context["analytics_unavailable"] is False
+
+
+@pytest.mark.django_db
+def test_disabled_platform_account_stays_listed_with_a_reason(owner_client, workspace):
+    """The reported bug: the account vanished from the switcher entirely.
+
+    It must still be listed, and selecting it must explain both that analytics
+    is off for the platform and that reconnecting is needed once it's back on —
+    the insights scope is requested at connect time, so flipping the admin
+    toggle alone leaves the stored token unable to read insights.
+    """
+    account = _account(workspace, "instagram_login", "Direct IG")
+    _disable_analytics("instagram_login")
+
+    response = owner_client.get(_account_url(workspace, account))
+
+    assert response.status_code == 200
+    assert [a.id for a in response.context["accounts"]] == [account.id]
+    assert response.context["analytics_unavailable"] is True
+    assert response.context["analytics_disabled_by_admin"] is True
+    assert response.context["accounts"][0].analytics_unavailable_reason
+    body = response.content.decode()
+    assert "Reconnect this account" in body
+    # The switcher marks it rather than listing it indistinguishably.
+    assert "No data" in body
+
+
+@pytest.mark.django_db
+def test_index_lands_on_the_only_account_even_when_disabled(owner_client, workspace):
+    """Better to land on the explanation than on "connect an account"."""
+    account = _account(workspace, "instagram_login", "Direct IG")
+    _disable_analytics("instagram_login")
+
+    response = owner_client.get(reverse("analytics:index", kwargs={"workspace_id": workspace.id}), follow=True)
+
+    assert response.status_code == 200
+    assert response.context["active_account"].id == account.id
+    assert response.context["analytics_unavailable"] is True
+
+
+@pytest.mark.django_db
+def test_index_prefers_an_account_with_analytics_available(owner_client, workspace):
+    disabled = _account(workspace, "facebook", "AAA Disabled")
+    available = _account(workspace, "instagram_login", "ZZZ Available")
+    _disable_analytics("facebook")
+
+    response = owner_client.get(reverse("analytics:index", kwargs={"workspace_id": workspace.id}), follow=True)
+
+    # "facebook" sorts first and would have been the redirect target on
+    # ordering alone; availability wins.
+    assert disabled.platform < available.platform
+    assert response.context["active_account"].id == available.id
+
+
+@pytest.mark.django_db
+def test_inherently_unavailable_platform_gets_no_reconnect_hint(owner_client, workspace):
+    """Bluesky has no analytics API — reconnecting would achieve nothing."""
+    account = _account(workspace, "bluesky", "Bluesky")
+
+    response = owner_client.get(_account_url(workspace, account))
+
+    assert response.context["analytics_unavailable"] is True
+    assert response.context["analytics_disabled_by_admin"] is False
+    assert "Reconnect this account" not in response.content.decode()
+
+
+@pytest.mark.django_db
+def test_disconnected_account_is_not_listed(owner_client, workspace):
+    """The connection-status filter is the one that still drops accounts."""
+    listed = _account(workspace, "instagram_login", "Direct IG")
+    dropped = _account(workspace, "threads", "Threads")
+    dropped.connection_status = SocialAccount.ConnectionStatus.ERROR
+    dropped.save(update_fields=["connection_status"])
+
+    response = owner_client.get(_account_url(workspace, listed))
+
+    assert [a.id for a in response.context["accounts"]] == [listed.id]
+
+
+@pytest.mark.django_db
+def test_devto_account_renders_the_unavailable_state(owner_client, workspace):
+    """DEV.to has no metrics methods and no entry in the PLATFORM_* maps.
+
+    It reaches the page now that a missing config row counts as enabled, so the
+    platform-keyed lookups all have to tolerate it rather than KeyError.
+    """
+    account = _account(workspace, "devto", "Dev Blog")
+
+    response = owner_client.get(_account_url(workspace, account))
+
+    assert response.status_code == 200
+    assert response.context["analytics_unavailable"] is True
+    assert response.context["analytics_disabled_by_admin"] is False
+
+
+@pytest.mark.django_db
+def test_unavailable_account_suppresses_the_scope_reconnect_banner(owner_client, workspace):
+    """Two reconnect CTAs on one screen give contradictory instructions.
+
+    The unavailable state carries its own, so the insufficient-scope banner
+    stands down while it's showing.
+    """
+    account = _account(workspace, "instagram_login", "Direct IG")
+    account.analytics_needs_reconnect = True
+    account.save(update_fields=["analytics_needs_reconnect"])
+    _disable_analytics("instagram_login")
+
+    response = owner_client.get(_account_url(workspace, account))
+
+    assert response.context["analytics_needs_reconnect"] is False
+    assert "insufficient-scope" not in response.content.decode()
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("platform", ["instagram_login", "bluesky"])
+def test_pages_never_leak_raw_template_tags(owner_client, workspace, platform):
+    """Django's ``{# #}`` is single-line only: a multi-line one is emitted as
+    visible page text instead of being stripped. Cheap to assert, and it caught
+    two real leaks in the account switcher and the unavailable state.
+    """
+    account = _account(workspace, platform, "Acct")
+    _disable_analytics(platform)
+
+    body = owner_client.get(_account_url(workspace, account)).content.decode()
+
+    assert "{#" not in body
+    assert "{%" not in body

--- a/apps/analytics/views.py
+++ b/apps/analytics/views.py
@@ -22,7 +22,6 @@ from apps.social_accounts.models import AnalyticsPlatformConfig, SocialAccount
 from apps.workspaces.models import Workspace
 
 from . import services
-from .constants import NO_ANALYTICS_PLATFORMS
 from .metrics import PLATFORM_COLOR, PLATFORM_PRIMARY
 
 logger = logging.getLogger(__name__)
@@ -38,15 +37,38 @@ def _get_workspace(request, workspace_id):
     return workspace
 
 
-def _enabled_accounts(workspace):
-    enabled = AnalyticsPlatformConfig.enabled_platforms()
-    return list(
+def _analytics_accounts(workspace, enabled_platforms):
+    """Every connected account in the workspace, annotated with why (if at all)
+    analytics is unavailable for it.
+
+    Deliberately unfiltered by platform: an account whose platform is switched
+    off in ``AnalyticsPlatformConfig`` used to be dropped here, so it vanished
+    from the account switcher with nothing anywhere saying why. It stays in the
+    list now and carries its verdict, which the switcher and the page body both
+    render.
+    """
+    accounts = list(
         SocialAccount.objects.filter(
             workspace=workspace,
             connection_status=SocialAccount.ConnectionStatus.CONNECTED,
-            platform__in=enabled,
         ).order_by("platform", "account_name")
     )
+    for account in accounts:
+        verdict = services.analytics_availability(account.platform, enabled_platforms)
+        account.analytics_verdict = verdict
+        account.analytics_unavailable_reason = verdict.message if verdict else None
+    return accounts
+
+
+def _preferred_account(accounts):
+    """The account to land on: the first with working analytics, else the first.
+
+    Shared by the index redirect and the unknown-``account_id`` fallback so the
+    two ways of arriving without a specific account agree. Falling back to
+    ``accounts[0]`` rather than the no-accounts page means a workspace whose
+    only account is unavailable still gets the page explaining why.
+    """
+    return next((a for a in accounts if a.analytics_verdict is None), accounts[0])
 
 
 def _parse_range(value: str | None) -> int:
@@ -83,11 +105,12 @@ def _parse_page(value: str | None) -> int:
 
 @login_required
 def analytics_index(request: HttpRequest, workspace_id) -> HttpResponse:
-    """Landing route: redirects to the first enabled connected account."""
+    """Landing route: redirects to the first connected account with analytics."""
     workspace = _get_workspace(request, workspace_id)
-    if not AnalyticsPlatformConfig.enabled_platforms():
+    enabled = AnalyticsPlatformConfig.enabled_platforms()
+    if not enabled:
         raise Http404("Analytics is disabled.")
-    accounts = _enabled_accounts(workspace)
+    accounts = _analytics_accounts(workspace, enabled)
     if not accounts:
         return render(
             request,
@@ -96,23 +119,26 @@ def analytics_index(request: HttpRequest, workspace_id) -> HttpResponse:
         )
     from django.urls import reverse
 
-    return redirect(reverse("analytics:account", kwargs={"workspace_id": workspace.id, "account_id": accounts[0].id}))
+    target = _preferred_account(accounts)
+
+    return redirect(reverse("analytics:account", kwargs={"workspace_id": workspace.id, "account_id": target.id}))
 
 
 @login_required
 def analytics_account(request: HttpRequest, workspace_id, account_id) -> HttpResponse:
     """Main analytics page for one connected SocialAccount."""
     workspace = _get_workspace(request, workspace_id)
-    if not AnalyticsPlatformConfig.enabled_platforms():
+    enabled = AnalyticsPlatformConfig.enabled_platforms()
+    if not enabled:
         raise Http404("Analytics is disabled.")
 
-    accounts = _enabled_accounts(workspace)
+    accounts = _analytics_accounts(workspace, enabled)
     if not accounts:
         return render(request, "analytics/no_accounts.html", {"workspace": workspace})
 
     account = next((a for a in accounts if str(a.id) == str(account_id)), None)
     if account is None:
-        return redirect("analytics:account", workspace_id=workspace.id, account_id=accounts[0].id)
+        return redirect("analytics:account", workspace_id=workspace.id, account_id=_preferred_account(accounts).id)
 
     days = _parse_range(request.GET.get("range"))
     primary_color = "var(--primary)"  # locked in chat — design's locked accent
@@ -127,7 +153,11 @@ def analytics_account(request: HttpRequest, workspace_id, account_id) -> HttpRes
 
     has_snapshots = AccountInsightsSnapshot.objects.filter(social_account=account).exists()
     is_fresh = not has_any_post and not has_snapshots
-    analytics_unavailable = account.platform in NO_ANALYTICS_PLATFORMS
+    # Every gate comes from the one shared predicate, which also reports which
+    # of them fired — only the admin-disabled one has a fix to offer (enable,
+    # then reconnect), so the template needs the cause, not just the message.
+    verdict = account.analytics_verdict
+    analytics_unavailable = verdict is not None
 
     context: dict = {
         "workspace": workspace,
@@ -138,9 +168,13 @@ def analytics_account(request: HttpRequest, workspace_id, account_id) -> HttpRes
         "primary_color": primary_color,
         "platform_color": PLATFORM_COLOR.get(account.platform, "var(--primary)"),
         "is_fresh": is_fresh,
-        "analytics_needs_reconnect": account.analytics_needs_reconnect,
+        # An unavailable platform gets its own reconnect instructions inside
+        # the empty state, so suppressing the scope banner here keeps one set
+        # of instructions on screen instead of two competing ones.
+        "analytics_needs_reconnect": account.analytics_needs_reconnect and not analytics_unavailable,
         "analytics_unavailable": analytics_unavailable,
-        "analytics_unavailable_notice": NO_ANALYTICS_PLATFORMS.get(account.platform, ""),
+        "analytics_unavailable_notice": verdict.message if verdict else "",
+        "analytics_disabled_by_admin": bool(verdict and verdict.cause == services.CAUSE_DISABLED),
     }
 
     if analytics_unavailable:

--- a/apps/common/context_processors.py
+++ b/apps/common/context_processors.py
@@ -67,14 +67,13 @@ def sidebar_context(request):
         # Connectable platforms: not yet connected in this workspace.
         # Show all known platforms (configured or not) so the sidebar
         # always surfaces what can be connected. The connect page itself
-        # handles the "not configured" case with an admin prompt.
+        # handles the "not configured" case with an admin prompt, and shares
+        # PlatformVisibility.visible_choices() with us so the two can't disagree.
         connected_platforms = {ch.platform for ch in sidebar_channels}
-        hidden_platforms = set(PlatformVisibility.objects.filter(is_visible=False).values_list("platform", flat=True))
-        sidebar_connectable_platforms = [
-            (p, label)
-            for p, label in _platform_display_names()
-            if p not in connected_platforms and p not in hidden_platforms
-        ]
+        sidebar_connectable_platforms = sorted(
+            ((p, label) for p, label in PlatformVisibility.visible_choices() if p not in connected_platforms),
+            key=_connect_suggestion_rank,
+        )
 
     # Unread inbox count for sidebar badge
     sidebar_unread_inbox_count = 0
@@ -116,11 +115,6 @@ def sidebar_context(request):
     if org_membership and org_membership.org_role in ("owner", "admin"):
         can_create_workspace = True
 
-    # Filter the sidebar channel list to those whose platform is analytics-enabled,
-    # so the per-channel deep-links under the Analytics nav item never point at a
-    # disabled platform. The full sidebar channel list above is unrelated.
-    analytics_sidebar_channels = [ch for ch in sidebar_channels if ch.platform in analytics_enabled_platforms]
-
     return {
         "sidebar_workspaces": sidebar_workspaces,
         "can_create_workspace": can_create_workspace,
@@ -132,23 +126,38 @@ def sidebar_context(request):
         "sidebar_idea_columns": sidebar_idea_columns,
         "sidebar_idea_tags": sidebar_idea_tags,
         "analytics_enabled_platforms": analytics_enabled_platforms,
-        "analytics_sidebar_channels": analytics_sidebar_channels,
     }
 
 
-def _platform_display_names():
-    """Return list of (platform_key, display_name) tuples."""
-    return [
-        ("instagram", "Instagram"),
-        ("facebook", "Facebook"),
-        ("linkedin_personal", "LinkedIn (Personal)"),
-        ("linkedin_company", "LinkedIn (Company)"),
-        ("tiktok", "TikTok"),
-        ("youtube", "YouTube"),
-        ("pinterest", "Pinterest"),
-        ("threads", "Threads"),
-        ("bluesky", "Bluesky"),
-        ("mastodon", "Mastodon"),
-        ("twitter", "X (Twitter)"),
-        ("google_business", "Google Business"),
-    ]
+# Display order for the sidebar's connect shortcuts, most-asked-for first.
+# The template shows only the first three, and ``Platform.choices`` is ordered
+# for the publish pipeline — leaving it to decide would put Facebook, Instagram
+# and Instagram (Direct) in all three slots and push LinkedIn/TikTok/YouTube
+# out of sight.
+#
+# Unlike the hand-maintained list this replaced, this is a *ranking*, not the
+# set: a platform missing from here still appears (ranked last), so a new
+# platform can never be silently hidden from the sidebar again.
+_CONNECT_SUGGESTION_ORDER: tuple[str, ...] = (
+    "instagram",
+    "linkedin_company",
+    "tiktok",
+    "youtube",
+    "facebook",
+    "linkedin_personal",
+    "threads",
+    "pinterest",
+    "instagram_login",
+    "google_business",
+    "bluesky",
+    "mastodon",
+    "devto",
+)
+
+
+def _connect_suggestion_rank(choice):
+    platform, _label = choice
+    try:
+        return (0, _CONNECT_SUGGESTION_ORDER.index(platform))
+    except ValueError:
+        return (1, 0)

--- a/apps/social_accounts/migrations/0017_seed_missing_analytics_platform_config.py
+++ b/apps/social_accounts/migrations/0017_seed_missing_analytics_platform_config.py
@@ -1,0 +1,31 @@
+"""Backfill AnalyticsPlatformConfig rows for platforms added after 0010.
+
+``0010_seed_analytics_platform_config`` enumerated the platform choices as they
+stood at that migration, so every slug added later (``devto`` was the first)
+has no row and never appears in the admin's Analytics platforms list — leaving
+no way to see, let alone change, its analytics state. ``enabled_platforms()``
+now reads a missing row as enabled, so this is cosmetic rather than
+load-bearing, but the admin list should show every platform.
+
+Idempotent, same as 0010: re-running touches nothing.
+"""
+
+from django.db import migrations
+
+
+def seed_missing_analytics_platform_config(apps, schema_editor):
+    AnalyticsPlatformConfig = apps.get_model("social_accounts", "AnalyticsPlatformConfig")
+    PlatformCredential = apps.get_model("credentials", "PlatformCredential")
+    for value, _label in PlatformCredential._meta.get_field("platform").choices:
+        AnalyticsPlatformConfig.objects.get_or_create(platform=value, defaults={"is_enabled": True})
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("social_accounts", "0016_socialaccount_webhook_error_detail_and_more"),
+        ("credentials", "0005_add_devto_platform"),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_missing_analytics_platform_config, migrations.RunPython.noop),
+    ]

--- a/apps/social_accounts/models.py
+++ b/apps/social_accounts/models.py
@@ -325,6 +325,19 @@ class PlatformVisibility(models.Model):
     def __str__(self):
         return f"{self.get_platform_display()} ({'visible' if self.is_visible else 'hidden'})"
 
+    @classmethod
+    def visible_choices(cls) -> list[tuple[str, str]]:
+        """``Platform.choices`` minus the platforms an admin has hidden.
+
+        The single source for "what can be connected" — the connect page and
+        the sidebar's connect shortcuts both read it, so they can't drift
+        (the sidebar used to keep its own hand-maintained copy, which had
+        fallen behind by two platforms). Platforms without a row default to
+        visible, matching ``is_visible``.
+        """
+        hidden = set(cls.objects.filter(is_visible=False).values_list("platform", flat=True))
+        return [(value, label) for value, label in PlatformCredential.Platform.choices if value not in hidden]
+
 
 class AnalyticsPlatformConfig(models.Model):
     """Site-wide toggle controlling which platforms are enabled for the
@@ -360,10 +373,16 @@ class AnalyticsPlatformConfig(models.Model):
     def enabled_platforms(cls) -> list[str]:
         """Return the list of platform slugs with analytics enabled.
 
-        Falls back to "all platforms" if no rows exist yet (fresh DB before
-        the seed migration has run). Otherwise honors only ``is_enabled=True``.
+        A platform with no row counts as enabled, matching ``is_enabled``'s
+        default and the fact that the admin forbids adding or deleting rows —
+        so a missing row always means "nothing has been said about this
+        platform", never "an admin turned it off". Without that, every platform
+        slug added after the seed migration (``devto`` was the first) had its
+        analytics silently switched off, which is invisible from the admin
+        because the platform isn't listed there either.
+
+        Driven off ``Platform.choices`` rather than the table, so a row left
+        behind by a renamed slug can't leak into the result.
         """
-        rows = list(cls.objects.values_list("platform", "is_enabled"))
-        if not rows:
-            return [value for value, _label in PlatformCredential.Platform.choices]
-        return [platform for platform, enabled in rows if enabled]
+        rows = dict(cls.objects.values_list("platform", "is_enabled"))
+        return [value for value, _label in PlatformCredential.Platform.choices if rows.get(value, True)]

--- a/apps/social_accounts/tests/test_models.py
+++ b/apps/social_accounts/tests/test_models.py
@@ -161,3 +161,38 @@ class TestMastodonAppRegistration:
             client_secret="secret",
         )
         assert str(reg) == "https://mastodon.social"
+
+
+@pytest.mark.django_db
+class TestAnalyticsPlatformConfigEnabledPlatforms:
+    """``enabled_platforms`` decides which platforms the analytics stack serves."""
+
+    def test_platform_without_a_row_counts_as_enabled(self):
+        """The seed migration enumerated the choices as of its own migration, so
+        every slug added afterwards (``devto`` was the first) has no row. Reading
+        that as "disabled" switched analytics off for them silently — and
+        invisibly, since a platform with no row isn't listed in the admin either.
+        """
+        from apps.credentials.models import PlatformCredential
+        from apps.social_accounts.models import AnalyticsPlatformConfig
+
+        AnalyticsPlatformConfig.objects.filter(platform=PlatformCredential.Platform.DEVTO).delete()
+
+        assert PlatformCredential.Platform.DEVTO in AnalyticsPlatformConfig.enabled_platforms()
+
+    def test_disabled_row_is_honored(self):
+        from apps.social_accounts.models import AnalyticsPlatformConfig
+
+        AnalyticsPlatformConfig.objects.update_or_create(platform="instagram_login", defaults={"is_enabled": False})
+
+        assert "instagram_login" not in AnalyticsPlatformConfig.enabled_platforms()
+
+    def test_stale_slug_row_does_not_leak_into_the_result(self):
+        """``instagram_personal`` was renamed to ``instagram_login``; a row left
+        behind by a partially-applied rename must not appear as a platform.
+        """
+        from apps.social_accounts.models import AnalyticsPlatformConfig
+
+        AnalyticsPlatformConfig.objects.create(platform="instagram_personal", is_enabled=True)
+
+        assert "instagram_personal" not in AnalyticsPlatformConfig.enabled_platforms()

--- a/apps/social_accounts/views.py
+++ b/apps/social_accounts/views.py
@@ -44,8 +44,7 @@ def _get_visible_platform_choices():
 
     Platforms without a PlatformVisibility row default to visible.
     """
-    hidden = set(PlatformVisibility.objects.filter(is_visible=False).values_list("platform", flat=True))
-    return [(value, label) for value, label in PlatformCredential.Platform.choices if value not in hidden]
+    return PlatformVisibility.visible_choices()
 
 
 def _apply_analytics_scope_flag(provider, platform):

--- a/templates/analytics/_no_analytics_state.html
+++ b/templates/analytics/_no_analytics_state.html
@@ -12,6 +12,22 @@
         <p style="font-size: 0.9375rem; color: var(--text-secondary); line-height: 1.6;">
             {{ analytics_unavailable_notice }}
         </p>
+        {% if analytics_disabled_by_admin %}
+        {% comment %}
+        Admin-disabled, not an API limitation — so unlike the LinkedIn Personal
+        / Bluesky / Mastodon copy above, there is something to do about it.
+        The reconnect matters: the insights scope is requested at connect time
+        based on this same toggle, so a token granted while it was off can't
+        read insights even once it's back on. ({# #} is single-line only in
+        Django — a multi-line one renders as visible page text.)
+        {% endcomment %}
+        <p style="font-size: 0.875rem; color: var(--text-tertiary); line-height: 1.6; margin-top: 12px;">
+            An administrator can switch it on under <strong>Analytics platforms</strong> in the
+            Django admin. Reconnect this account afterwards — the analytics permission is
+            requested when the account connects, so the current connection can't read insights
+            until it's granted.
+        </p>
+        {% endif %}
         <div style="margin-top: 28px; display: flex; gap: 10px; justify-content: center;">
             <a href="{% url 'composer:create_landing' workspace_id=workspace.id %}" class="btn-brand" style="width: auto; padding: 9px 20px;">Create a post</a>
         </div>

--- a/templates/analytics/_page_header.html
+++ b/templates/analytics/_page_header.html
@@ -50,6 +50,15 @@
                                 <span style="display: block; font-size: 0.8125rem; font-weight: 600; color: var(--neutral-900); overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">{{ acc.account_name }}</span>
                                 <span style="display: block; font-size: 0.6875rem; color: var(--text-tertiary);">{{ acc.follower_count|intcomma }} followers</span>
                             </span>
+                            {% if acc.analytics_unavailable_reason %}
+                                {% comment %}
+                                Present but unavailable. Listing it silently would be the same
+                                dead end as dropping it from the switcher entirely — select it
+                                and the page body says which of the two reasons applies.
+                                {% endcomment %}
+                                <span title="{{ acc.analytics_unavailable_reason }}"
+                                      style="flex-shrink: 0; font-size: 0.625rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-tertiary); background: var(--surface-2); border-radius: var(--radius-full); padding: 2px 7px;">No data</span>
+                            {% endif %}
                             {% if acc.id == active_account.id %}
                                 <svg width="16" height="16" fill="none" stroke="var(--primary)" viewBox="0 0 24 24" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>
                             {% endif %}

--- a/templates/analytics/no_accounts.html
+++ b/templates/analytics/no_accounts.html
@@ -18,7 +18,9 @@
             </div>
             <h2 style="font-family: var(--font-display); font-size: 1.5rem; font-weight: 700; color: var(--text-primary); margin-bottom: 8px;">Connect an account to see analytics</h2>
             <p style="font-size: 0.9375rem; color: var(--text-secondary); line-height: 1.6; margin-bottom: 20px;">
-                No analytics-enabled accounts are connected to this workspace yet. Connect one to start tracking per-post performance.
+                This workspace has no connected accounts. Connect one to start tracking per-post
+                performance — and if you have connected an account before, check the Channels page:
+                one that needs reconnecting doesn't show up here.
             </p>
             <a href="{% url 'social_accounts:connect' workspace_id=workspace.id %}" class="btn-brand" style="width: auto; padding: 9px 20px;">Connect a channel</a>
         </div>


### PR DESCRIPTION
## What prompted this

Connecting an account via **Instagram (Direct)** ("Sign in with Instagram · no Facebook needed") and then not finding it on the analytics page. That reads as "Instagram Direct isn't supported for analytics" — it is. `instagram_login` has metric keys, a primary metric, a chart colour, a 90-day backfill window, an `instagram_business_manage_insights` scope, and working `get_account_metrics` / `get_post_metrics` against `graph.instagram.com`.

The account was missing because the page filtered its account list on the analytics platform toggle:

```python
SocialAccount.objects.filter(
    workspace=workspace,
    connection_status=CONNECTED,
    platform__in=AnalyticsPlatformConfig.enabled_platforms(),
)
```

Switch a platform off in Django admin → *Analytics platforms* and every account on it disappears from the switcher — no notice, no explanation, same dead end whether the cause was that toggle or a platform with no analytics API at all.

## What changed

**The page explains instead of hiding.** Every connected account is listed; one without analytics carries its reason. `services.analytics_availability` now returns a `(cause, message)` pair rather than bare copy, so the UI can distinguish an admin toggle — which has a fix to offer — from a platform that simply has no API. Its docstring already claimed the web view shared this predicate; only the agent API did.

The fix it offers matters: `_apply_analytics_scope_flag` picks the OAuth scope set from the same toggle **at connect time**, so a token granted while the platform was off cannot read insights even after it is switched back on. The empty state says to reconnect afterwards.

**The gaps that made that toggle so easy to hit:**

- `enabled_platforms()` read a missing row as *disabled*, so every platform slug added after the `0010` seed migration had analytics silently switched off — and invisibly, since a platform with no row isn't in the admin list either. `devto` had been in that hole since it landed. A missing row now means enabled (matching the field default; admin add/delete are both disabled), and a migration backfills the rows so the admin list is complete.
- Letting DEV.to through would have hit `SocialProvider.get_account_metrics`'s `NotImplementedError`, so it joins `NO_ANALYTICS_PLATFORMS`. The 0-day backfill window that entry is meant to pair with **does not** keep the cron away — `_sync_account_metrics` runs before the `cap_days == 0` check — so `sync_all_account_analytics` and `backfill_account_analytics` filter on the shared predicate instead. Without that, such accounts rebuilt a provider and failed every hour forever: they never write a snapshot row, so `has_today_rows` never became true. (Pre-existing for Bluesky/Mastodon/LinkedIn-Personal.)
- `_resolve_provider` in the analytics sync was a hand-copy of the publish engine's resolver and had drifted — no `instagram_login` branch (so Instagram Direct providers carried no `ig_user_id`/`account_handle`), no Bluesky `pds_url`. It calls `_resolve_publish_credentials` now, which also brings Mastodon in line with publishing: registration credentials apply only as a fallback, and an `instance_url` failing the SSRF check is dropped.
- The sidebar's connectable-platform list was a hand-maintained copy that omitted Instagram (Direct) and DEV.to and offered a `twitter` slug that isn't a platform. It shares `PlatformVisibility.visible_choices()` with the connect page now. Display order is a separate *ranking* rather than a set, so an unranked platform sorts last instead of vanishing — the failure mode of the list it replaces.

## For anyone hitting this today

No deploy needed: check Django admin → **Analytics platforms** for *Instagram (Direct)*. If it was off, turn it on **and reconnect the account**.

## Verification

- `pytest` — **1422 passed**. New `apps/analytics/tests/test_views.py` covers the reported bug (a disabled platform's account stays in the switcher), the DEV.to path, the index landing preference, and a guard asserting no raw `{#`/`{%` reaches the response.
- `ruff check .` and `ruff format --check .` clean.
- Driven against a running server on a throwaway copy of the dev DB: disabled → the account stays listed with a "No data" chip and the page explains why; re-enabled → the normal charts return.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
