### PR TITLE
fix(analytics): grant Instagram Direct the insights scope it was gated out of

### DIFF
--- a/apps/analytics/signals.py
+++ b/apps/analytics/signals.py
@@ -1,13 +1,22 @@
 """Signal handlers: enqueue analytics backfill when a SocialAccount is
-created or reconnected (oauth_access_token changes).
+created or reconnected (oauth_access_token changes), and when an admin
+switches a platform on in :class:`AnalyticsPlatformConfig`.
 """
 
 from __future__ import annotations
 
-from django.db.models.signals import post_save
+from django.db import transaction
+from django.db.models.signals import post_save, pre_save
 from django.dispatch import receiver
 
-from apps.social_accounts.models import SocialAccount
+from apps.social_accounts.models import AnalyticsPlatformConfig, SocialAccount
+
+# Set by :func:`enqueue_backfill_on_platform_enable` on the saved
+# ``AnalyticsPlatformConfig`` instance so the admin can report what the save
+# set in motion (see ``AnalyticsPlatformConfigAdmin.save_model``). The queueing
+# lives here rather than in the admin so it also covers ``save()`` from a shell,
+# ``update_or_create``, and any other code path that writes the row.
+BACKFILL_QUEUED_ATTR = "analytics_backfill_queued"
 
 
 @receiver(post_save, sender=SocialAccount)
