### PR TITLE
fix(analytics): gap-fill a day missing one metric instead of skipping it whole

### DIFF
--- a/apps/analytics/tasks.py
+++ b/apps/analytics/tasks.py
@@ -376,18 +376,61 @@ _POST_NON_CADENCE_METRICS_BY_PLATFORM: dict[str, frozenset[str]] = {
 
 _FOLLOWER_TOTAL_REFRESH_PLATFORMS: frozenset[str] = frozenset({"facebook", "instagram", "instagram_login"})
 
+# Metric keys ``_account_metrics_to_dict`` is actually capable of writing —
+# the ``AccountMetrics`` dataclass fields it reads plus the generic ``extra``
+# keys it recognizes. Intersected with a platform's ``PLATFORM_METRICS``
+# catalog (which also lists post-only keys the account-level writer never
+# touches, e.g. Instagram's ``saves``) this gives the set of keys a
+# COMPLETE day's fetch would have written — see ``_account_day_is_complete``.
+# ``followers`` is deliberately excluded: it's a live point-in-time total
+# written to ``on_date`` only, after this loop, by a dedicated mechanism
+# (``_needs_empty_follower_count_refresh``) — folding it in here would make
+# any day whose profile fetch keeps failing look permanently incomplete.
+_ACCOUNT_METRICS_WRITER_KEYS: frozenset[str] = frozenset(
+    {"impressions", "reach", "follows"}
+    | {"views", "watch_time", "avg_view_pct", "subscribers", "likes", "comments", "shares"}
+)
+
 
 def _needs_empty_follower_count_refresh(account) -> bool:
     return account.follower_count <= 0 and account.platform in _FOLLOWER_TOTAL_REFRESH_PLATFORMS
 
 
+def _account_day_is_complete(account, target: dt_date, *, existing_keys: set[str]) -> bool:
+    """Whether ``target`` already has every metric key this platform's
+    account-level sync can produce (see ``_ACCOUNT_METRICS_WRITER_KEYS``).
+
+    A platform whose catalog carries none of those keys (or a provider that
+    never returns anything the writer recognizes) reports complete by
+    default — there's nothing for this sync to ever add.
+    """
+    from .metrics import PLATFORM_METRICS
+
+    expected = frozenset(PLATFORM_METRICS.get(account.platform, [])) & _ACCOUNT_METRICS_WRITER_KEYS
+    if not expected:
+        return True
+    return expected <= existing_keys
+
+
 def _sync_account_metrics(account, on_date: dt_date, *, force_today: bool = False) -> None:
-    """Fetch account-level metrics for ``on_date`` and any recent missing days.
+    """Fetch account-level metrics for ``on_date`` and any recent incomplete days.
 
     Walks ``on_date`` and the prior ``_ACCOUNT_METRICS_RECENT_DAYS - 1`` days,
-    skipping days that already have an :class:`AccountInsightsSnapshot`. For
-    providers without lag (Instagram, Facebook) this is a no-op past
-    ``on_date`` because the existing rows short-circuit the iteration.
+    skipping a day only once it has EVERY metric key this platform's
+    account-level sync can produce (:func:`_account_day_is_complete`) — not
+    just "some row exists for it". A day missing one of those keys (e.g.
+    Instagram writing ``views``/``followers`` for a day while ``reach``
+    failed to write) gets gap-filled: only the missing keys are written, so
+    the first capture of an already-present key stays authoritative. For
+    providers without lag (Instagram, Facebook) a genuinely complete day is a
+    no-op past ``on_date`` because the completeness check short-circuits the
+    iteration.
+
+    ``on_date`` itself keeps the pre-existing "multiple ticks overwrite
+    today" behavior instead of gap-filling: a live day's numbers can
+    legitimately change between re-runs, so a refetch (``force_today``, or an
+    hourly re-run finding it incomplete) writes every key the fetch returns,
+    not just the missing ones.
 
     ``force_today`` re-fetches ``on_date`` even when its rows already exist.
     One-shot backfills pass it because they run at the moments the token's
@@ -396,8 +439,8 @@ def _sync_account_metrics(account, on_date: dt_date, *, force_today: bool = Fals
     insufficient-scope error and sets ``analytics_needs_reconnect``. Without
     it, a same-day re-run finds today's rows present, skips every offset,
     never calls the provider, and reports success for a token that cannot
-    read insights. The hourly cron does not pass it: there, existing rows
-    genuinely mean the work is done.
+    read insights. The hourly cron does not pass it: there, a complete day
+    genuinely means the work is done.
 
     For YouTube, also fetches per-video Analytics-API metrics (watch_time,
     avg_view_pct, shares) that the Data API can't provide per-post — see
@@ -425,9 +468,14 @@ def _sync_account_metrics(account, on_date: dt_date, *, force_today: bool = Fals
     current_followers = None
     for offset in range(recent_days):
         target = on_date - timedelta(days=offset)
-        has_rows_for_day = AccountInsightsSnapshot.objects.filter(social_account=account, date=target).exists()
-        needs_current_day_refetch = target == on_date and (force_today or _needs_empty_follower_count_refresh(account))
-        if has_rows_for_day and not needs_current_day_refetch:
+        is_today = target == on_date
+        existing_keys = set(
+            AccountInsightsSnapshot.objects.filter(social_account=account, date=target).values_list(
+                "metric_key", flat=True
+            )
+        )
+        needs_current_day_refetch = is_today and (force_today or _needs_empty_follower_count_refresh(account))
+        if _account_day_is_complete(account, target, existing_keys=existing_keys) and not needs_current_day_refetch:
             continue
         start = datetime.combine(target, time.min, tzinfo=tz)
         end = datetime.combine(target, time.max, tzinfo=tz)
@@ -449,6 +497,11 @@ def _sync_account_metrics(account, on_date: dt_date, *, force_today: bool = Fals
         # The live followers total is written to on_date after the loop; keep it
         # out of every dated/backfilled snapshot written here.
         metric_values.pop("followers", None)
+        if not is_today:
+            # A past/backfilled day only gap-fills what's missing — the
+            # first capture of a day stays authoritative. ``on_date`` keeps
+            # the full-overwrite behavior documented above.
+            metric_values = {key: value for key, value in metric_values.items() if key not in existing_keys}
         _write_account_snapshot(
             account,
             metric_values,
@@ -687,8 +740,8 @@ def sync_all_account_analytics() -> None:
     # ...) is "enabled" as far as AnalyticsPlatformConfig is concerned, and the
     # ``cap_days == 0`` guard below only skips the per-post loop — so without
     # this those accounts reached _sync_account_metrics every single hour, built
-    # a provider, and failed. They never write a snapshot row, so ``has_today_rows``
-    # never became True and the waste repeated forever.
+    # a provider, and failed. They never write a snapshot row, so a day never
+    # becomes complete and the waste repeats forever.
     enabled = AnalyticsPlatformConfig.enabled_platforms()
     syncable = [p for p in enabled if services.analytics_availability(p, enabled) is None]
     if not syncable:
@@ -699,21 +752,20 @@ def sync_all_account_analytics() -> None:
         connection_status=SocialAccount.ConnectionStatus.CONNECTED,
         platform__in=syncable,
     ).select_related("workspace")
-    from .models import AccountInsightsSnapshot
 
     for account in accounts:
-        # Account-level: at most once per day per account. Skip if today's
-        # row already exists so an hourly cron doesn't turn into 24 API calls.
-        # Also skip accounts already flagged for analytics reconnect — their
-        # token can't read the Analytics API, so retrying only re-fails and
-        # re-logs every hour. Reconnecting clears the flag and runs a one-shot
-        # backfill (see backfill_account_analytics), so the cron resumes on its
-        # own. The per-post Data-API loop below still runs (it uses the
-        # publish/read scopes the account already has).
-        has_today_rows = AccountInsightsSnapshot.objects.filter(social_account=account, date=today).exists()
-        if not account.analytics_needs_reconnect and (
-            not has_today_rows or _needs_empty_follower_count_refresh(account)
-        ):
+        # Account-level: skip accounts already flagged for analytics
+        # reconnect — their token can't read the Analytics API, so retrying
+        # only re-fails and re-logs every hour. Reconnecting clears the flag
+        # and runs a one-shot backfill (see backfill_account_analytics), so
+        # the cron resumes on its own. Otherwise always defer to
+        # _sync_account_metrics: it walks the last _ACCOUNT_METRICS_RECENT_DAYS
+        # days and only calls the provider for a day that isn't yet COMPLETE
+        # (see _account_day_is_complete) — a day with every expected metric
+        # key already present costs no extra API call, but a merely partial
+        # one (some keys present, others missing) now gets gap-filled instead
+        # of being skipped outright just because SOME row exists for it.
+        if not account.analytics_needs_reconnect:
             _sync_account_metrics(account, today)
 
         # Per-post: only those whose cadence window has elapsed

--- a/apps/analytics/tests/test_tasks.py
+++ b/apps/analytics/tests/test_tasks.py
@@ -206,9 +206,10 @@ def test_sync_account_metrics_refetches_today_when_forced(workspace):
 
     The fetch is the only thing that surfaces an insufficient-scope error and
     sets ``analytics_needs_reconnect``. Without ``force_today``, re-enabling a
-    platform on the same day it last synced finds today's rows present, skips
-    every offset, never calls the provider, and reports success for a token
-    that cannot read insights.
+    platform on the same day it last synced finds every day already
+    COMPLETE (every metric key instagram_login's account-level sync can
+    produce is present), skips every offset, never calls the provider, and
+    reports success for a token that cannot read insights.
     """
     from datetime import date, timedelta
     from unittest.mock import MagicMock, patch
@@ -227,13 +228,16 @@ def test_sync_account_metrics_refetches_today_when_forced(workspace):
         connection_status=SocialAccount.ConnectionStatus.CONNECTED,
     )
     today = date(2026, 6, 24)
+    # Every metric key instagram_login's account-level writer can produce —
+    # a genuinely complete day, not just "some row exists".
     for offset in range(3):  # every day _sync_account_metrics would walk
-        AccountInsightsSnapshot.objects.create(
-            social_account=account,
-            date=today - timedelta(days=offset),
-            metric_key="reach",
-            value=10,
-        )
+        for metric_key in ("reach", "views", "likes", "comments", "shares"):
+            AccountInsightsSnapshot.objects.create(
+                social_account=account,
+                date=today - timedelta(days=offset),
+                metric_key=metric_key,
+                value=10,
+            )
     fake_provider = MagicMock()
     fake_provider.account_metrics_supports_date_range = True
     fake_provider.get_account_metrics.return_value = AccountMetrics(reach=42, followers=500)
@@ -244,6 +248,131 @@ def test_sync_account_metrics_refetches_today_when_forced(workspace):
 
         _sync_account_metrics(account, today, force_today=True)
         assert fake_provider.get_account_metrics.call_count == 1
+
+
+@pytest.mark.django_db
+def test_sync_account_metrics_gap_fills_a_missing_metric_without_overwriting_existing_rows(workspace):
+    """A day that already has SOME of a platform's metric keys but not all
+    (Instagram writing ``views``/``followers`` while ``reach`` failed to
+    write) must be treated as partial, not complete — the missing key gets
+    backfilled, but a key that's already there keeps its first-captured
+    value untouched (the first capture of a day stays authoritative).
+    """
+    from datetime import date, timedelta
+    from unittest.mock import MagicMock, patch
+
+    from apps.analytics.models import AccountInsightsSnapshot
+    from apps.analytics.tasks import _sync_account_metrics
+    from providers.types import AccountMetrics
+
+    account = SocialAccount.objects.create(
+        workspace=workspace,
+        platform="instagram",
+        account_platform_id="ig-2",
+        account_name="IG Two",
+        oauth_access_token="token",
+        connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+    )
+    today = date(2026, 6, 24)
+    yesterday = today - timedelta(days=1)
+    # Yesterday captured "views" but "reach" never made it in — a partial day.
+    AccountInsightsSnapshot.objects.create(
+        social_account=account,
+        date=yesterday,
+        metric_key="views",
+        value=999,
+    )
+    fake_provider = MagicMock()
+    fake_provider.account_metrics_supports_date_range = True
+    fake_provider.get_account_metrics.return_value = AccountMetrics(
+        reach=5, extra={"views": 7, "likes": 2, "comments": 1, "shares": 1}
+    )
+
+    with patch("apps.analytics.tasks._resolve_provider", return_value=fake_provider):
+        _sync_account_metrics(account, today)
+
+    # The missing key was backfilled...
+    assert AccountInsightsSnapshot.objects.get(social_account=account, date=yesterday, metric_key="reach").value == 5
+    assert AccountInsightsSnapshot.objects.get(social_account=account, date=yesterday, metric_key="comments").value == 1
+    # ...but the pre-existing "views" row was NOT overwritten by the fresh
+    # fetch's value of 7 — the first capture of a day stays authoritative.
+    assert AccountInsightsSnapshot.objects.get(social_account=account, date=yesterday, metric_key="views").value == 999
+
+
+@pytest.mark.django_db
+def test_sync_account_metrics_complete_day_is_not_refetched(workspace):
+    """A day with every expected metric key present costs no API call, even
+    without ``force_today``."""
+    from datetime import date, timedelta
+    from unittest.mock import MagicMock, patch
+
+    from apps.analytics.models import AccountInsightsSnapshot
+    from apps.analytics.tasks import _sync_account_metrics
+
+    account = SocialAccount.objects.create(
+        workspace=workspace,
+        platform="instagram",
+        account_platform_id="ig-3",
+        account_name="IG Three",
+        follower_count=500,
+        oauth_access_token="token",
+        connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+    )
+    today = date(2026, 6, 24)
+    for offset in range(3):  # every day _sync_account_metrics would walk
+        for metric_key in ("reach", "views", "likes", "comments", "shares"):
+            AccountInsightsSnapshot.objects.create(
+                social_account=account,
+                date=today - timedelta(days=offset),
+                metric_key=metric_key,
+                value=10,
+            )
+    fake_provider = MagicMock()
+    fake_provider.account_metrics_supports_date_range = True
+
+    with patch("apps.analytics.tasks._resolve_provider", return_value=fake_provider):
+        _sync_account_metrics(account, today)
+
+    assert fake_provider.get_account_metrics.call_count == 0
+
+
+@pytest.mark.django_db
+def test_sync_all_account_analytics_still_syncs_when_today_has_some_rows(workspace):
+    """Before Fix 4, the caller skipped ``_sync_account_metrics`` entirely
+    once ANY row existed for today, so a day that was merely partial (some
+    metric keys captured, others not) never got a chance to gap-fill —
+    that's the IG "reach" gap. The caller must now defer that decision to
+    ``_sync_account_metrics`` itself, which knows per-metric completeness.
+    """
+    from unittest.mock import patch
+
+    from django.utils import timezone
+
+    from apps.analytics.models import AccountInsightsSnapshot
+    from apps.analytics.tasks import sync_all_account_analytics
+
+    AnalyticsPlatformConfig.objects.update_or_create(platform="instagram", defaults={"is_enabled": True})
+    account = SocialAccount.objects.create(
+        workspace=workspace,
+        platform="instagram",
+        account_platform_id="ig-4",
+        account_name="IG Four",
+        oauth_access_token="token",
+        connection_status=SocialAccount.ConnectionStatus.CONNECTED,
+    )
+    today = timezone.now().date()
+    AccountInsightsSnapshot.objects.create(
+        social_account=account,
+        date=today,
+        metric_key="views",
+        value=10,
+    )
+
+    with patch("apps.analytics.tasks._sync_account_metrics") as mock_sync:
+        sync_all_account_analytics.now()
+
+    synced_ids = {call.args[0].id for call in mock_sync.call_args_list}
+    assert account.id in synced_ids
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
_sync_account_metrics skipped a day the moment ANY AccountInsightsSnapshot row existed for it, and sync_all_account_analytics skipped calling it at all once today had any row -- so a day that was only PARTIALLY captured (Instagram writing views/followers while reach failed to write) never got a second chance. The gap never healed, since the next run always saw "some row exists" and moved on. Observed in production: a day with a partial Instagram outage permanently lost its reach metric even after the platform recovered.

Fix: both now compare against the set of metric keys this platform's account-level sync can actually produce (_account_day_is_complete) and only skip a day once every expected key is present. A partial day gets only its missing keys backfilled -- an already-written key keeps its first-captured value, never overwritten by the gap-fill. Today keeps the existing full-overwrite behavior on a refetch, since its numbers can legitimately still be changing.

Tested: expanded apps/analytics/tests/test_tasks.py covering a partially-captured day getting its missing key backfilled without touching the already-written key, a fully-captured day still being skipped, and today's full-overwrite behavior being preserved. Full apps/analytics/tests/test_tasks.py passes.