### PR TITLE
fix(youtube): fetch the real subscriber total independent of Analytics lag

### DIFF
--- a/providers/youtube.py
+++ b/providers/youtube.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from urllib.parse import urlencode
 
 from .base import SocialProvider
-from .exceptions import OAuthError, PublishError
+from .exceptions import APIError, OAuthError, PublishError
 from .types import (
     AccountMetrics,
     AccountProfile,
@@ -487,13 +487,22 @@ class YouTubeProvider(SocialProvider):
         )
 
     def get_account_metrics(self, access_token: str, date_range: tuple[datetime, datetime]) -> AccountMetrics:
-        """Channel-level metrics from the YouTube Analytics API.
+        """Channel-level metrics: the real subscriber total plus Analytics extras.
 
-        Fetches the metrics the YouTube Data API can't provide per-video:
-        watch time, average view %, subscribers gained, and shares.
-        Views/likes/comments come from per-post snapshots so the main page
-        stays consistent with the per-post drawer; shares is the exception
-        because ``videos.list?part=statistics`` exposes no shareCount field.
+        ``followers`` comes from ``channels.list?part=statistics`` — a live
+        point-in-time count independent of ``date_range`` — rather than the
+        Analytics API, which typically lags 1–2 days behind real-time and
+        returns no rows at all for a channel with no activity yet today. The
+        statistics fetch happens first and stands on its own: an Analytics
+        failure (or an empty-rows day) must not cost the caller the
+        subscriber total it already has.
+
+        The rest of ``extra`` — watch time, average view %, subscribers
+        gained, and shares — still comes from the Analytics ``/reports``
+        endpoint, unchanged. Views/likes/comments come from per-post
+        snapshots so the main page stays consistent with the per-post
+        drawer; shares is the exception because ``videos.list?part=statistics``
+        exposes no shareCount field.
 
         Per-video equivalents of the channel-level watch-time / avg-view-% /
         shares triple come from :meth:`get_post_analytics`, which calls the
@@ -505,27 +514,41 @@ class YouTubeProvider(SocialProvider):
         it as a single day's snapshot. Larger ranges would silently collapse
         into one cell.
 