@@ -32,3 +41,76 @@ def enqueue_analytics_backfill(sender, instance: SocialAccount, created: bool, u
     from .tasks import backfill_account_analytics
 
     backfill_account_analytics(str(instance.id))
+
+
+@receiver(pre_save, sender=AnalyticsPlatformConfig)
+def stash_previous_enabled(sender, instance: AnalyticsPlatformConfig, **kwargs):
+    """Record the stored ``is_enabled`` so post_save can spot an off → on flip.
+
+    Read here rather than in post_save because by then the new value has
+    already overwritten the row.
+    """
+    instance._previously_enabled = (
+        None
+        if instance.pk is None
+        else sender.objects.filter(pk=instance.pk).values_list("is_enabled", flat=True).first()
+    )
+
+
+@receiver(post_save, sender=AnalyticsPlatformConfig)
+def enqueue_backfill_on_platform_enable(sender, instance: AnalyticsPlatformConfig, created: bool, **kwargs):
+    """Switching a platform on re-checks the accounts already connected to it.
+
+    Without this, enabling a platform changes nothing visible until the hourly
+    ``sync_all_account_analytics`` cron happens to run: accounts whose token
+    predates the toggle fail on scope there, and only then get flagged for
+    reconnect. Running the backfill now collapses that window — the account
+    either gets its first snapshot or gets flagged for reconnect.
+
+    Deliberately narrow about what counts as "switched on":
+
+    * ``created`` is skipped. A platform with no row already reads as enabled
+      (see ``AnalyticsPlatformConfig.enabled_platforms``), so writing a first
+      row with ``is_enabled=True`` states the status quo rather than changing it.
+    * Platforms with no analytics API at all (``NO_ANALYTICS_PLATFORMS``) are
+      skipped via the shared ``analytics_availability`` predicate — the same
+      gate the page, the cron and the agent API use. Queueing them would insert
+      a task per account that returns immediately, the waste
+      ``sync_all_account_analytics`` documents having already stamped out.
+
+    Note ``queryset.update()`` fires no signals at all, so a bulk update still
+    bypasses this — the analytics page's copy therefore does not promise the
+    re-check, it only offers reconnecting as a possibility.
+    """
+    if created or not instance.is_enabled or getattr(instance, "_previously_enabled", None):
+        return
+    # Imported inside the handler so AppConfig.ready() doesn't pull in
+    # background_task (via .tasks) before the apps registry is fully loaded.
+    from . import services
+    from .tasks import backfill_account_analytics
+
+    if services.analytics_availability(instance.platform) is not None:
+        return
+
+    account_ids = [
+        str(pk)
+        for pk in SocialAccount.objects.filter(
+            platform=instance.platform,
+            connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+        ).values_list("id", flat=True)
+    ]
+    setattr(instance, BACKFILL_QUEUED_ATTR, len(account_ids))
+    if not account_ids:
+        return
+
+    def _enqueue():
+        for account_id in account_ids:
+            # Deduped: the admin toggle, a reconnect and a manual backfill can
+            # all target the same account, and each call would otherwise insert
+            # another task row for the same 90-day fetch.
+            backfill_account_analytics(account_id, remove_existing_tasks=True)
+
+    # Deferred to commit so the inserts don't extend the transaction the admin
+    # changelist wraps around its saves, and so nothing is queued for a save
+    # that ends up rolled back.
+    transaction.on_commit(_enqueue)

--- a/apps/analytics/tasks.py
+++ b/apps/analytics/tasks.py
@@ -381,13 +381,23 @@ def _needs_empty_follower_count_refresh(account) -> bool:
     return account.follower_count <= 0 and account.platform in _FOLLOWER_TOTAL_REFRESH_PLATFORMS
 
 
-def _sync_account_metrics(account, on_date: dt_date) -> None:
+def _sync_account_metrics(account, on_date: dt_date, *, force_today: bool = False) -> None:
     """Fetch account-level metrics for ``on_date`` and any recent missing days.
 
     Walks ``on_date`` and the prior ``_ACCOUNT_METRICS_RECENT_DAYS - 1`` days,
     skipping days that already have an :class:`AccountInsightsSnapshot`. For
     providers without lag (Instagram, Facebook) this is a no-op past
     ``on_date`` because the existing rows short-circuit the iteration.
+
+    ``force_today`` re-fetches ``on_date`` even when its rows already exist.
+    One-shot backfills pass it because they run at the moments the token's
+    reach may have *changed* — a connect, a reconnect, or an admin switching
+    the platform on — and the fetch is the only thing that surfaces an
+    insufficient-scope error and sets ``analytics_needs_reconnect``. Without
+    it, a same-day re-run finds today's rows present, skips every offset,
+    never calls the provider, and reports success for a token that cannot
+    read insights. The hourly cron does not pass it: there, existing rows
+    genuinely mean the work is done.
 
     For YouTube, also fetches per-video Analytics-API metrics (watch_time,
     avg_view_pct, shares) that the Data API can't provide per-post — see
@@ -416,8 +426,8 @@ def _sync_account_metrics(account, on_date: dt_date) -> None:
     for offset in range(recent_days):
         target = on_date - timedelta(days=offset)
         has_rows_for_day = AccountInsightsSnapshot.objects.filter(social_account=account, date=target).exists()
-        needs_current_follower_refresh = target == on_date and _needs_empty_follower_count_refresh(account)
-        if has_rows_for_day and not needs_current_follower_refresh:
+        needs_current_day_refetch = target == on_date and (force_today or _needs_empty_follower_count_refresh(account))
+        if has_rows_for_day and not needs_current_day_refetch:
             continue
         start = datetime.combine(target, time.min, tzinfo=tz)
         end = datetime.combine(target, time.max, tzinfo=tz)
@@ -652,7 +662,7 @@ def backfill_account_analytics(account_id: str, days: int | None = None) -> None
     today = timezone.now().date()
     cutoff = timezone.now() - timedelta(days=days)
 
-    _sync_account_metrics(account, today)
+    _sync_account_metrics(account, today, force_today=True)
 
     posts = PlatformPost.objects.filter(
         social_account=account,

--- a/apps/analytics/tests/test_signals.py
+++ b/apps/analytics/tests/test_signals.py
@@ -1,0 +1,192 @@
+"""Switching a platform on in ``AnalyticsPlatformConfig`` re-checks its accounts.
+
+The queueing lives in a signal rather than in ``AnalyticsPlatformConfigAdmin``
+so it covers every write path — a shell ``save()`` and ``update_or_create`` as
+well as the admin checkbox. (``queryset.update()`` fires no signals at all and
+is deliberately out of reach; the page copy promises nothing that depends on
+this running.)
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from apps.analytics.signals import BACKFILL_QUEUED_ATTR
+from apps.social_accounts.models import AnalyticsPlatformConfig, SocialAccount
+
+
+@pytest.fixture
+def workspace(db):
+    from apps.organizations.models import Organization
+    from apps.workspaces.models import Workspace
+
+    org = Organization.objects.create(name="Analytics Signals Org")
+    return Workspace.objects.create(organization=org, name="Analytics Signals WS")
+
+
+def _account(workspace, *, platform="instagram_login", status=SocialAccount.ConnectionStatus.CONNECTED):
+    return SocialAccount.objects.create(
+        workspace=workspace,
+        platform=platform,
+        account_platform_id=f"{platform}-{status}",
+        account_name="Pink Lion",
+        account_handle="pinklion.xyz",
+        oauth_access_token="token",
+        connection_status=status,
+    )
+
+
+def _set_enabled(platform, *, is_enabled):
+    """Write the row as it stands before the edit under test.
+
+    The handler still fires here, but its enqueue is deferred to commit and
+    nothing outside ``captureOnCommitCallbacks`` ever executes those callbacks
+    in a test — so arranging state can't leak a queued task into the assertion.
+    """
+    AnalyticsPlatformConfig.objects.update_or_create(platform=platform, defaults={"is_enabled": is_enabled})
+    return AnalyticsPlatformConfig.objects.get(platform=platform)
+
+
+def _toggle(platform, *, is_enabled):
+    """Flip the row through ``save()`` and return the patched backfill task.
+
+    ``captureOnCommitCallbacks`` runs the ``transaction.on_commit`` hook the
+    handler defers its enqueue to — without it the callback is discarded with
+    the test's rollback and nothing is ever queued.
+    """
+    from django.test import TestCase
+
+    config = AnalyticsPlatformConfig.objects.get(platform=platform)
+    config.is_enabled = is_enabled
+    with (
+        patch("apps.analytics.tasks.backfill_account_analytics") as backfill,
+        TestCase.captureOnCommitCallbacks(execute=True),
+    ):
+        config.save()
+    return backfill, config
+
+
+@pytest.mark.django_db(transaction=False)
+class TestPlatformEnableQueuesBackfill:
+    def test_switching_on_queues_each_connected_account_deduped(self, workspace):
+        account = _account(workspace)
+        _set_enabled("instagram_login", is_enabled=False)
+
+        backfill, config = _toggle("instagram_login", is_enabled=True)
+
+        backfill.assert_called_once_with(str(account.id), remove_existing_tasks=True)
+        assert getattr(config, BACKFILL_QUEUED_ATTR) == 1
+
+    def test_a_shell_update_or_create_queues_too(self, workspace):
+        """The reason this isn't in ``ModelAdmin.save_model``: non-admin writes."""
+        from django.test import TestCase
+
+        account = _account(workspace)
+        _set_enabled("instagram_login", is_enabled=False)
+
+        with (
+            patch("apps.analytics.tasks.backfill_account_analytics") as backfill,
+            TestCase.captureOnCommitCallbacks(execute=True),
+        ):
+            AnalyticsPlatformConfig.objects.update_or_create(
+                platform="instagram_login",
+                defaults={"is_enabled": True},
+            )
+
+        backfill.assert_called_once_with(str(account.id), remove_existing_tasks=True)
+
+    def test_a_platform_with_no_analytics_api_queues_nothing(self, workspace):
+        """``bluesky`` is listed in the admin but has no analytics API at all.
+
+        Queueing would insert a task per account that returns immediately from
+        ``backfill_account_analytics``'s own availability check.
+        """
+        _account(workspace, platform="bluesky")
+        _set_enabled("bluesky", is_enabled=False)
+
+        backfill, config = _toggle("bluesky", is_enabled=True)
+
+        backfill.assert_not_called()
+        assert not hasattr(config, BACKFILL_QUEUED_ATTR)
+
+    def test_a_disconnected_account_is_left_alone(self, workspace):
+        _account(workspace, status=SocialAccount.ConnectionStatus.DISCONNECTED)
+        _set_enabled("instagram_login", is_enabled=False)
+
+        backfill, config = _toggle("instagram_login", is_enabled=True)
+
+        backfill.assert_not_called()
+        assert getattr(config, BACKFILL_QUEUED_ATTR) == 0
+
+    def test_accounts_on_other_platforms_are_left_alone(self, workspace):
+        _account(workspace, platform="facebook")
+        _set_enabled("instagram_login", is_enabled=False)
+
+        backfill, _ = _toggle("instagram_login", is_enabled=True)
+
+        backfill.assert_not_called()
+
+    def test_resaving_an_already_enabled_row_queues_nothing(self, workspace):
+        _account(workspace)
+        _set_enabled("instagram_login", is_enabled=True)
+
+        backfill, config = _toggle("instagram_login", is_enabled=True)
+
+        backfill.assert_not_called()
+        assert not hasattr(config, BACKFILL_QUEUED_ATTR)
+
+    def test_switching_a_platform_off_queues_nothing(self, workspace):
+        _account(workspace)
+        _set_enabled("instagram_login", is_enabled=True)
+
+        backfill, _ = _toggle("instagram_login", is_enabled=False)
+
+        backfill.assert_not_called()
+        assert AnalyticsPlatformConfig.objects.get(platform="instagram_login").is_enabled is False
+
+    def test_creating_a_row_is_not_a_transition(self, workspace):
+        """A platform with no row already reads as enabled, so writing the first
+        row with ``is_enabled=True`` states the status quo rather than changing it.
+
+        The connected account is on the same platform as the row being created,
+        so this fails if ``created`` stops being skipped — a distractor account
+        on some other platform would pass either way.
+        """
+        from django.test import TestCase
+
+        _account(workspace, platform="threads")
+        AnalyticsPlatformConfig.objects.filter(platform="threads").delete()
+
+        with (
+            patch("apps.analytics.tasks.backfill_account_analytics") as backfill,
+            TestCase.captureOnCommitCallbacks(execute=True),
+        ):
+            AnalyticsPlatformConfig.objects.create(platform="threads", is_enabled=True)
+
+        backfill.assert_not_called()
+
+    def test_nothing_is_queued_when_the_save_rolls_back(self, workspace):
+        """The enqueue is deferred to commit, so an aborted save queues nothing.
+
+        ``captureOnCommitCallbacks`` wraps the rollback rather than sitting
+        inside it: it executes whatever survived, so the assertion fails if the
+        callback outlives the transaction instead of passing vacuously.
+        """
+        from django.db import transaction
+        from django.test import TestCase
+
+        _account(workspace)
+        _set_enabled("instagram_login", is_enabled=False)
+
+        config = AnalyticsPlatformConfig.objects.get(platform="instagram_login")
+        config.is_enabled = True
+        with (
+            patch("apps.analytics.tasks.backfill_account_analytics") as backfill,
+            TestCase.captureOnCommitCallbacks(execute=True),
+            pytest.raises(RuntimeError),
+            transaction.atomic(),
+        ):
+            config.save()
+            raise RuntimeError("boom")
+
+        backfill.assert_not_called()

--- a/apps/analytics/tests/test_tasks.py
+++ b/apps/analytics/tests/test_tasks.py
@@ -201,6 +201,75 @@ def test_sync_account_metrics_refreshes_empty_follower_count_when_today_rows_exi
 
 
 @pytest.mark.django_db
+def test_sync_account_metrics_refetches_today_when_forced(workspace):
+    """A one-shot backfill must call the provider even when today's rows exist.
+
+    The fetch is the only thing that surfaces an insufficient-scope error and
+    sets ``analytics_needs_reconnect``. Without ``force_today``, re-enabling a
+    platform on the same day it last synced finds today's rows present, skips
+    every offset, never calls the provider, and reports success for a token
+    that cannot read insights.
+    """
+    from datetime import date, timedelta
+    from unittest.mock import MagicMock, patch
+
+    from apps.analytics.models import AccountInsightsSnapshot
+    from apps.analytics.tasks import _sync_account_metrics
+    from providers.types import AccountMetrics
+
+    account = SocialAccount.objects.create(
+        workspace=workspace,
+        platform="instagram_login",
+        account_platform_id="ig-direct-1",
+        account_name="Direct IG",
+        follower_count=500,  # non-zero, so the follower-refresh override can't be what re-fetches
+        oauth_access_token="token",
+        connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+    )
+    today = date(2026, 6, 24)
+    for offset in range(3):  # every day _sync_account_metrics would walk
+        AccountInsightsSnapshot.objects.create(
+            social_account=account,
+            date=today - timedelta(days=offset),
+            metric_key="reach",
+            value=10,
+        )
+    fake_provider = MagicMock()
+    fake_provider.account_metrics_supports_date_range = True
+    fake_provider.get_account_metrics.return_value = AccountMetrics(reach=42, followers=500)
+
+    with patch("apps.analytics.tasks._resolve_provider", return_value=fake_provider):
+        _sync_account_metrics(account, today)
+        assert fake_provider.get_account_metrics.call_count == 0
+
+        _sync_account_metrics(account, today, force_today=True)
+        assert fake_provider.get_account_metrics.call_count == 1
+
+
+@pytest.mark.django_db
+def test_backfill_forces_todays_refetch(workspace):
+    """``backfill_account_analytics`` is the one-shot path, so it forces."""
+    from unittest.mock import patch
+
+    from apps.analytics.tasks import backfill_account_analytics
+
+    account = SocialAccount.objects.create(
+        workspace=workspace,
+        platform="instagram_login",
+        account_platform_id="ig-direct-2",
+        account_name="Direct IG",
+        oauth_access_token="token",
+        connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+    )
+    AnalyticsPlatformConfig.objects.update_or_create(platform="instagram_login", defaults={"is_enabled": True})
+
+    with patch("apps.analytics.tasks._sync_account_metrics") as sync:
+        backfill_account_analytics.now(str(account.id))
+
+    assert sync.call_args.kwargs["force_today"] is True
+
+
+@pytest.mark.django_db
 def test_resolve_provider_carries_instagram_login_credentials(workspace):
     """``_resolve_provider`` was a hand-copy of the publish engine's resolver and
     had drifted: no ``instagram_login`` branch, so Instagram Direct providers

--- a/apps/analytics/tests/test_views.py
+++ b/apps/analytics/tests/test_views.py
@@ -78,10 +78,9 @@ def test_instagram_direct_account_is_listed_and_available(owner_client, workspac
 def test_disabled_platform_account_stays_listed_with_a_reason(owner_client, workspace):
     """The reported bug: the account vanished from the switcher entirely.
 
-    It must still be listed, and selecting it must explain both that analytics
-    is off for the platform and that reconnecting is needed once it's back on —
-    the insights scope is requested at connect time, so flipping the admin
-    toggle alone leaves the stored token unable to read insights.
+    It must still be listed, and selecting it must carry the admin note saying
+    where the platform is switched on. Anchored on the note's id rather than its
+    prose so the copy can be reworded without touching this test.
     """
     account = _account(workspace, "instagram_login", "Direct IG")
     _disable_analytics("instagram_login")
@@ -94,7 +93,7 @@ def test_disabled_platform_account_stays_listed_with_a_reason(owner_client, work
     assert response.context["analytics_disabled_by_admin"] is True
     assert response.context["accounts"][0].analytics_unavailable_reason
     body = response.content.decode()
-    assert "Reconnect this account" in body
+    assert 'id="analytics-disabled-admin-note"' in body
     # The switcher marks it rather than listing it indistinguishably.
     assert "No data" in body
 

--- a/apps/social_accounts/admin.py
+++ b/apps/social_accounts/admin.py
@@ -1,4 +1,8 @@
-from django.contrib import admin
+from django.contrib import admin, messages
+
+# Safe at module scope: signals.py imports no background_task at module level,
+# and admin autodiscover runs after every app's models are loaded.
+from apps.analytics.signals import BACKFILL_QUEUED_ATTR
 
 from .models import AnalyticsPlatformConfig, MastodonAppRegistration, PlatformVisibility, SocialAccount
 
@@ -51,3 +55,23 @@ class AnalyticsPlatformConfigAdmin(admin.ModelAdmin):
 
     def has_delete_permission(self, request, obj=None):
         return False
+
+    def save_model(self, request, obj, form, change):
+        """Report the re-check that switching a platform on set in motion.
+
+        The queueing itself lives in ``apps.analytics.signals`` so it also
+        covers writes that never reach the admin (a shell ``save()``,
+        ``update_or_create``). This only surfaces the count it recorded, so an
+        operator ticking the box learns the save did something beyond flipping
+        a flag. Nothing queued (already enabled, no connected accounts, or a
+        platform with no analytics API) means nothing to report.
+        """
+        super().save_model(request, obj, form, change)
+        queued = getattr(obj, BACKFILL_QUEUED_ATTR, 0)
+        if queued:
+            messages.info(
+                request,
+                f"Queued an analytics backfill for {queued} connected "
+                f"{obj.get_platform_display()} account(s). Any whose connection predates this "
+                f"may need reconnecting before insights can be read.",
+            )

--- a/apps/social_accounts/tests/test_admin.py
+++ b/apps/social_accounts/tests/test_admin.py
@@ -1,0 +1,115 @@
+"""Tests for the social_accounts admin.
+
+``AnalyticsPlatformConfigAdmin`` no longer decides anything about the analytics
+backfill — that lives in ``apps.analytics.signals`` so non-admin writes are
+covered too (see ``apps/analytics/tests/test_signals.py``). What is left here is
+operator feedback: ticking the box must say what it set in motion, rather than
+looking like it only flipped a flag.
+"""
+
+from unittest.mock import patch
+
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.contrib.messages import get_messages
+from django.contrib.messages.middleware import MessageMiddleware
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.test import RequestFactory
+
+from apps.social_accounts.admin import AnalyticsPlatformConfigAdmin
+from apps.social_accounts.models import AnalyticsPlatformConfig, SocialAccount
+
+
+@pytest.fixture
+def workspace(db):
+    from apps.organizations.models import Organization
+    from apps.workspaces.models import Workspace
+
+    org = Organization.objects.create(name="Admin Test Org")
+    return Workspace.objects.create(organization=org, name="Admin Test WS")
+
+
+@pytest.fixture
+def model_admin():
+    return AnalyticsPlatformConfigAdmin(AnalyticsPlatformConfig, AdminSite())
+
+
+@pytest.fixture
+def request_with_messages():
+    """A real request carrying the messages framework, not a stub.
+
+    The message is the whole point of ``save_model``, so it has to be readable
+    back — patching ``messages`` out would leave every assertion below vacuous.
+    """
+    request = RequestFactory().post("/admin/social_accounts/analyticsplatformconfig/")
+    SessionMiddleware(lambda r: None).process_request(request)
+    MessageMiddleware(lambda r: None).process_request(request)
+    return request
+
+
+def _account(workspace, *, platform="instagram_login"):
+    return SocialAccount.objects.create(
+        workspace=workspace,
+        platform=platform,
+        account_platform_id=f"{platform}-1",
+        account_name="Pink Lion",
+        account_handle="pinklion.xyz",
+        oauth_access_token="token",
+        connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+    )
+
+
+def _save(model_admin, request, platform, *, is_enabled):
+    """Drive ``save_model`` the way the changelist's ``list_editable`` does."""
+    config = AnalyticsPlatformConfig.objects.get(platform=platform)
+    config.is_enabled = is_enabled
+    with patch("apps.analytics.tasks.backfill_account_analytics"):
+        model_admin.save_model(request, config, form=None, change=True)
+    return [str(m) for m in get_messages(request)]
+
+
+@pytest.mark.django_db
+class TestAnalyticsPlatformConfigAdminSaveModel:
+    def test_switching_on_reports_what_was_queued(self, workspace, model_admin, request_with_messages):
+        _account(workspace)
+        AnalyticsPlatformConfig.objects.update_or_create(platform="instagram_login", defaults={"is_enabled": False})
+
+        sent = _save(model_admin, request_with_messages, "instagram_login", is_enabled=True)
+
+        assert len(sent) == 1
+        assert "1 connected Instagram (Direct) account(s)" in sent[0]
+        assert "may need reconnecting" in sent[0]
+        assert AnalyticsPlatformConfig.objects.get(platform="instagram_login").is_enabled is True
+
+    def test_no_connected_accounts_says_nothing(self, workspace, model_admin, request_with_messages):
+        AnalyticsPlatformConfig.objects.update_or_create(platform="instagram_login", defaults={"is_enabled": False})
+
+        sent = _save(model_admin, request_with_messages, "instagram_login", is_enabled=True)
+
+        assert sent == []
+
+    def test_resaving_an_already_enabled_row_says_nothing(self, workspace, model_admin, request_with_messages):
+        _account(workspace)
+        AnalyticsPlatformConfig.objects.update_or_create(platform="instagram_login", defaults={"is_enabled": True})
+
+        sent = _save(model_admin, request_with_messages, "instagram_login", is_enabled=True)
+
+        assert sent == []
+
+    def test_switching_off_says_nothing(self, workspace, model_admin, request_with_messages):
+        _account(workspace)
+        AnalyticsPlatformConfig.objects.update_or_create(platform="instagram_login", defaults={"is_enabled": True})
+
+        sent = _save(model_admin, request_with_messages, "instagram_login", is_enabled=False)
+
+        assert sent == []
+        assert AnalyticsPlatformConfig.objects.get(platform="instagram_login").is_enabled is False
+
+    def test_a_platform_with_no_analytics_api_says_nothing(self, workspace, model_admin, request_with_messages):
+        """Nothing is queued for Bluesky, so there is nothing to claim."""
+        _account(workspace, platform="bluesky")
+        AnalyticsPlatformConfig.objects.update_or_create(platform="bluesky", defaults={"is_enabled": False})
+
+        sent = _save(model_admin, request_with_messages, "bluesky", is_enabled=True)
+
+        assert sent == []

--- a/apps/social_accounts/views.py
+++ b/apps/social_accounts/views.py
@@ -54,8 +54,12 @@ def _apply_analytics_scope_flag(provider, platform):
     ``yt-analytics.readonly``) to the OAuth scope list only when this flag is
     True. If the platform is disabled in ``AnalyticsPlatformConfig`` (analytics
     not yet rolled out for it), we omit those scopes so a self-hoster whose
