### PR TITLE
fix(tiktok): point unaudited-client error at account privacy, not post privacy

### DIFF
--- a/providers/tiktok.py
+++ b/providers/tiktok.py
@@ -56,10 +56,13 @@ PERMANENT_PUBLISH_ERROR_CODES = frozenset(
 )
 
 UNAUDITED_CLIENT_HINT = (
-    "The TikTok app has not passed TikTok's content-posting audit yet. "
-    "Until TikTok approves the audit (developer portal → Content Posting API "
-    "→ apply for an audit), videos can only be published as private "
-    "(SELF_ONLY). Set this post's TikTok privacy to 'Only you' to publish now."
+    "The TikTok app has not passed TikTok's content-posting audit yet. Until "
+    "then TikTok only accepts posts to a private account: switch the TikTok "
+    "account itself to Private (TikTok app → Settings and privacy → Privacy → "
+    "Private account) and keep this post's TikTok privacy on 'Only you', then "
+    "retry. Post-level privacy alone is not enough — TikTok rejects SELF_ONLY "
+    "posts to public accounts. The restriction lifts once the audit "
+    "(developer portal → Content Posting API → apply for an audit) is approved."
 )
 
 # Optional post_info fields the composer may set via platform_extra.

--- a/tests/providers/test_tiktok.py
+++ b/tests/providers/test_tiktok.py
@@ -610,3 +610,20 @@ class TestPublishPost:
 
         assert excinfo.value.retryable is False
         mock_request.assert_not_called()
+
+
+class TestUnauditedClientErrorCopy:
+    def test_unaudited_error_directs_user_to_account_privacy(self):
+        """TikTok's unaudited gate is about the ACCOUNT being private — a
+        SELF_ONLY post on a public account is still rejected (verified in
+        production), so the hint must direct users to the account toggle."""
+        provider = TikTokProvider({"client_key": "k", "client_secret": "s"})
+        exc = APIError(
+            "TikTok API error 400",
+            raw_response={"error": {"code": "unaudited_client_can_only_post_to_private_accounts"}},
+        )
+        with pytest.raises(PublishError) as excinfo:
+            provider._raise_classified_publish_error(exc)
+        message = str(excinfo.value).lower()
+        assert "private account" in message
+        assert excinfo.value.retryable is False


### PR DESCRIPTION
TikTok's `unaudited_client_can_only_post_to_private_accounts` is about the target ACCOUNT being private — a SELF_ONLY post to a public account is still rejected. The current hint tells the user to set the post to 'Only you', which cannot fix it.

Hit this in production: post privacy was already SELF_ONLY, TikTok kept rejecting, and the hint sent us in circles until we read the error code literally. Switching the TikTok account itself to Private (Settings and privacy → Privacy → Private account) resolved it immediately.

The new hint names the account toggle, keeps the 'Only you' advice, and still explains the audit path.

Tested: new unit test asserts the message directs at account privacy and is non-retryable; full `tests/providers/test_tiktok.py` passes.