### PR TITLE
feat(publisher): verify async platform processing after publish

### DIFF
--- a/apps/publisher/engine.py
+++ b/apps/publisher/engine.py
@@ -367,6 +367,14 @@ class PublishEngine:
                 # Update rate limit state
                 self._update_rate_limit(account, result)
 
+                # Platforms that validate the file after accepting the upload
+                # (TikTok) get a deferred re-check so an async rejection does
+                # not leave a phantom "published" post.
+                if result.get("needs_verification") and platform_post.platform_post_id:
+                    from apps.publisher.tasks import verify_platform_post_publish
+
+                    verify_platform_post_publish(str(platform_post.id))
+
                 return result
             else:
                 error_msg = result.get("error", "Unknown publish error")
@@ -561,6 +569,7 @@ class PublishEngine:
                 "platform_post_id": result.platform_post_id,
                 "url": result.url,
                 "response": result.extra,
+                "needs_verification": bool(getattr(provider, "verifies_publish_async", False)),
             }
         finally:
             # Clean up temp files regardless of success/failure

--- a/apps/publisher/tasks.py
+++ b/apps/publisher/tasks.py
@@ -21,3 +21,86 @@ def run_publish_cycle():
     published = engine.poll_and_publish()
     if published:
         logger.info("Publish cycle completed - %d post(s) published", published)
+
+
+# --- async publish verification ---------------------------------------------
+# TikTok (and any future provider with verifies_publish_async=True) validates
+# the file after accepting the upload; the post must not stay "published" in
+# our DB when the platform's processing rejected it.
+
+VERIFY_DELAY_SECONDS = 30
+VERIFY_MAX_ATTEMPTS = 10  # 10 x 30s = a 5-minute verification window
+
+# User-facing hints for the fail reasons we can explain; publish_error must
+# stay human-readable (raw codes go to the PublishLog row instead).
+ASYNC_FAIL_REASON_HINTS = {
+    "frame_rate_check_failed": (
+        "TikTok rejected the video during processing: its frame rate must be between 23 and 60 fps."
+    ),
+    "picture_size_check_failed": (
+        "TikTok rejected the video during processing: the resolution is too low or the dimensions are unsupported."
+    ),
+    "duration_check_failed": (
+        "TikTok rejected the video during processing: its duration is outside the allowed range."
+    ),
+    "file_format_check_failed": (
+        "TikTok rejected the video during processing: unsupported file format (use an H.264 MP4)."
+    ),
+    "video_pull_failed": "TikTok could not download the video file.",
+}
+
+
+@background(schedule=VERIFY_DELAY_SECONDS)
+def verify_platform_post_publish(platform_post_id, attempt=1):
+    """Re-check a published post against the platform's processing status."""
+    from apps.composer.models import PlatformPost
+    from apps.publisher.models import PublishLog
+
+    platform_post = PlatformPost.objects.filter(id=platform_post_id).first()
+    if not platform_post or platform_post.status != PlatformPost.Status.PUBLISHED:
+        return
+
+    from apps.publisher.engine import _provider_and_access_token
+
+    try:
+        provider, access_token = _provider_and_access_token(platform_post.social_account)
+        verdict = provider.verify_publish(access_token, platform_post.platform_post_id)
+    except Exception:
+        logger.warning(
+            "Publish verification errored for PlatformPost %s (attempt %d)",
+            platform_post_id,
+            attempt,
+            exc_info=True,
+        )
+        verdict = {"state": "processing", "reason": ""}
+
+    state = (verdict or {}).get("state", "complete")
+
+    if state == "failed":
+        reason = (verdict or {}).get("reason") or "unknown"
+        platform_post.status = PlatformPost.Status.FAILED
+        platform_post.publish_error = ASYNC_FAIL_REASON_HINTS.get(
+            reason,
+            f"The platform rejected the post during processing ({reason}).",
+        )[:2000]
+        platform_post.save()
+        PublishLog.objects.create(
+            platform_post=platform_post,
+            attempt_number=platform_post.retry_count + 1,
+            error_message=f"async processing failed: {reason}",
+        )
+        logger.warning(
+            "PlatformPost %s failed platform-side processing: %s", platform_post.id, reason
+        )
+        return
+
+    if state == "processing":
+        if attempt < VERIFY_MAX_ATTEMPTS:
+            verify_platform_post_publish(str(platform_post.id), attempt + 1)
+        else:
+            logger.warning(
+                "Gave up verifying PlatformPost %s after %d attempts; leaving as published",
+                platform_post.id,
+                attempt,
+            )
+    # state == "complete": nothing to do — the published status is confirmed.