-        Requires the ``yt-analytics.readonly`` scope. The YouTube Analytics
-        API typically lags 1–2 days behind real-time.
+        Requires the ``yt-analytics.readonly`` scope for the Analytics half.
+        An auth/scope failure on the ``/reports`` call still propagates —
+        that's the only thing that surfaces to the sync layer's
+        ``_is_insufficient_scope`` check and flags the account for
+        reconnect — but any other Analytics failure is recorded in
+        ``extra["insight_errors"]`` and degrades to followers-only, per the
+        same convention as the other Meta-family providers' insights calls.
         """
+        followers = self._fetch_subscriber_count(access_token)
+
         start_date = date_range[0].date().isoformat()
         end_date = date_range[1].date().isoformat()
-        resp = self._request(
-            "GET",
-            f"{ANALYTICS_BASE}/reports",
-            access_token=access_token,
-            params={
-                "ids": "channel==MINE",
-                "startDate": start_date,
-                "endDate": end_date,
-                "metrics": "estimatedMinutesWatched,averageViewPercentage,subscribersGained,shares",
-            },
-        )
+        try:
+            resp = self._request(
+                "GET",
+                f"{ANALYTICS_BASE}/reports",
+                access_token=access_token,
+                params={
+                    "ids": "channel==MINE",
+                    "startDate": start_date,
+                    "endDate": end_date,
+                    "metrics": "estimatedMinutesWatched,averageViewPercentage,subscribersGained,shares",
+                },
+            )
+        except APIError as exc:
+            if exc.status_code in (401, 403):
+                raise
+            logger.warning("YouTube Analytics /reports failed: %s", exc)
+            return AccountMetrics(followers=followers, extra={"insight_errors": {"reports": str(exc)}})
+
         body = resp.json()
         headers = body.get("columnHeaders", [])
         rows = body.get("rows", [])
         if not rows or not rows[0]:
-            return AccountMetrics()
+            return AccountMetrics(followers=followers)
 
         index = {col.get("name", ""): i for i, col in enumerate(headers)}
         row = rows[0]
@@ -555,7 +578,33 @@ class YouTubeProvider(SocialProvider):
             v = _value_or_none(api_key)
             if v is not None:
                 extra[catalog_key] = v
-        return AccountMetrics(extra=extra)
+        return AccountMetrics(followers=followers, extra=extra)
+
+    def _fetch_subscriber_count(self, access_token: str) -> int | None:
+        """Current subscriber total from ``channels.list``.
+
+        Returns ``None`` (not 0) on failure or an unreadable response, so a
+        transient error doesn't overwrite a known-good total with a
+        fabricated zero — ``_account_metrics_to_dict`` already skips a
+        ``None`` followers value rather than writing a spurious 0 snapshot.
+        """
+        try:
+            resp = self._request(
+                "GET",
+                f"{API_BASE}/channels",
+                access_token=access_token,
+                params={"part": "statistics", "mine": "true"},
+            )
+        except APIError as exc:
+            logger.warning("YouTube channel statistics unavailable: %s", exc)
+            return None
+        items = resp.json().get("items", [])
+        if not items:
+            return None
+        try:
+            return int(items[0].get("statistics", {}).get("subscriberCount", 0))
+        except (TypeError, ValueError):
+            return None
 
     def get_post_analytics(
         self,

--- a/tests/providers/test_youtube.py
+++ b/tests/providers/test_youtube.py
@@ -1,8 +1,9 @@
-"""Tests for YouTubeProvider.get_post_analytics."""
+"""Tests for YouTubeProvider.get_post_analytics and get_account_metrics."""
 
 from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
+from providers.exceptions import APIError
 from providers.youtube import _ANALYTICS_VIDEO_FILTER_CHUNK, YouTubeProvider
 
 
@@ -193,3 +194,142 @@ class TestGetPostAnalytics:
 
         assert set(result.keys()) == {"def456"}
         assert result["def456"].extra == {"watch_time": 50.0}
+
+
+def _channels_response(subscriber_count: int) -> MagicMock:
+    return _make_response(
+        {"items": [{"statistics": {"subscriberCount": str(subscriber_count), "viewCount": "0", "videoCount": "0"}}]}
+    )
+
+
+def _reports_response(rows: list) -> MagicMock:
+    return _make_response(
+        {
+            "columnHeaders": [
+                {"name": "estimatedMinutesWatched"},
+                {"name": "averageViewPercentage"},
+                {"name": "subscribersGained"},
+                {"name": "shares"},
+            ],
+            "rows": rows,
+        }
+    )
+
+
+class TestGetAccountMetrics:
+    """A channel's subscriber total comes from ``channels.list``, not the lagged
+    Analytics ``/reports`` endpoint — see Fix 1's context: Analytics can return
+    zero rows for today (1-2 day lag) while the channel's real total is known
+    right away, and an Analytics failure must not lose it either.
+    """
+
+    @patch.object(YouTubeProvider, "_request")
+    def test_followers_set_from_channel_statistics(self, mock_request):
+        def fake_request(method, url, **kwargs):
+            if url.endswith("/channels"):
+                return _channels_response(4321)
+            return _reports_response([[1500.0, 47.5, 3.0, 12.0]])
+
+        mock_request.side_effect = fake_request
+
+        provider = YouTubeProvider()
+        metrics = provider.get_account_metrics("token", _date_range())
+
+        assert metrics.followers == 4321
+        # The Analytics extra is untouched by the followers fetch.
+        assert metrics.extra == {"watch_time": 1500.0, "avg_view_pct": 47.5, "subscribers": 3.0, "shares": 12.0}
+
+    @patch.object(YouTubeProvider, "_request")
+    def test_empty_analytics_day_still_returns_followers(self, mock_request):
+        # A channel with zero activity today: /reports comes back with no rows
+        # (Analytics lags 1-2 days), but the subscriber total is still real.
+        def fake_request(method, url, **kwargs):
+            if url.endswith("/channels"):
+                return _channels_response(4321)
+            return _reports_response([])
+
+        mock_request.side_effect = fake_request
+
+        provider = YouTubeProvider()
+        metrics = provider.get_account_metrics("token", _date_range())
+
+        assert metrics.followers == 4321
+        assert metrics.extra == {}
+
+    @patch.object(YouTubeProvider, "_request")
+    def test_analytics_failure_still_returns_followers(self, mock_request):
+        def fake_request(method, url, **kwargs):
+            if url.endswith("/channels"):
+                return _channels_response(4321)
+            raise APIError("YouTube API error 500: internal error", status_code=500, platform="YouTube")
+
+        mock_request.side_effect = fake_request
+
+        provider = YouTubeProvider()
+        metrics = provider.get_account_metrics("token", _date_range())
+
+        assert metrics.followers == 4321
+        # The failed /reports call is recorded rather than silently dropped.
+        assert "reports" in metrics.extra.get("insight_errors", {})
+
+    @patch.object(YouTubeProvider, "_request")
+    def test_channel_statistics_failure_does_not_lose_analytics(self, mock_request):
+        # The inverse: channels.list failing must not also blank the Analytics
+        # data — followers just comes back unknown (None), not a fabricated 0.
+        def fake_request(method, url, **kwargs):
+            if url.endswith("/channels"):
+                raise APIError("YouTube API error 403: forbidden", status_code=403, platform="YouTube")
+            return _reports_response([[1500.0, 47.5, 3.0, 12.0]])
+
+        mock_request.side_effect = fake_request
+
+        provider = YouTubeProvider()
+        metrics = provider.get_account_metrics("token", _date_range())
+
+        assert metrics.followers is None
+        assert metrics.extra == {"watch_time": 1500.0, "avg_view_pct": 47.5, "subscribers": 3.0, "shares": 12.0}
+
+    @patch.object(YouTubeProvider, "_request")
+    def test_analytics_scope_error_still_raises(self, mock_request):
+        # Unlike a generic failure, an auth/scope error from /reports must
+        # still propagate: it's the only thing that surfaces to the sync
+        # layer's _is_insufficient_scope check and sets
+        # analytics_needs_reconnect. Swallowing it here would silently break
+        # that reconnect path for every YouTube account.
+        def fake_request(method, url, **kwargs):
+            if url.endswith("/channels"):
+                return _channels_response(4321)
+            raise APIError(
+                "YouTube API error 403: Request had insufficient authentication scopes.",
+                status_code=403,
+                platform="YouTube",
+            )
+
+        mock_request.side_effect = fake_request
+
+        provider = YouTubeProvider()
+        try:
+            provider.get_account_metrics("token", _date_range())
+        except APIError as exc:
+            assert exc.status_code == 403
+        else:
+            raise AssertionError("expected APIError to propagate")
+
+    @patch.object(YouTubeProvider, "_request")
+    def test_channels_list_request_shape(self, mock_request):
+        def fake_request(method, url, **kwargs):
+            if url.endswith("/channels"):
+                return _channels_response(1)
+            return _reports_response([])
+
+        mock_request.side_effect = fake_request
+
+        provider = YouTubeProvider()
+        provider.get_account_metrics("token-xyz", _date_range())
+
+        channels_calls = [c for c in mock_request.call_args_list if c.args[1].endswith("/channels")]
+        assert len(channels_calls) == 1
+        args, kwargs = channels_calls[0]
+        assert args[0] == "GET"
+        assert kwargs["access_token"] == "token-xyz"
+        assert kwargs["params"] == {"part": "statistics", "mine": "true"}


### PR DESCRIPTION
get_account_metrics only called the Analytics /reports endpoint, so a channel with no activity yet today (Analytics lags 1-2 days and returns empty rows) reported followers=0 instead of its real subscriber count -- and any /reports failure lost the total too, since the whole call had nothing else to fall back on. Hit this in production on a low-activity channel.

Fix: fetch channels.list?part=statistics first -- it's a live point-in-time count independent of date_range, so it stands on its own regardless of what /reports does. A generic Analytics failure now degrades to followers-only (recorded in extra["insight_errors"], matching the other Meta-family providers' insights convention) rather than losing everything; an auth/scope failure still propagates unchanged, since that's what the sync layer's _is_insufficient_scope check relies on to flag the account for reconnect.

Tested: 6 new unit tests covering followers-from-statistics, an empty Analytics day, a generic Analytics failure, a channel-statistics failure (followers becomes None, Analytics untouched), a scope error still raising, and the channels.list request shape. Full tests/providers/test_youtube.py passes.