-    Meta / TikTok / Google app hasn't been approved for them can still connect
-    accounts for publishing.
+    Facebook / TikTok / Google app hasn't been approved for them can still
+    connect accounts for publishing.
+
+    A no-op for ``instagram`` and ``instagram_login``, which both request their
+    insights scope unconditionally — see ``SocialProvider.analytics_only_scopes``
+    for why deferring it there did more harm than good.
     """
     from apps.social_accounts.models import AnalyticsPlatformConfig
 

--- a/providers/base.py
+++ b/providers/base.py
@@ -82,8 +82,19 @@ class SocialProvider(ABC):
 
         These are conditionally excluded from the OAuth init flow when the
         platform's analytics is disabled in ``AnalyticsPlatformConfig`` — so
-        a self-hoster whose Meta / TikTok app hasn't yet been approved for
-        the analytics scope can still connect accounts for publishing.
+        a self-hoster whose Facebook / TikTok / Google app hasn't yet been
+        approved for the analytics scope can still connect accounts for
+        publishing. Honored by ``facebook``, ``tiktok`` and ``youtube``.
+
+        NOT honored by ``instagram_login``, which lists
+        ``instagram_business_manage_insights`` in ``required_scopes``
+        unconditionally (as ``instagram`` has always done with
+        ``instagram_manage_insights``): the grant is frozen at connect time
+        while this toggle can flip afterwards, so deferring the scope minted
+        tokens that could never read insights once analytics was switched on.
+        The cost of that choice is that an Instagram app without the
+        permission added under *Permissions and features* now sees it on the
+        authorize URL — see the Instagram (Direct) setup steps in the README.
 
         Providers without analytics-specific scopes return the default `[]`.
         """