--- a/apps/publisher/test_publish_verification.py
+++ b/apps/publisher/test_publish_verification.py
@@ -1,0 +1,152 @@
+"""Async publish verification.
+
+TikTok accepts an upload and then validates the file asynchronously — a post
+can be "published" in our DB while TikTok has already rejected it
+(picture_size_check_failed, frame_rate_check_failed; both hit in production).
+The engine must verify async platforms after publishing and surface failures.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from background_task.models import Task
+from django.test import TestCase
+from django.utils import timezone
+
+from apps.composer.models import PlatformPost, Post
+from apps.organizations.models import Organization
+from apps.publisher.models import PublishLog
+from apps.publisher.tasks import VERIFY_MAX_ATTEMPTS, verify_platform_post_publish
+from apps.social_accounts.models import SocialAccount
+from apps.workspaces.models import Workspace
+from providers.types import PostType, PublishResult
+
+
+def _verifying_provider(verdict):
+    provider = MagicMock()
+    provider.verifies_publish_async = True
+    provider.verify_publish = MagicMock(return_value=verdict)
+    return provider
+
+
+class VerifyTaskTest(TestCase):
+    def setUp(self):
+        self.org = Organization.objects.create(name="Org")
+        self.workspace = Workspace.objects.create(organization=self.org, name="WS")
+        self.account = SocialAccount.objects.create(
+            workspace=self.workspace,
+            platform="tiktok",
+            account_platform_id="tt-user-1",
+            account_name="Test TikTok",
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+        self.post = Post.objects.create(workspace=self.workspace, caption="hi")
+        self.platform_post = PlatformPost.objects.create(
+            post=self.post,
+            social_account=self.account,
+            status=PlatformPost.Status.PUBLISHED,
+            platform_post_id="v_pub_file~v2-1.123",
+            published_at=timezone.now(),
+        )
+
+    def _run(self, provider, attempt=1):
+        with patch(
+            "apps.publisher.engine._provider_and_access_token",
+            return_value=(provider, "token"),
+        ):
+            verify_platform_post_publish.task_function(str(self.platform_post.id), attempt)
+
+    def test_a_failed_async_check_flips_the_post_to_failed(self):
+        self._run(_verifying_provider({"state": "failed", "reason": "frame_rate_check_failed"}))
+
+        self.platform_post.refresh_from_db()
+        assert self.platform_post.status == PlatformPost.Status.FAILED
+        # publish_error is user-facing: friendly hint, not just the raw code
+        assert "frame rate" in self.platform_post.publish_error.lower()
+        log = PublishLog.objects.filter(platform_post=self.platform_post).latest("created_at")
+        assert "frame_rate_check_failed" in (log.error_message or "")
+
+    def test_a_complete_check_leaves_the_post_published(self):
+        self._run(_verifying_provider({"state": "complete"}))
+
+        self.platform_post.refresh_from_db()
+        assert self.platform_post.status == PlatformPost.Status.PUBLISHED
+        assert not Task.objects.filter(task_name__contains="verify_platform_post_publish").exists()
+
+    def test_processing_reschedules_until_the_attempt_budget(self):
+        self._run(_verifying_provider({"state": "processing"}), attempt=1)
+
+        self.platform_post.refresh_from_db()
+        assert self.platform_post.status == PlatformPost.Status.PUBLISHED
+        assert Task.objects.filter(task_name__contains="verify_platform_post_publish").exists()
+
+    def test_processing_at_the_final_attempt_gives_up_and_stays_published(self):
+        self._run(_verifying_provider({"state": "processing"}), attempt=VERIFY_MAX_ATTEMPTS)
+
+        self.platform_post.refresh_from_db()
+        assert self.platform_post.status == PlatformPost.Status.PUBLISHED
+        assert not Task.objects.filter(task_name__contains="verify_platform_post_publish").exists()
+
+    def test_a_post_no_longer_published_is_left_alone(self):
+        self.platform_post.status = PlatformPost.Status.FAILED
+        self.platform_post.save()
+        provider = _verifying_provider({"state": "complete"})
+
+        self._run(provider)
+
+        provider.verify_publish.assert_not_called()
+
+
+class EngineSchedulesVerificationTest(TestCase):
+    def setUp(self):
+        self.org = Organization.objects.create(name="Org")
+        self.workspace = Workspace.objects.create(organization=self.org, name="WS")
+        self.account = SocialAccount.objects.create(
+            workspace=self.workspace,
+            platform="tiktok",
+            account_platform_id="tt-user-1",
+            account_name="Test TikTok",
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        )
+        self.post = Post.objects.create(workspace=self.workspace, caption="hi")
+        self.platform_post = PlatformPost.objects.create(
+            post=self.post,
+            social_account=self.account,
+            status=PlatformPost.Status.SCHEDULED,
+        )
+
+    def _publish(self, provider):
+        from apps.publisher.engine import PublishEngine
+
+        with patch(
+            "apps.publisher.engine._provider_and_access_token",
+            return_value=(provider, "token"),
+        ):
+            PublishEngine()._publish_platform_post(self.platform_post)
+
+    def test_engine_schedules_verification_for_async_providers(self):
+        provider = MagicMock()
+        provider.verifies_publish_async = True
+        provider.supported_post_types = [PostType.VIDEO, PostType.SHORT]
+        provider.publish_post = MagicMock(
+            return_value=PublishResult(platform_post_id="v_pub~1", url="", extra={})
+        )
+
+        self._publish(provider)
+
+        self.platform_post.refresh_from_db()
+        assert self.platform_post.status == PlatformPost.Status.PUBLISHED
+        assert Task.objects.filter(task_name__contains="verify_platform_post_publish").exists()
+
+    def test_engine_does_not_schedule_verification_for_sync_providers(self):
+        provider = MagicMock()
+        provider.verifies_publish_async = False
+        provider.supported_post_types = [PostType.VIDEO, PostType.SHORT]
+        provider.publish_post = MagicMock(
+            return_value=PublishResult(platform_post_id="fb-1", url="", extra={})
+        )
+
+        self._publish(provider)
+
+        self.platform_post.refresh_from_db()
+        assert self.platform_post.status == PlatformPost.Status.PUBLISHED
+        assert not Task.objects.filter(task_name__contains="verify_platform_post_publish").exists()

--- a/providers/base.py
+++ b/providers/base.py
@@ -155,6 +155,19 @@ class SocialProvider(ABC):
         """Post a comment on an existing post (e.g. first comment)."""
         raise NotImplementedError(f"{self.platform_name} does not support comments")
 
+    # Platforms that validate the file AFTER accepting the upload (TikTok)
+    # set this True and implement verify_publish; the engine then re-checks
+    # the post after publishing instead of trusting the upload-accept.
+    verifies_publish_async = False
+
+    def verify_publish(self, access_token: str, platform_post_id: str) -> dict | None:
+        """Check a published post's asynchronous processing outcome.
+
+        Returns ``{"state": "complete"|"processing"|"failed", "reason": str}``
+        or ``None`` when the platform has no async processing step.
+        """
+        return None
+
     # ------------------------------------------------------------------
     # Analytics (optional - override per provider)
     # ------------------------------------------------------------------

--- a/providers/tiktok.py
+++ b/providers/tiktok.py
@@ -493,6 +493,24 @@ class TikTokProvider(SocialProvider):
     # Analytics
     # ------------------------------------------------------------------
 
+    verifies_publish_async = True
+
+    def verify_publish(self, access_token: str, platform_post_id: str) -> dict:
+        """Map /post/publish/status/fetch/ onto the async-verification contract.
+
+        TikTok validates resolution/frame-rate/duration AFTER the upload is
+        accepted, so a publish that returned a publish_id can still fail —
+        observed in production as picture_size_check_failed and
+        frame_rate_check_failed on posts our DB called published.
+        """
+        data = self._fetch_publish_status(access_token, platform_post_id)
+        status = (data.get("status") or "").upper()
+        if status == "PUBLISH_COMPLETE":
+            return {"state": "complete", "reason": ""}
+        if status == "FAILED":
+            return {"state": "failed", "reason": data.get("fail_reason", "")}
+        return {"state": "processing", "reason": ""}
+
     def _fetch_publish_status(self, access_token: str, publish_id: str) -> dict:
         """Fetch the publish status payload for an in-flight publish job.
 

