### PR TITLE
feat(threads): implement account-level insights

### DIFF
--- a/providers/threads.py
+++ b/providers/threads.py
@@ -4,11 +4,14 @@ from __future__ import annotations
 
 import logging
 import time
+from datetime import datetime
 from urllib.parse import urlencode
 
 from .base import SocialProvider
 from .exceptions import OAuthError, PublishError
+from .meta_insights import parse_insights_response
 from .types import (
+    AccountMetrics,
     AccountProfile,
     AuthType,
     CommentResult,
@@ -506,4 +509,34 @@ class ThreadsProvider(SocialProvider):
                 "quotes": metrics.get("quotes", 0),
                 "raw": data,
             },
+        )
+
+    def get_account_metrics(self, access_token: str, date_range: tuple[datetime, datetime]) -> AccountMetrics:
+        """Account-level insights from ``me/threads_insights``.
+
+        ``views`` is a daily time-series metric — Threads returns it under
+        ``values[]``, one entry per day the window covers — while
+        ``followers_count`` is a lifetime total, returned under
+        ``total_value.value`` and unaffected by ``since``/``until``.
+        :func:`parse_insights_response`, shared with the other Meta-backed
+        providers, already distinguishes the two shapes.
+
+        The sync layer always calls this with a single-day ``date_range``, so
+        ``views`` resolves to that one day's count; a day with no activity
+        simply omits the ``views`` entry rather than returning a zero.
+        """
+        resp = self._request(
+            "GET",
+            f"{API_BASE}/me/threads_insights",
+            access_token=access_token,
+            params={
+                "metric": "views,followers_count",
+                "since": int(date_range[0].timestamp()),
+                "until": int(date_range[1].timestamp()),
+            },
+        )
+        values = parse_insights_response(resp.json())
+        return AccountMetrics(
+            followers=values.get("followers_count"),
+            extra={"views": values.get("views", 0), "raw_insights": values},
         )

--- a/tests/providers/test_threads.py
+++ b/tests/providers/test_threads.py
@@ -6,8 +6,12 @@ has to return it as ``OAuthTokens.refresh_token`` — every refresh path in the 
 skips accounts whose ``oauth_refresh_token`` is empty.
 """
 
+from datetime import UTC, datetime
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from providers.exceptions import APIError
 from providers.threads import LONG_LIVED_TOKEN_TTL, ThreadsProvider
 
 CREDENTIALS = {"app_id": "th-id", "app_secret": "th-sec"}
@@ -15,6 +19,13 @@ CREDENTIALS = {"app_id": "th-id", "app_secret": "th-sec"}
 
 def _response(body: dict) -> MagicMock:
     return MagicMock(json=MagicMock(return_value=body))
+
+
+def _date_range() -> tuple[datetime, datetime]:
+    return (
+        datetime(2026, 8, 12, 0, 0, 0, tzinfo=UTC),
+        datetime(2026, 8, 12, 23, 59, 59, tzinfo=UTC),
+    )
 
 
 class TestExchangeCode:
@@ -82,3 +93,83 @@ class TestRefreshToken:
             "grant_type": "th_refresh_token",
             "access_token": "current-long-lived",
         }
+
+
+class TestGetAccountMetrics:
+    """``views`` is a daily time-series metric (returned under ``values[]``);
+    ``followers_count`` is a lifetime total (returned under
+    ``total_value.value``) — same two shapes ``parse_insights_response``
+    already handles for the other Meta-backed providers.
+    """
+
+    @patch.object(ThreadsProvider, "_request")
+    def test_request_shape(self, mock_request):
+        mock_request.return_value = _response({"data": []})
+
+        ThreadsProvider(CREDENTIALS).get_account_metrics("token-xyz", _date_range())
+
+        assert mock_request.call_count == 1
+        args, kwargs = mock_request.call_args
+        assert args[0] == "GET"
+        assert args[1] == "https://graph.threads.net/v1.0/me/threads_insights"
+        assert kwargs["access_token"] == "token-xyz"
+        assert kwargs["params"] == {
+            "metric": "views,followers_count",
+            "since": 1786492800,
+            "until": 1786579199,
+        }
+
+    @patch.object(ThreadsProvider, "_request")
+    def test_maps_views_series_and_followers_total(self, mock_request):
+        mock_request.return_value = _response(
+            {
+                "data": [
+                    {
+                        "name": "views",
+                        "period": "day",
+                        "values": [{"value": 142, "end_time": "2026-08-12T07:00:00+0000"}],
+                    },
+                    {
+                        "name": "followers_count",
+                        "period": "day",
+                        "total_value": {"value": 987},
+                    },
+                ]
+            }
+        )
+
+        metrics = ThreadsProvider(CREDENTIALS).get_account_metrics("token", _date_range())
+
+        assert metrics.followers == 987
+        assert metrics.extra["views"] == 142
+
+    @patch.object(ThreadsProvider, "_request")
+    def test_empty_day_still_returns_followers_total(self, mock_request):
+        # A day with no views activity: Threads omits the "views" entry
+        # entirely rather than returning a zero-valued one.
+        mock_request.return_value = _response(
+            {
+                "data": [
+                    {
+                        "name": "followers_count",
+                        "period": "day",
+                        "total_value": {"value": 987},
+                    },
+                ]
+            }
+        )
+
+        metrics = ThreadsProvider(CREDENTIALS).get_account_metrics("token", _date_range())
+
+        assert metrics.followers == 987
+        assert metrics.extra["views"] == 0
+
+    @patch.object(ThreadsProvider, "_request")
+    def test_request_failure_propagates(self, mock_request):
+        # No account-level insights data at all: let the caller's own
+        # _is_insufficient_scope / logging handle it, matching every other
+        # method in this provider (no swallowing here).
+        mock_request.side_effect = APIError("Threads API error 400: bad request", status_code=400, platform="Threads")
+
+        with pytest.raises(APIError):
+            ThreadsProvider(CREDENTIALS).get_account_metrics("token", _date_range())


### PR DESCRIPTION
get_account_metrics had no override for Threads, so every Threads account skipped account-level analytics entirely -- it raised NotImplementedError, leaving the account with no follower/views history at all. Noticed in production while auditing which providers actually populate account-level analytics.

Fix: add it against me/threads_insights with metric=views,followers_count. views is a daily time-series metric (Threads returns it under values[]) and followers_count is a lifetime total (returned under total_value.value) -- the same two response shapes parse_insights_response already handles for the other Meta-backed providers, reused here rather than re-implemented. A day with no view activity simply omits the views entry, which maps to 0 rather than being dropped.

Tested: new unit tests in tests/providers/test_threads.py covering the request shape, the two response shapes (time-series views + lifetime followers_count), and a day with no views activity. Full test_threads.py passes.