--- a/providers/instagram_login.py
+++ b/providers/instagram_login.py
@@ -126,21 +126,22 @@ class InstagramLoginProvider(SocialProvider):
 
     @property
     def required_scopes(self) -> list[str]:
-        scopes = [
+        return [
             "instagram_business_basic",
             "instagram_business_content_publish",
             "instagram_business_manage_comments",
             "instagram_business_manage_messages",
+            # Required for the `/insights` endpoints, and requested
+            # unconditionally rather than through ``analytics_only_scopes``.
+            # An OAuth grant is frozen at connect time while the
+            # AnalyticsPlatformConfig toggle it was gated on can flip
+            # afterwards, so gating it minted tokens that could never read
+            # insights once analytics was switched on — the account had to be
+            # reconnected, with nothing but an empty page to say so. Mirrors
+            # providers/instagram.py, which has always asked for
+            # instagram_manage_insights on the Facebook-Page path.
+            "instagram_business_manage_insights",
         ]
-        if self.include_analytics_scopes:
-            scopes.extend(self.analytics_only_scopes)
-        return scopes
-
-    @property
-    def analytics_only_scopes(self) -> list[str]:
-        # Required for `/insights` endpoints on the IG-Login OAuth path.
-        # Only requested when analytics is enabled in AnalyticsPlatformConfig.
-        return ["instagram_business_manage_insights"]
 
     @property
     def rate_limits(self) -> RateLimitConfig:

--- a/templates/analytics/_no_analytics_state.html
+++ b/templates/analytics/_no_analytics_state.html
@@ -16,16 +16,21 @@
         {% comment %}
         Admin-disabled, not an API limitation — so unlike the LinkedIn Personal
         / Bluesky / Mastodon copy above, there is something to do about it.
-        The reconnect matters: the insights scope is requested at connect time
-        based on this same toggle, so a token granted while it was off can't
-        read insights even once it's back on. ({# #} is single-line only in
-        Django — a multi-line one renders as visible page text.)
+        "May need reconnecting" rather than a promise that this page will offer
+        the button: whether the stored token can read insights depends on the
+        platform (Instagram Direct now always asks for the scope; Facebook /
+        TikTok / YouTube still gate theirs on this toggle), and the re-check
+        that surfaces the Reconnect banner is a background task — it doesn't
+        run if the worker is down, and a bulk queryset.update() of the toggle
+        fires no signal at all. Advice that holds in every one of those cases
+        beats advice that is usually superseded. The id is what the view test
+        anchors on, so this copy can be reworded freely. ({# #} is single-line
+        only in Django — a multi-line one renders as visible page text.)
         {% endcomment %}
-        <p style="font-size: 0.875rem; color: var(--text-tertiary); line-height: 1.6; margin-top: 12px;">
+        <p id="analytics-disabled-admin-note" style="font-size: 0.875rem; color: var(--text-tertiary); line-height: 1.6; margin-top: 12px;">
             An administrator can switch it on under <strong>Analytics platforms</strong> in the
-            Django admin. Reconnect this account afterwards — the analytics permission is
-            requested when the account connects, so the current connection can't read insights
-            until it's granted.
+            Django admin. If this account connected while it was off, it may also need
+            reconnecting before insights can be read.
         </p>
         {% endif %}
         <div style="margin-top: 28px; display: flex; gap: 10px; justify-content: center;">

--- a/tests/providers/test_instagram.py
+++ b/tests/providers/test_instagram.py
@@ -1,5 +1,6 @@
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, call
+from urllib.parse import parse_qs, urlparse
 
 import pytest
 
@@ -210,6 +211,30 @@ def test_instagram_media_metrics_use_current_metrics_and_field_fallbacks():
     assert metrics.saves == 5
     assert metrics.shares == 2
     assert metrics.extra["total_interactions"] == 22
+
+
+def test_instagram_login_always_requests_the_insights_scope():
+    """The insights scope is not gated on ``include_analytics_scopes``.
+
+    An OAuth grant is frozen at connect time, but the AnalyticsPlatformConfig
+    toggle the flag is derived from can flip afterwards — so a token minted while
+    analytics was off could never read ``/insights`` once it was switched back on,
+    however the Meta app's own permissions were configured.
+    """
+    provider = InstagramLoginProvider({"client_id": "id", "client_secret": "secret"})
+    provider.include_analytics_scopes = False
+
+    assert "instagram_business_manage_insights" in provider.required_scopes
+
+
+def test_instagram_login_auth_url_carries_the_insights_scope():
+    provider = InstagramLoginProvider({"client_id": "id", "client_secret": "secret"})
+    provider.include_analytics_scopes = False
+
+    url = provider.get_auth_url("https://studio.example/callback", "state-1")
+
+    scope = parse_qs(urlparse(url).query)["scope"][0]
+    assert "instagram_business_manage_insights" in scope.split(",")
 
 
 def test_instagram_login_account_metrics_use_current_insights_metrics():


### PR DESCRIPTION
## What does this PR do?

Makes `instagram_business_manage_insights` an unconditional scope for the Instagram (Direct) connector, and makes switching a platform on in **Analytics platforms** re-check the accounts already connected to it.

## Why?

An Instagram Business account connected via Instagram (Direct) showed *"Analytics aren't available for Instagram (Direct)"* even with `instagram_business_manage_insights` approved on the Meta app. Two independent causes:

1. **The platform was switched off in the admin.** That copy is the `CAUSE_DISABLED` branch of `analytics_availability()`, which fires only for an `AnalyticsPlatformConfig` row with `is_enabled=False`. That's a deployment setting and stays one — no migration flips it here.

2. **The insights scope was never on the token.** It was only added to the authorize URL when that *same* toggle was on. An OAuth grant is frozen at connect time while the toggle can flip afterwards, so an account connected while analytics was off carried a token that could never read `/insights` — no matter how the Meta app was configured. Approving the permission in the Meta dashboard genuinely did nothing, which is what made this confusing.

`providers/instagram.py` has always requested `instagram_manage_insights` unconditionally on the Facebook-Page path; the Direct connector now matches. **The trade-off, recorded in `SocialProvider.analytics_only_scopes`:** an Instagram app that hasn't added the permission under *Permissions and features* will now see it on the authorize URL. Facebook, TikTok and YouTube keep the conditional gate, where app review is still a real constraint.

The second half closes the window where enabling a platform changed nothing visible until the hourly cron happened to run, fail on scope, and set `analytics_needs_reconnect`. The re-check lives in a `post_save` receiver rather than `ModelAdmin.save_model`, so a shell `save()` and `update_or_create` are covered too; it skips `created` (a first row states the status quo — a missing row already reads as enabled), skips platforms in `NO_ANALYTICS_PLATFORMS` via the shared `services.analytics_availability` predicate, dedupes, and defers the enqueue to commit.

`backfill_account_analytics` now forces today's re-fetch: `_sync_account_metrics` skips days that already have a snapshot, so a platform re-enabled on the same day it last synced never called the provider and reported success for a token that couldn't read insights. That fetch is the only thing that surfaces an insufficient-scope error.

The disabled-state copy now says the account *"may also need reconnecting"* rather than promising a Reconnect button — that promise held only where the toggle was flipped through a signal-firing path *and* a worker was up to run the task.

## How to test

Automated: `pytest` (1440 passing). New cover in `apps/analytics/tests/test_signals.py` (9 cases), rewritten `apps/social_accounts/tests/test_admin.py` using `RequestFactory` with real messages storage, plus two `force_today` regression tests in `apps/analytics/tests/test_tasks.py`.

The four new guards were mutation-checked rather than trusted green — removing the availability gate, un-skipping `created`, dropping `force_today`, and swapping `transaction.on_commit` for a direct call each fail exactly one test.

End-to-end, after deploy:

1. Django admin → **Analytics platforms** → tick `instagram_login` → Save. Expect an info message naming the queued account(s).
2. Open the analytics page for that account. The "aren't available" state should be gone; the amber **Reconnect for analytics** banner appears once the worker runs the backfill (the stored token predates the scope).
3. Click **Reconnect**. The Instagram consent screen should now list the insights permission. Approve — `analytics_needs_reconnect` clears and a 90-day backfill runs.
4. If the queue is slow: `python manage.py backfill_analytics --account-id <uuid>`. To isolate the API side: `python manage.py instagram_review_test_calls`.

## Checklist

- [x] Tests pass (`pytest`) — 1440 passed
- [x] Lint passes (`ruff check .` and `ruff format --check .`)
- [x] Documentation updated (if applicable) — `SocialProvider.analytics_only_scopes` and `_apply_analytics_scope_flag` docstrings now name which providers honor the gate and why Instagram Direct opts out; README already listed the permission as required

🤖 Generated with [Claude Code](https://claude.com/claude-code)