--- a/tests/providers/test_tiktok.py
+++ b/tests/providers/test_tiktok.py
@@ -610,3 +610,28 @@ class TestPublishPost:
 
         assert excinfo.value.retryable is False
         mock_request.assert_not_called()
+
+
+class TestVerifyPublish:
+    """TikTok validates files AFTER accepting the upload; verify_publish maps
+    /post/publish/status/fetch/ onto the engine's async-verification contract."""
+
+    def _provider(self, payload):
+        provider = TikTokProvider({"client_key": "k", "client_secret": "s"})
+        provider._request = MagicMock(return_value=_make_response({"data": payload}))
+        return provider
+
+    def test_declares_async_verification(self):
+        assert TikTokProvider({"client_key": "k", "client_secret": "s"}).verifies_publish_async is True
+
+    def test_publish_complete_maps_to_complete(self):
+        verdict = self._provider({"status": "PUBLISH_COMPLETE"}).verify_publish("t", "v_pub~1")
+        assert verdict == {"state": "complete", "reason": ""}
+
+    def test_failed_maps_to_failed_with_reason(self):
+        verdict = self._provider({"status": "FAILED", "fail_reason": "frame_rate_check_failed"}).verify_publish("t", "v_pub~1")
+        assert verdict == {"state": "failed", "reason": "frame_rate_check_failed"}
+
+    def test_anything_else_maps_to_processing(self):
+        verdict = self._provider({"status": "PROCESSING_UPLOAD"}).verify_publish("t", "v_pub~1")
+        assert verdict == {"state": "processing", "reason": ""}


