### PR TITLE
fix(instagram): fail cleanly when a post has no media

### DIFF
--- a/providers/instagram.py
+++ b/providers/instagram.py
@@ -297,6 +297,17 @@ class InstagramProvider(SocialProvider):
     # ------------------------------------------------------------------
 
     def publish_post(self, access_token: str, content: PublishContent) -> PublishResult:
+        if not content.media_urls:
+            # Instagram has no text-only posts; without this guard an empty
+            # media list surfaces as a raw IndexError (or an empty carousel
+            # spinning in the container wait loop) and burns the retry
+            # schedule on an unfixable input.
+            raise PublishError(
+                "Instagram requires at least one image or video — attach media to this post.",
+                platform=self.platform_name,
+                retryable=False,
+            )
+
         ig_user_id = content.extra.get("ig_user_id") or self._get_ig_user_id(access_token)
 
         if content.post_type == PostType.CAROUSEL:

--- a/tests/providers/test_instagram.py
+++ b/tests/providers/test_instagram.py
@@ -3,10 +3,11 @@ from unittest.mock import MagicMock, call
 
 import pytest
 
-from providers.exceptions import APIError
+from providers.exceptions import APIError, PublishError
 from providers.instagram import InstagramProvider
 from providers.instagram_login import InstagramLoginProvider
 from providers.meta_comments import INSTAGRAM_COMMENT_FIELD_SETS
+from providers.types import PostType, PublishContent
 
 
 def _resp(data):
@@ -908,3 +909,30 @@ def test_comment_poll_keeps_the_author_when_only_replies_are_rejected(make_provi
     sent = provider._request.call_args_list[1].kwargs["params"]["fields"]
     assert "from{" in sent
     assert "replies" not in sent
+
+
+class TestMediaRequired:
+    """A media-less publish must fail with a clear, non-retryable error —
+    not a raw IndexError (production incident: text-only post to Instagram
+    crashed with 'list index out of range' and burned the retry schedule)."""
+
+    def _content(self, post_type):
+        return PublishContent(text="hello", post_type=post_type, extra={"ig_user_id": "17841400000000000"})
+
+    def _assert_clean_media_error(self, post_type):
+        provider = InstagramProvider({"client_id": "id", "client_secret": "secret"})
+        provider._request = MagicMock()  # any API call would be a bug here
+        with pytest.raises(PublishError) as excinfo:
+            provider.publish_post("token", self._content(post_type))
+        assert "media" in str(excinfo.value).lower() or "image or video" in str(excinfo.value).lower()
+        assert excinfo.value.retryable is False
+        provider._request.assert_not_called()
+
+    def test_image_post_without_media_raises_publish_error(self):
+        self._assert_clean_media_error(PostType.IMAGE)
+
+    def test_reel_without_media_raises_publish_error(self):
+        self._assert_clean_media_error(PostType.REEL)
+
+    def test_carousel_without_media_raises_publish_error(self):
+        self._assert_clean_media_error(PostType.CAROUSEL)


### PR DESCRIPTION
A media-less Instagram publish currently crashes with a raw `IndexError` (`media_urls[0]`) — and a media-less CAROUSEL is worse: it creates an empty container and spins in `_wait_for_container` until the processing timeout. Both burn the retry schedule on an input no retry can fix.

Hit in production twice: a text-only post routed to Instagram ('list index out of range' in the publish log ×4), and again when a post's attachment was removed while a retry was pending.

Fix: raise a non-retryable `PublishError` ('Instagram requires at least one image or video — attach media to this post.') before any API call.

Tested: three new tests (IMAGE/REEL/CAROUSEL) assert the clean error and that no API request is made; full `tests/providers/test_instagram.py` passes. Side effect: the carousel test case dropped from a 2-minute wait-loop to instant.