### PR TITLE
feat(social-accounts): add insights-only mode to the IG review test calls

### DIFF
--- a/apps/social_accounts/management/commands/instagram_review_test_calls.py
+++ b/apps/social_accounts/management/commands/instagram_review_test_calls.py
@@ -13,6 +13,12 @@ Usage:
     python manage.py instagram_review_test_calls \
         --account-id <uuid> \
         --image-url https://example.com/test.jpg
+
+To re-fire only the insights calls against a post that already exists (no new
+post, no new comment):
+
+    python manage.py instagram_review_test_calls \
+        --account-id <uuid> --insights-only
 """
 
 from __future__ import annotations
@@ -37,8 +43,22 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--image-url",
-            required=True,
-            help="Public HTTPS URL of an image Meta can fetch (JPEG/PNG). Localhost or short-TTL signed URLs will not work.",
+            help=(
+                "Public HTTPS URL of an image Meta can fetch (JPEG/PNG). Localhost or short-TTL signed URLs will "
+                "not work. Required unless --insights-only is given."
+            ),
+        )
+        parser.add_argument(
+            "--insights-only",
+            action="store_true",
+            help=(
+                "Skip publishing and commenting; fire only the insights calls against an existing post "
+                "(--media-id, or the account's most recent post)."
+            ),
+        )
+        parser.add_argument(
+            "--media-id",
+            help="Existing IG media id to read post insights for. Only used with --insights-only.",
         )
         parser.add_argument(
             "--caption",
@@ -61,6 +81,33 @@ class Command(BaseCommand):
             help="Skip the comment call (use if instagram_business_manage_comments is already verified).",
         )
 
+    def _latest_media_id(self, provider, token: str) -> str:
+        """Newest post on the account, for --insights-only runs without --media-id."""
+        from providers.instagram_login import API_BASE
+
+        try:
+            payload = provider._request(
+                "GET",
+                f"{API_BASE}/me/media",
+                access_token=token,
+                params={"fields": "id,media_type,timestamp,permalink", "limit": 1},
+            ).json()
+        except Exception as exc:
+            raise CommandError(f"Could not list the account's media to pick a post: {exc}") from exc
+
+        items = payload.get("data") or []
+        if not items:
+            raise CommandError(
+                "The account has no posts to read insights for. Publish one first (drop --insights-only) "
+                "or pass --media-id."
+            )
+        newest = items[0]
+        self.stdout.write(
+            f"  · newest post: {newest.get('media_type')} from {newest.get('timestamp')} "
+            f"({newest.get('permalink') or newest['id']})"
+        )
+        return newest["id"]
+
     def handle(self, *args, **opts):
         from apps.analytics.tasks import _resolve_provider  # mirror credential resolution
         from apps.social_accounts.models import SocialAccount
@@ -70,6 +117,13 @@ class Command(BaseCommand):
         image_url = opts["image_url"]
         caption = opts["caption"]
         comment_text = opts["comment"]
+        insights_only = opts["insights_only"]
+
+        if insights_only:
+            if opts["skip_insights"]:
+                raise CommandError("--insights-only and --skip-insights cancel each other out.")
+        elif not image_url:
+            raise CommandError("--image-url is required unless you pass --insights-only.")
 
         try:
             account = SocialAccount.objects.get(id=account_id)
@@ -99,21 +153,29 @@ class Command(BaseCommand):
         # ------------------------------------------------------------------
         # 1. instagram_business_content_publish — publish_post()
         # ------------------------------------------------------------------
-        self.stdout.write("  • Publishing test image (this may take 3–8 seconds while Meta fetches the URL)…")
-        content = PublishContent(
-            text=caption,
-            media_urls=[image_url],
-            post_type=PostType.IMAGE,
-        )
-        try:
-            result = provider.publish_post(token, content)
-        except Exception as exc:
-            raise CommandError(f"publish_post failed: {exc}") from exc
-        media_id = result.platform_post_id
-        permalink = result.url or f"https://www.instagram.com/p/{media_id}/"
-        self.stdout.write(
-            self.style.SUCCESS(f"  ✓ instagram_business_content_publish — media_id={media_id}  permalink={permalink}")
-        )
+        published = False
+        if insights_only:
+            media_id = opts["media_id"] or self._latest_media_id(provider, token)
+            self.stdout.write(f"  - skipping publish (--insights-only); reading insights for media_id={media_id}")
+        else:
+            self.stdout.write("  • Publishing test image (this may take 3–8 seconds while Meta fetches the URL)…")
+            content = PublishContent(
+                text=caption,
+                media_urls=[image_url],
+                post_type=PostType.IMAGE,
+            )
+            try:
+                result = provider.publish_post(token, content)
+            except Exception as exc:
+                raise CommandError(f"publish_post failed: {exc}") from exc
+            media_id = result.platform_post_id
+            permalink = result.url or f"https://www.instagram.com/p/{media_id}/"
+            published = True
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"  ✓ instagram_business_content_publish — media_id={media_id}  permalink={permalink}"
+                )
+            )
 
         # ------------------------------------------------------------------
         # 2. instagram_business_manage_insights — get_post_metrics() + get_account_metrics()
@@ -137,17 +199,23 @@ class Command(BaseCommand):
             self.stdout.write(
                 self.style.SUCCESS(
                     f"  ✓ instagram_business_manage_insights — "
-                    f"post(reach={post_metrics.reach}, views={post_metrics.impressions}, "
+                    f"post(reach={post_metrics.reach}, views={post_metrics.video_views}, "
                     f"likes={post_metrics.likes}, comments={post_metrics.comments}, saves={post_metrics.saves}); "
                     f"account(followers={account_metrics.followers}, reach={account_metrics.reach})"
                 )
             )
+            # Per-metric failures are swallowed by fetch_insights_safe so one bad
+            # metric can't sink the rest — surface them, since a run where every
+            # metric errored still prints zeros above and looks like a success.
+            for label, metrics in (("post", post_metrics), ("account", account_metrics)):
+                for metric, error in (metrics.extra.get("insight_errors") or {}).items():
+                    self.stdout.write(self.style.WARNING(f"    ! {label} metric {metric!r} failed: {error}"))
 
         # ------------------------------------------------------------------
         # 3. instagram_business_manage_comments — publish_comment()
         # ------------------------------------------------------------------
-        if opts["skip_comment"]:
-            self.stdout.write("  - skipping comment call (--skip-comment)")
+        if insights_only or opts["skip_comment"]:
+            self.stdout.write("  - skipping comment call")
         else:
             self.stdout.write("  • Posting a comment on the new post…")
             try:
@@ -166,4 +234,5 @@ class Command(BaseCommand):
             "Check the Meta App Review dashboard — the touched permissions should flip to 'API call verified' "
             "within a minute or two."
         )
-        self.stdout.write(f"You may want to delete the test post manually from Instagram: {permalink}")
+        if published:
+            self.stdout.write(f"You may want to delete the test post manually from Instagram: {permalink}")

--- a/apps/social_accounts/models.py
+++ b/apps/social_accounts/models.py
@@ -360,6 +360,12 @@ class AnalyticsPlatformConfig(models.Model):
     )
     updated_at = models.DateTimeField(auto_now=True)
 
+    # Not a column: ``apps.analytics.signals.stash_previous_enabled`` writes the
+    # stored ``is_enabled`` here on pre_save so post_save can spot an off → on
+    # flip. Declared so that write type-checks; ``None`` means "not stashed",
+    # which is what the post_save reader already defaults to.
+    _previously_enabled: bool | None = None
+
     class Meta:
         db_table = "social_accounts_analytics_platform_config"
         verbose_name = "Analytics platform"


### PR DESCRIPTION
## Why

Meta App Review needs one verified API call for `instagram_business_manage_insights` on the Instagram Direct connector. `instagram_review_test_calls` could fire that call, but only after publishing a post — so re-running it to satisfy a single outstanding permission meant leaving another throwaway post on the account.

`backfill_analytics` isn't a substitute: `backfill_account_analytics` is `@background(schedule=0)`, so the command only enqueues, and it's gated on `AnalyticsPlatformConfig.enabled_platforms()`.

## What

- `--insights-only` skips the publish and comment steps and reads insights for an existing post. `--media-id` names one explicitly; otherwise `_latest_media_id()` pulls the newest post via `/me/media?limit=1` and prints which one it picked.
- `--image-url` is now required only when actually publishing.
- Per-metric insight failures print as warnings. `fetch_insights_safe` swallows non-permission errors, so a run where every metric 400'd still printed a green ✓ line with zeros — during App Review that's exactly the failure you don't want to miss. Genuine scope errors still raise.
- Fixed the success line reading `post_metrics.impressions`, which the Instagram Login provider never populates (it writes views into `video_views`), so it always printed `views=0`.

```bash
python manage.py instagram_review_test_calls --account-id <uuid> --insights-only
```

## Testing

`ruff check` and `ruff format --check` pass. Argument parsing and the new validation errors were exercised via `manage.py`; the live Meta calls were not run from this branch — that happens against the connected production account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)