### PR DESCRIPTION
TikTok validates resolution/frame-rate/duration AFTER accepting an upload, so a post can sit `published` in the DB while TikTok has already rejected it. The provider even ships `_fetch_publish_status`, but nothing calls it after publishing.

Hit twice in production in one day: two 'published' TikTok posts that never appeared on the profile — `status/fetch` showed `FAILED` with `picture_size_check_failed` and `frame_rate_check_failed`. From the user's side the tool simply lied.

Design:
- `SocialProvider.verifies_publish_async` (default `False`) + `verify_publish()` returning `{state: complete|processing|failed, reason}`; TikTok implements it over `/post/publish/status/fetch/`.
- After a successful publish of an async provider, the engine schedules a background re-check (30 s interval, 10 attempts ≈ 5-minute window — TikTok processing is usually seconds).
- `failed` → post flips to FAILED with a human-readable hint (`frame rate must be between 23 and 60 fps`, …) in `publish_error` and the raw reason in a PublishLog row; `complete` → confirmed, nothing else runs; still `processing` after the window → left as published with a warning log (fail-open, never un-publishes a live post).
- Network errors during verification count as `processing` and retry — a flaky check must not fail a good post.

Tested: 7 new engine/task tests (failed→FAILED with hint + log row, complete→untouched, reschedule budget, gives up gracefully, non-published posts ignored, sync providers never scheduled) + 4 provider mapping tests. Full suite passes.